### PR TITLE
Add radio station classifiers API with Spotify audio feature descript…

### DIFF
--- a/app/controllers/api/v1/radio_station_classifiers_controller.rb
+++ b/app/controllers/api/v1/radio_station_classifiers_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class RadioStationClassifiersController < ApiController
+      def index
+        classifiers = RadioStationClassifier.includes(:radio_station)
+        classifiers = classifiers.where(radio_station_id: params[:radio_station_id]) if params[:radio_station_id].present?
+        classifiers = classifiers.where(day_part: params[:day_part]) if params[:day_part].present?
+
+        render json: RadioStationClassifierSerializer.serializable_hash_with_descriptions(classifiers).to_json
+      end
+
+      def descriptions
+        render json: { data: RadioStationClassifier.attribute_descriptions }.to_json
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/radio_stations_controller.rb
+++ b/app/controllers/api/v1/radio_stations_controller.rb
@@ -24,7 +24,7 @@ module Api
       end
 
       def classifiers
-        render json: RadioStationClassifierSerializer.new(@radio_station.radio_station_classifiers).serializable_hash.to_json
+        render json: RadioStationClassifierSerializer.serializable_hash_with_descriptions(@radio_station.radio_station_classifiers).to_json
       end
 
       def last_played_songs

--- a/app/models/radio_station_classifier.rb
+++ b/app/models/radio_station_classifier.rb
@@ -34,5 +34,85 @@
 #  fk_rails_...  (radio_station_id => radio_stations.id)
 #
 class RadioStationClassifier < ApplicationRecord
+  DAY_PARTS = %w[night breakfast morning lunch afternoon dinner evening].freeze
+
+  ATTRIBUTE_DESCRIPTIONS = {
+    danceability: {
+      name: 'Danceability',
+      description: 'Describes how suitable a track is for dancing based on a combination of musical elements ' \
+                   'including tempo, rhythm stability, beat strength, and overall regularity. ' \
+                   'A value of 0.0 is least danceable and 1.0 is most danceable.',
+      range: '0.0 - 1.0'
+    },
+    energy: {
+      name: 'Energy',
+      description: 'Represents a perceptual measure of intensity and activity. Typically, energetic tracks feel ' \
+                   'fast, loud, and noisy. For example, death metal has high energy, while a Bach prelude scores ' \
+                   'low on the scale. Perceptual features contributing to this attribute include dynamic range, ' \
+                   'perceived loudness, timbre, onset rate, and general entropy.',
+      range: '0.0 - 1.0'
+    },
+    speechiness: {
+      name: 'Speechiness',
+      description: 'Detects the presence of spoken words in a track. The more exclusively speech-like the ' \
+                   'recording (e.g. talk show, audio book, poetry), the closer to 1.0 the attribute value. ' \
+                   'Values above 0.66 describe tracks that are probably made entirely of spoken words. ' \
+                   'Values between 0.33 and 0.66 describe tracks that may contain both music and speech. ' \
+                   'Values below 0.33 most likely represent music and other non-speech-like tracks.',
+      range: '0.0 - 1.0'
+    },
+    acousticness: {
+      name: 'Acousticness',
+      description: 'A confidence measure of whether the track is acoustic. A value of 1.0 represents high ' \
+                   'confidence the track is acoustic (uses acoustic instruments like guitars, pianos, strings). ' \
+                   'A value of 0.0 represents high confidence the track is electronic or uses electric instruments.',
+      range: '0.0 - 1.0'
+    },
+    instrumentalness: {
+      name: 'Instrumentalness',
+      description: 'Predicts whether a track contains no vocals. "Ooh" and "aah" sounds are treated as ' \
+                   'instrumental in this context. Rap or spoken word tracks are clearly "vocal". ' \
+                   'The closer the instrumentalness value is to 1.0, the greater likelihood the track ' \
+                   'contains no vocal content. Values above 0.5 are intended to represent instrumental tracks.',
+      range: '0.0 - 1.0'
+    },
+    liveness: {
+      name: 'Liveness',
+      description: 'Detects the presence of an audience in the recording. Higher liveness values represent ' \
+                   'an increased probability that the track was performed live. A value above 0.8 provides ' \
+                   'strong likelihood that the track is live.',
+      range: '0.0 - 1.0'
+    },
+    valence: {
+      name: 'Valence',
+      description: 'A measure describing the musical positiveness conveyed by a track. Tracks with high valence ' \
+                   'sound more positive (e.g. happy, cheerful, euphoric), while tracks with low valence sound ' \
+                   'more negative (e.g. sad, depressed, angry).',
+      range: '0.0 - 1.0'
+    },
+    tempo: {
+      name: 'Tempo',
+      description: 'The overall estimated tempo of a track in beats per minute (BPM). In musical terminology, ' \
+                   'tempo is the speed or pace of a given piece and derives directly from the average beat duration.',
+      range: '0 - 250 BPM'
+    },
+    day_part: {
+      name: 'Day Part',
+      description: 'The time segment of the day when these audio characteristics were measured. ' \
+                   'Night (00:00-05:59), Breakfast (06:00-09:59), Morning (10:00-11:59), ' \
+                   'Lunch (12:00-12:59), Afternoon (13:00-15:59), Dinner (16:00-19:59), Evening (20:00-23:59).',
+      values: DAY_PARTS
+    },
+    counter: {
+      name: 'Sample Count',
+      description: 'The total number of songs analyzed to calculate the average values for this day part. ' \
+                   'A higher count indicates more reliable average values.'
+    }
+  }.freeze
+
   belongs_to :radio_station
