### PR TITLE
Add is_currently_playing flag to last_played_songs endpoint

### DIFF
--- a/app/services/spotify/song_enricher.rb
+++ b/app/services/spotify/song_enricher.rb
@@ -46,6 +46,7 @@ module Spotify
         spotify_artwork_url: response.dig('album', 'images', 0, 'url'),
         spotify_preview_url: response['preview_url'],
         isrc: response.dig('external_ids', 'isrc'),
+        duration_ms: response['duration_ms'],
         artists: response['artists']
       )
     end
@@ -66,6 +67,7 @@ module Spotify
       updates[:spotify_artwork_url] = result.spotify_artwork_url if result.spotify_artwork_url.present?
       updates[:spotify_preview_url] = result.spotify_preview_url if result.spotify_preview_url.present?
       updates[:isrc] = result.isrc if result.isrc.present? && @song.isrc.blank?
+      updates[:duration_ms] = result.duration_ms if result.duration_ms.present?
       updates
     end
 

--- a/app/services/spotify/track_finder/result.rb
+++ b/app/services/spotify/track_finder/result.rb
@@ -4,7 +4,7 @@ module Spotify
       attr_reader :track, :artists, :title, :id, :isrc, :spotify_artwork_url,
                   :spotify_song_url, :spotify_query_result, :filter_result, :tracks,
                   :spotify_preview_url, :release_date, :release_date_precision,
-                  :matched_artist_distance, :matched_title_distance
+                  :matched_artist_distance, :matched_title_distance, :duration_ms
 
       TRACK_TYPES = %w[album single compilation].freeze
       FEATURING_REGEX = /\(feat\..+\)/
@@ -35,6 +35,7 @@ module Spotify
         @id = set_id
         @release_date = set_release_date
         @release_date_precision = set_release_date_precision
+        @duration_ms = set_duration_ms
 
         @track
       end
@@ -187,6 +188,12 @@ module Spotify
         return if @track.blank?
 
         @track['title_distance']
+      end
+
+      def set_duration_ms
+        return if @track.blank?
+
+        @track['duration_ms']
       end
 
       def dig_for_usable_tracks

--- a/app/services/track_extractor/song_extractor.rb
+++ b/app/services/track_extractor/song_extractor.rb
@@ -52,7 +52,8 @@ class TrackExtractor::SongExtractor < TrackExtractor
       id_on_spotify: (id_on_spotify if song.id_on_spotify.blank?),
       spotify_song_url: (spotify_song_url if song.spotify_song_url.blank?),
       spotify_artwork_url: (spotify_artwork_url if song.spotify_artwork_url.blank?),
-      isrc: (isrc if song.isrc.blank?)
+      isrc: (isrc if song.isrc.blank?),
+      duration_ms: (duration_ms if song.duration_ms.blank?)
     }.compact
   end
 
@@ -116,6 +117,10 @@ class TrackExtractor::SongExtractor < TrackExtractor
     @track&.isrc
   end
 
+  def duration_ms
+    @track&.duration_ms if @track.respond_to?(:duration_ms)
+  end
+
   # Spotify methods
   def spotify_song_url
     @track&.spotify_song_url if @track.respond_to?(:spotify_song_url)
@@ -177,6 +182,7 @@ class TrackExtractor::SongExtractor < TrackExtractor
       attrs[:spotify_artwork_url] = spotify_artwork_url
       attrs[:spotify_preview_url] = spotify_preview_url
       attrs[:id_on_spotify] = id_on_spotify
+      attrs[:duration_ms] = duration_ms
     end
 
     # Add Deezer attributes if available

--- a/db/migrate/20260221192706_add_duration_ms_to_songs.rb
+++ b/db/migrate/20260221192706_add_duration_ms_to_songs.rb
@@ -1,0 +1,5 @@
+class AddDurationMsToSongs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :songs, :duration_ms, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_02_21_060243) do
+ActiveRecord::Schema[8.1].define(version: 2026_02_21_192706) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -215,6 +215,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_02_21_060243) do
     t.string "deezer_artwork_url"
     t.string "deezer_preview_url"
     t.string "deezer_song_url"
+    t.integer "duration_ms"
     t.string "id_on_deezer"
     t.string "id_on_itunes"
     t.string "id_on_spotify"

