### PR TITLE
Add Last.fm artist bio endpoint to API

### DIFF
--- a/app/controllers/api/v1/artists_controller.rb
+++ b/app/controllers/api/v1/artists_controller.rb
@@ -3,7 +3,7 @@
 module Api
   module V1
     class ArtistsController < ApiController
-      before_action :artist, only: %i[show graph_data songs chart_positions time_analytics air_plays]
+      before_action :artist, only: %i[show graph_data songs chart_positions time_analytics air_plays bio]
       def index
         render json: ArtistSerializer.new(artists)
                                      .serializable_hash
@@ -65,6 +65,11 @@ module Api
                                       .serializable_hash
                                       .merge(pagination_data(artist_air_plays))
                                       .to_json
+      end
+
+      def bio
+        bio_data = Lastfm::ArtistFinder.new.get_info(artist.name)
+        render json: { bio: bio_data }
       end
 
       private

--- a/app/services/lastfm/artist_finder.rb
+++ b/app/services/lastfm/artist_finder.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Lastfm
+  class ArtistFinder < Base
+    def get_info(artist_name)
+      response = make_request(method: 'artist.getinfo', artist: artist_name, autocorrect: 1)
+      return nil if response.nil? || response['error'].present?
+
+      response.dig('artist', 'bio')
+    end
+  end
+end

--- a/app/services/lastfm/base.rb
+++ b/app/services/lastfm/base.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Lastfm
+  class Base
+    BASE_URL = 'https://ws.audioscrobbler.com/2.0/'
+
+    private
+
+    def make_request(params)
+      Rails.cache.fetch(cache_key(params), expires_in: 24.hours) do
+        response = connection.get do |req|
+          req.params = default_params.merge(params)
+        end
+
+        response.body
+      end
+    rescue StandardError => e
+      ExceptionNotifier.notify_new_relic(e)
+      Rails.logger.error("Lastfm API error: #{e.message}")
+      nil
+    end
+
+    def connection
+      @connection ||= Faraday.new(url: BASE_URL) do |conn|
+        conn.response :json
+      end
+    end
+
+    def default_params
+      {
+        api_key: ENV.fetch('LASTFM_API_KEY', nil),
+        format: 'json'
+      }
+    end
+
+    def cache_key(params)
+      "lastfm:#{params.values.join(':')}"
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
         get :chart_positions, on: :member
         get :time_analytics, on: :member
         get :air_plays, on: :member
+        get :bio, on: :member
       end
       resources :songs, only: %i[index show] do
         get :graph_data, on: :member

--- a/spec/services/lastfm/artist_finder_spec.rb
+++ b/spec/services/lastfm/artist_finder_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+describe Lastfm::ArtistFinder do
+  subject(:artist_finder) { described_class.new }
+
+  before do
+    allow(ENV).to receive(:fetch).and_call_original
+    allow(ENV).to receive(:fetch).with('LASTFM_API_KEY', nil).and_return('test_api_key')
+  end
+
+  describe '#get_info' do
+    let(:artist_name) { 'Coldplay' }
+
+    context 'when API returns valid data' do
+      let(:api_response) do
+        {
+          'artist' => {
+            'name' => 'Coldplay',
+            'bio' => {
+              'summary' => 'Coldplay are a British rock band formed in London in 1996.',
+              'content' => 'Full biography content here.'
+            }
+          }
+        }
+      end
+
+      before do
+        allow(Rails.cache).to receive(:fetch).and_yield
+        allow_any_instance_of(Faraday::Connection).to receive(:get).and_return( # rubocop:disable RSpec/AnyInstance
+          instance_double(Faraday::Response, body: api_response)
+        )
+      end
+
+      it 'returns the bio data' do
+        result = artist_finder.get_info(artist_name)
+        expect(result).to eq(api_response['artist']['bio'])
+      end
+    end
+
+    context 'when API returns an error' do
+      let(:error_response) do
+        {
+          'error' => 6,
+          'message' => 'Artist not found'
+        }
+      end
+
+      before do
+        allow(Rails.cache).to receive(:fetch).and_yield
+        allow_any_instance_of(Faraday::Connection).to receive(:get).and_return( # rubocop:disable RSpec/AnyInstance
+          instance_double(Faraday::Response, body: error_response)
+        )
+      end
+
+      it 'returns nil' do
+        result = artist_finder.get_info(artist_name)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when API request fails' do
+      before do
+        allow(Rails.cache).to receive(:fetch).and_yield
+        allow_any_instance_of(Faraday::Connection).to receive(:get).and_raise(Faraday::Error) # rubocop:disable RSpec/AnyInstance
+        allow(ExceptionNotifier).to receive(:notify_new_relic)
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it 'returns nil' do
+        result = artist_finder.get_info(artist_name)
+        expect(result).to be_nil
+      end
+
+      it 'logs the error' do
+        artist_finder.get_info(artist_name)
+        expect(Rails.logger).to have_received(:error).with(/Lastfm API error/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a new endpoint GET /api/v1/artists/:id/bio that fetches artist biography data from the Last.fm API. This exposes the bio summary and full content for artists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)