+
+  def self.attribute_descriptions
+    ATTRIBUTE_DESCRIPTIONS
+  end
 end

--- a/app/serializers/radio_station_classifier_serializer.rb
+++ b/app/serializers/radio_station_classifier_serializer.rb
@@ -53,9 +53,22 @@ class RadioStationClassifierSerializer
              :liveness_average,
              :valence,
              :valence_average,
-             :tempo
+             :tempo,
+             :counter
 
-  def radio_station
-    RadioStationSerializer.new(object.radio_station)
+  attribute :radio_station do |object|
+    RadioStationSerializer.new(object.radio_station).serializable_hash[:data]
+  end
+
+  class << self
+    def attribute_descriptions
+      RadioStationClassifier::ATTRIBUTE_DESCRIPTIONS
+    end
+
+    def serializable_hash_with_descriptions(classifiers, options = {})
+      hash = new(classifiers, options).serializable_hash
+      hash[:meta] = { attribute_descriptions: attribute_descriptions }
+      hash
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,9 @@ Rails.application.routes.draw do
         get :last_played_songs, on: :collection
         get :new_played_songs, on: :collection
       end
+      resources :radio_station_classifiers, only: %i[index] do
+        get :descriptions, on: :collection
+      end
     end
   end
 

--- a/spec/factories/radio_station_classifiers.rb
+++ b/spec/factories/radio_station_classifiers.rb
@@ -35,15 +35,23 @@
 #
 FactoryBot.define do
   factory :radio_station_classifier do
-    radio_station { nil }
-    danceable { 1 }
-    energy { 1 }
-    speechs { 1 }
-    acoustic { 1 }
-    instrumental { 1 }
-    live { 1 }
-    valance { 1 }
-    day_part { 'MyString' }
-    tags { '' }
+    radio_station
+    danceability { 50 }
+    danceability_average { 0.65 }
+    energy { 45 }
+    energy_average { 0.72 }
+    speechiness { 10 }
+    speechiness_average { 0.08 }
+    acousticness { 20 }
+    acousticness_average { 0.25 }
+    instrumentalness { 5 }
+    instrumentalness_average { 0.02 }
+    liveness { 15 }
+    liveness_average { 0.12 }
+    valence { 40 }
+    valence_average { 0.58 }
+    tempo { 120.5 }
+    counter { 100 }
+    day_part { 'morning' }
   end
 end

