### PR TITLE
Replace Last.fm bio with Wikipedia API for artist information

### DIFF
--- a/app/controllers/api/v1/artists_controller.rb
+++ b/app/controllers/api/v1/artists_controller.rb
@@ -68,7 +68,7 @@ module Api
       end
 
       def bio
-        bio_data = Lastfm::ArtistFinder.new.get_info(artist.name)
+        bio_data = Wikipedia::ArtistFinder.new.get_info(artist.name)
         render json: { bio: bio_data }
       end
 

--- a/app/services/wikipedia/artist_finder.rb
+++ b/app/services/wikipedia/artist_finder.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Wikipedia
+  class ArtistFinder < Base
+    ALLOWED_TAGS = %w[p b i a br em strong].freeze
+
+    def get_info(artist_name)
+      encoded_name = ERB::Util.url_encode(artist_name)
+      response = make_request("/page/summary/#{encoded_name}")
+      return nil if response.nil? || response['type'] == 'not_found'
+
+      {
+        'summary' => sanitize_html(response['extract_html']),
+        'description' => response['description'],
+        'url' => response.dig('content_urls', 'desktop', 'page')
+      }
+    end
+
+    private
+
+    def sanitize_html(html)
+      return nil if html.nil?
+
+      ActionController::Base.helpers.sanitize(html, tags: ALLOWED_TAGS)
+    end
+  end
+end

--- a/app/services/wikipedia/base.rb
+++ b/app/services/wikipedia/base.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Wikipedia
+  class Base
+    BASE_URL = 'https://en.wikipedia.org/api/rest_v1'
+
+    private
+
+    def make_request(path)
+      Rails.cache.fetch(cache_key(path), expires_in: 24.hours) do
+        response = connection.get(path)
+        response.body
+      end
+    rescue StandardError => e
+      ExceptionNotifier.notify_new_relic(e)
+      Rails.logger.error("Wikipedia API error: #{e.message}")
+      nil
+    end
+
+    def connection
+      @connection ||= Faraday.new(url: BASE_URL) do |conn|
+        conn.response :json
+      end
+    end
+
+    def cache_key(path)
+      "wikipedia:#{path}"
+    end
+  end
+end

--- a/spec/controllers/api/v1/artists_controller_spec.rb
+++ b/spec/controllers/api/v1/artists_controller_spec.rb
@@ -254,21 +254,17 @@ describe Api::V1::ArtistsController do
   describe 'GET #bio' do
     subject(:get_bio) { get :bio, params: { id: artist_one.id, format: :json } }
 
-    before do
-      allow(ENV).to receive(:fetch).and_call_original
-      allow(ENV).to receive(:fetch).with('LASTFM_API_KEY', nil).and_return('test_api_key')
-    end
-
-    context 'when Last.fm returns bio data' do
+    context 'when Wikipedia returns bio data' do
       let(:bio_data) do
         {
-          'summary' => 'Artist bio summary text.',
-          'content' => 'Full artist biography content.'
+          'summary' => '<p><b>Artist One</b> is a musical artist.</p>',
+          'description' => 'Musical artist',
+          'url' => 'https://en.wikipedia.org/wiki/Artist_One'
         }
       end
 
       before do
-        allow_any_instance_of(Lastfm::ArtistFinder).to receive(:get_info).and_return(bio_data) # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Wikipedia::ArtistFinder).to receive(:get_info).and_return(bio_data) # rubocop:disable RSpec/AnyInstance
       end
 
       it 'returns status OK/200' do
@@ -282,9 +278,9 @@ describe Api::V1::ArtistsController do
       end
     end
 
-    context 'when Last.fm returns no data' do
+    context 'when Wikipedia returns no data' do
       before do
-        allow_any_instance_of(Lastfm::ArtistFinder).to receive(:get_info).and_return(nil) # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(Wikipedia::ArtistFinder).to receive(:get_info).and_return(nil) # rubocop:disable RSpec/AnyInstance
       end
 
       it 'returns status OK/200' do

--- a/spec/services/wikipedia/artist_finder_spec.rb
+++ b/spec/services/wikipedia/artist_finder_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+describe Wikipedia::ArtistFinder do
+  subject(:artist_finder) { described_class.new }
+
+  describe '#get_info' do
+    let(:artist_name) { 'Coldplay' }
+
+    context 'when API returns valid data' do
+      let(:api_response) do
+        {
+          'type' => 'standard',
+          'title' => 'Coldplay',
+          'extract_html' => '<p><b>Coldplay</b> are a British rock band formed in London in 1997.</p>',
+          'description' => 'British rock band',
+          'content_urls' => {
+            'desktop' => {
+              'page' => 'https://en.wikipedia.org/wiki/Coldplay'
+            }
+          }
+        }
+      end
+
+      before do
+        allow(Rails.cache).to receive(:fetch).and_yield
+        allow_any_instance_of(Faraday::Connection).to receive(:get).and_return( # rubocop:disable RSpec/AnyInstance
+          instance_double(Faraday::Response, body: api_response)
+        )
+      end
+
+      it 'returns the bio data with summary, description and url' do
+        result = artist_finder.get_info(artist_name)
+        expect(result).to eq({
+                               'summary' => '<p><b>Coldplay</b> are a British rock band formed in London in 1997.</p>',
+                               'description' => 'British rock band',
+                               'url' => 'https://en.wikipedia.org/wiki/Coldplay'
+                             })
+      end
+    end
+
+    context 'when API returns not found' do
+      let(:not_found_response) do
+        {
+          'type' => 'not_found',
+          'title' => 'Not found'
+        }
+      end
+
+      before do
+        allow(Rails.cache).to receive(:fetch).and_yield
+        allow_any_instance_of(Faraday::Connection).to receive(:get).and_return( # rubocop:disable RSpec/AnyInstance
+          instance_double(Faraday::Response, body: not_found_response)
+        )
+      end
+
+      it 'returns nil' do
+        result = artist_finder.get_info(artist_name)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when API request fails' do
+      before do
+        allow(Rails.cache).to receive(:fetch).and_yield
+        allow_any_instance_of(Faraday::Connection).to receive(:get).and_raise(Faraday::Error) # rubocop:disable RSpec/AnyInstance
+        allow(ExceptionNotifier).to receive(:notify_new_relic)
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it 'returns nil' do
+        result = artist_finder.get_info(artist_name)
+        expect(result).to be_nil
+      end
+
+      it 'logs the error' do
+        artist_finder.get_info(artist_name)
+        expect(Rails.logger).to have_received(:error).with(/Wikipedia API error/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Switch from Last.fm to Wikipedia REST API for fetching artist biographies. The Wikipedia API provides cleaner, more focused summaries with additional metadata (description, article URL). Includes server-side HTML sanitization for security.

🤖 Generated with [Claude Code](https://claude.com/claude-code)