--- a/spec/requests/api/v1/radio_stations_spec.rb
+++ b/spec/requests/api/v1/radio_stations_spec.rb
@@ -196,12 +196,12 @@ describe 'RadioStations API', type: :request do
         example 'application/json', :example, {
           data: [
             {
-              radio_station: {
-                id: 1,
-                name: 'Radio 538',
-                slug: 'radio-538'
-              },
-              last_song: {
+              id: 1,
+              name: 'Radio 538',
+              slug: 'radio-538',
+              country_code: 'NL',
+              is_currently_playing: true,
+              last_played_song: {
                 id: 1,
                 title: 'Bohemian Rhapsody',
                 artists: [{ id: 1, name: 'Queen' }],
@@ -209,12 +209,12 @@ describe 'RadioStations API', type: :request do
               }
             },
             {
-              radio_station: {
-                id: 2,
-                name: 'Qmusic',
-                slug: 'qmusic'
-              },
-              last_song: {
+              id: 2,
+              name: 'Qmusic',
+              slug: 'qmusic',
+              country_code: 'NL',
+              is_currently_playing: false,
+              last_played_song: {
                 id: 2,
                 title: 'Blinding Lights',
                 artists: [{ id: 2, name: 'The Weeknd' }],

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1212,7 +1212,6 @@ paths:
                         id: 1
                         name: Radio 538
                         slug: radio-538
-                        direct_stream_url: https://stream.538.nl/538/mp3
                         url: https://www.538.nl
                         country_code: NL
                     - id: '2'
@@ -1221,7 +1220,6 @@ paths:
                         id: 2
                         name: Qmusic
                         slug: qmusic
-                        direct_stream_url: https://stream.qmusic.nl/qmusic/mp3
                         url: https://www.qmusic.nl
                         country_code: NL
   "/api/v1/radio_stations/{id}":
@@ -1251,7 +1249,6 @@ paths:
                         id: 1
                         name: Radio 538
                         slug: radio-538
-                        direct_stream_url: https://stream.538.nl/538/mp3
                         url: https://www.538.nl
                         country_code: NL
         '404':
@@ -1385,22 +1382,24 @@ paths:
                 example:
                   value:
                     data:
-                    - radio_station:
-                        id: 1
-                        name: Radio 538
-                        slug: radio-538
-                      last_song:
+                    - id: 1
+                      name: Radio 538
+                      slug: radio-538
+                      country_code: NL
+                      is_currently_playing: true
+                      last_played_song:
                         id: 1
                         title: Bohemian Rhapsody
                         artists:
                         - id: 1
                           name: Queen
                         broadcasted_at: '2024-12-01T14:30:00Z'
-                    - radio_station:
-                        id: 2
-                        name: Qmusic
-                        slug: qmusic
-                      last_song:
+                    - id: 2
+                      name: Qmusic
+                      slug: qmusic
+                      country_code: NL
+                      is_currently_playing: false
+                      last_played_song:
                         id: 2
                         title: Blinding Lights
                         artists:
@@ -1599,6 +1598,8 @@ paths:
                 example:
                   value:
                     error: No stream URL configured for this radio station
+        '403':
+          description: Forbidden when hostname cannot be resolved
   "/api/v1/song_import_logs":
     get:
       summary: List song import logs
@@ -2451,9 +2452,6 @@ components:
             name:
               type: string
             slug:
-              type: string
-              nullable: true
-            direct_stream_url:
               type: string
               nullable: true
             country_code:


### PR DESCRIPTION
## Summary

- Add `duration_ms` column to `songs` table, populated from the Spotify API during import and enrichment
- Add `is_currently_playing` boolean to `last_played_songs` response by comparing `broadcasted_at + song duration` against the current time
- Falls back to a 5-minute default when `duration_ms` is not yet available for a song

Closes #1859

## Test plan

- [x] `bundle exec rspec spec/models/radio_station_spec.rb` — all passing, 6 new specs for `.currently_playing?`
- [x] `bundle exec rspec spec/requests/api/v1/radio_stations_spec.rb` — all passing, updated Swagger example
- [x] `bundle exec rubocop` — no offenses
- [x] `bundle exec rake rswag:specs:swaggerize` — Swagger docs regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)