--- a/spec/requests/api/v1/radio_station_classifiers_spec.rb
+++ b/spec/requests/api/v1/radio_station_classifiers_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'RadioStationClassifiers API', type: :request do
+  path '/api/v1/radio_station_classifiers' do
+    get 'List all radio station classifiers' do
+      tags 'Radio Station Classifiers'
+      produces 'application/json'
+      description 'Returns audio feature classifiers for radio stations, aggregated by day part. ' \
+                  'Includes Spotify audio features like danceability, energy, valence, etc. ' \
+                  'Response includes attribute descriptions in the meta section.'
+      parameter name: :radio_station_id, in: :query, type: :integer, required: false,
+                description: 'Filter by radio station ID'
+      parameter name: :day_part, in: :query, type: :string, required: false,
+                description: 'Filter by day part (night, breakfast, morning, lunch, afternoon, dinner, evening)'
+
+      response '200', 'Classifiers retrieved successfully' do
+        let!(:radio_station) { create(:radio_station) }
+        let!(:classifier) { create(:radio_station_classifier, radio_station: radio_station, day_part: 'morning') }
+
+        run_test! do |response|
+          json = JSON.parse(response.body)
+          expect(json['data']).to be_an(Array)
+          expect(json['data'].first['attributes']['day_part']).to eq('morning')
+          expect(json['meta']['attribute_descriptions']).to be_present
+          expect(json['meta']['attribute_descriptions']['danceability']).to include('name', 'description', 'range')
+        end
+      end
+
+      response '200', 'Classifiers filtered by radio station' do
+        let!(:radio_station1) { create(:radio_station) }
+        let!(:radio_station2) { create(:radio_station) }
+        let!(:classifier1) { create(:radio_station_classifier, radio_station: radio_station1, day_part: 'morning') }
+        let!(:classifier2) { create(:radio_station_classifier, radio_station: radio_station2, day_part: 'evening') }
+        let(:radio_station_id) { radio_station1.id }
+
+        run_test! do |response|
+          json = JSON.parse(response.body)
+          expect(json['data'].length).to eq(1)
+          expect(json['data'].first['attributes']['day_part']).to eq('morning')
+        end
+      end
+
+      response '200', 'Classifiers filtered by day part' do
+        let!(:radio_station) { create(:radio_station) }
+        let!(:morning_classifier) { create(:radio_station_classifier, radio_station: radio_station, day_part: 'morning') }
+        let!(:evening_classifier) { create(:radio_station_classifier, radio_station: radio_station, day_part: 'evening') }
+        let(:day_part) { 'evening' }
+
+        run_test! do |response|
+          json = JSON.parse(response.body)
+          expect(json['data'].length).to eq(1)
+          expect(json['data'].first['attributes']['day_part']).to eq('evening')
+        end
+      end
+    end
+  end
+
+  path '/api/v1/radio_station_classifiers/descriptions' do
+    get 'Get attribute descriptions for audio features' do
+      tags 'Radio Station Classifiers'
+      produces 'application/json'
+      description 'Returns detailed descriptions for all audio feature attributes used in classifiers. ' \
+                  'Useful for displaying tooltips or help text in the frontend.'
+
+      response '200', 'Descriptions retrieved successfully' do
+        run_test! do |response|
+          json = JSON.parse(response.body)
+          expect(json['data']).to be_a(Hash)
+          expect(json['data']['danceability']).to include('name', 'description', 'range')
+          expect(json['data']['energy']).to include('name', 'description', 'range')
+          expect(json['data']['valence']).to include('name', 'description', 'range')
+          expect(json['data']['tempo']).to include('name', 'description', 'range')
+          expect(json['data']['day_part']).to include('name', 'description', 'values')
+        end
+      end
+    end
+  end
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -462,6 +462,41 @@ paths:
       responses:
         '200':
           description: Artist bio retrieved successfully
+  "/api/v1/radio_station_classifiers":
+    get:
+      summary: List all radio station classifiers
+      tags:
+      - Radio Station Classifiers
+      description: Returns audio feature classifiers for radio stations, aggregated
+        by day part. Includes Spotify audio features like danceability, energy, valence,
+        etc. Response includes attribute descriptions in the meta section.
+      parameters:
+      - name: radio_station_id
+        in: query
+        required: false
+        description: Filter by radio station ID
+        schema:
+          type: integer
+      - name: day_part
+        in: query
+        required: false
+        description: Filter by day part (night, breakfast, morning, lunch, afternoon,
+          dinner, evening)
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Classifiers filtered by day part
+  "/api/v1/radio_station_classifiers/descriptions":
+    get:
+      summary: Get attribute descriptions for audio features
+      tags:
+      - Radio Station Classifiers
+      description: Returns detailed descriptions for all audio feature attributes
+        used in classifiers. Useful for displaying tooltips or help text in the frontend.
+      responses:
+        '200':
+          description: Descriptions retrieved successfully
   "/api/v1/radio_stations":
     get:
       summary: List all radio stations


### PR DESCRIPTION
…ions

Expose radio station classifiers through a dedicated API endpoint with detailed descriptions for each Spotify audio feature attribute. This enables the frontend to display informative tooltips explaining what each metric (danceability, energy, valence, etc.) represents.

- Add ATTRIBUTE_DESCRIPTIONS constant with detailed explanations
- Create /api/v1/radio_station_classifiers endpoint with filtering
- Add /descriptions endpoint for standalone attribute descriptions
- Include descriptions in meta section of classifier responses
- Fix factory attributes to match actual database columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)