### PR TITLE
Update all code to use isrcs column instead of isrc

### DIFF
--- a/app/jobs/song_external_ids_enrichment_job.rb
+++ b/app/jobs/song_external_ids_enrichment_job.rb
@@ -10,7 +10,7 @@ class SongExternalIdsEnrichmentJob
     scope = Song
               .where(id_on_deezer: nil)
               .or(Song.where(id_on_itunes: nil))
-              .or(Song.where(isrcs: []).where.not(isrc: [nil, '']))
+              .or(Song.where('array_length(isrcs, 1) = 1'))
 
     scope.find_each { |song| perform_async(song.id) }
   end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -62,7 +62,7 @@ class Song < ApplicationRecord
   scope :matching, lambda { |search_term|
     where('songs.search_text ILIKE ?', "%#{search_term}%") if search_term.present?
   }
-  scope :with_iscr, ->(isrc) { where(isrc: isrc) }
+  scope :with_isrc, ->(isrc) { where('? = ANY(isrcs)', isrc) }
   scope :with_id_on_spotify, -> { where.not(id_on_spotify: nil) }
   scope :with_music_profile, lambda { |filters|
     return all if filters.blank?
@@ -188,8 +188,8 @@ class Song < ApplicationRecord
     end
 
     # Try by ISRC
-    if isrc.present?
-      youtube_id = song_finder.get_youtube_video_id_by_isrc(isrc)
+    if isrcs.present?
+      youtube_id = song_finder.get_youtube_video_id_by_isrc(isrcs.first)
       return update(id_on_youtube: youtube_id) if youtube_id.present?
     end
 
@@ -260,11 +260,11 @@ class Song < ApplicationRecord
   end
 
   def should_update_youtube?
-    id_on_youtube.blank? && (id_on_spotify.present? || isrc.present? || title.present?)
+    id_on_youtube.blank? && (id_on_spotify.present? || isrcs.present? || title.present?)
   end
 
   def should_enrich_with_deezer?
-    id_on_deezer.blank? && (isrc.present? || title.present?)
+    id_on_deezer.blank? && (isrcs.present? || title.present?)
   end
 
   def should_enrich_with_itunes?
@@ -272,6 +272,6 @@ class Song < ApplicationRecord
   end
 
   def should_enrich_with_music_brainz?
-    isrcs.blank? && isrc.present?
+    isrcs.size == 1
   end
 end

--- a/app/services/deezer/song_enricher.rb
+++ b/app/services/deezer/song_enricher.rb
@@ -27,7 +27,7 @@ module Deezer
       result = Deezer::TrackFinder::Result.new(
         artists: @song.artists.map(&:name).join(' '),
         title: @song.title,
-        isrc: @song.isrc
+        isrc: @song.isrcs&.first
       )
       result.execute
       result

--- a/app/services/music_brainz/recording_finder.rb
+++ b/app/services/music_brainz/recording_finder.rb
@@ -25,10 +25,10 @@ module MusicBrainz
     private
 
     def find_by_isrc
-      return nil if @song.isrc.blank?
+      return nil if @song.isrcs.blank?
 
-      Rails.logger.info "MusicBrainz::RecordingFinder: Searching by ISRC #{@song.isrc}"
-      query = "isrc:#{@song.isrc}"
+      Rails.logger.info "MusicBrainz::RecordingFinder: Searching by ISRC #{@song.isrcs.first}"
+      query = "isrc:#{@song.isrcs.first}"
       search(query)
     end
 

--- a/app/services/music_brainz/song_enricher.rb
+++ b/app/services/music_brainz/song_enricher.rb
@@ -8,10 +8,10 @@ module MusicBrainz
 
     def enrich
       return if @song.blank?
-      return if @song.isrc.blank?
-      return if @song.isrcs.present?
+      return if @song.isrcs.blank?
+      return if @song.isrcs.size > 1
 
-      isrcs = MusicBrainz::IsrcsFinder.new(@song.isrc).find
+      isrcs = MusicBrainz::IsrcsFinder.new(@song.isrcs.first).find
       return if isrcs.blank?
 
       @song.update(isrcs: isrcs)

--- a/app/services/spotify/song_enricher.rb
+++ b/app/services/spotify/song_enricher.rb
@@ -66,7 +66,7 @@ module Spotify
       updates[:spotify_song_url] = result.spotify_song_url if result.spotify_song_url.present?
       updates[:spotify_artwork_url] = result.spotify_artwork_url if result.spotify_artwork_url.present?
       updates[:spotify_preview_url] = result.spotify_preview_url if result.spotify_preview_url.present?
-      updates[:isrc] = result.isrc if result.isrc.present? && @song.isrc.blank?
+      updates[:isrcs] = @song.isrcs | [result.isrc] if result.isrc.present? && !@song.isrcs.include?(result.isrc)
       updates[:duration_ms] = result.duration_ms if result.duration_ms.present?
       updates
     end

--- a/app/services/track_extractor/song_extractor.rb
+++ b/app/services/track_extractor/song_extractor.rb
@@ -48,13 +48,14 @@ class TrackExtractor::SongExtractor < TrackExtractor
   end
 
   def build_spotify_updates(song)
-    {
+    updates = {
       id_on_spotify: (id_on_spotify if song.id_on_spotify.blank?),
       spotify_song_url: (spotify_song_url if song.spotify_song_url.blank?),
       spotify_artwork_url: (spotify_artwork_url if song.spotify_artwork_url.blank?),
-      isrc: (isrc if song.isrc.blank?),
       duration_ms: (duration_ms if song.duration_ms.blank?)
     }.compact
+    updates[:isrcs] = song.isrcs | [isrc] if isrc.present? && !song.isrcs.include?(isrc)
+    updates
   end
 
   # Methode for checking if there are songs with the same title.
@@ -85,7 +86,7 @@ class TrackExtractor::SongExtractor < TrackExtractor
   # and recognizer find different platform versions of the same recording
   # (e.g., "Frank Boeijen" vs "Frank Boeijen Groep" versions with same ISRC).
   def find_by_track
-    @find_by_track ||= (isrc.present? && Song.find_by(isrc:)) ||
+    @find_by_track ||= (isrc.present? && Song.where('? = ANY(isrcs)', isrc).first) ||
                        (id_on_spotify.present? && Song.find_by(id_on_spotify:)) ||
                        (id_on_deezer.present? && Song.find_by(id_on_deezer:)) ||
                        (id_on_itunes.present? && Song.find_by(id_on_itunes:))
@@ -171,7 +172,7 @@ class TrackExtractor::SongExtractor < TrackExtractor
   def song_attributes
     attrs = {
       title:,
-      isrc:,
+      isrcs: [isrc].compact,
       release_date:,
       release_date_precision:
     }

--- a/app/services/track_extractor/spotify_track_finder.rb
+++ b/app/services/track_extractor/spotify_track_finder.rb
@@ -30,7 +30,7 @@ class TrackExtractor::SpotifyTrackFinder < TrackExtractor
   def find_existing_song
     # First, try to find by ISRC (most reliable identifier from audio recognition)
     if isrc_code.present?
-      song_by_isrc = Song.find_by(isrc: isrc_code)
+      song_by_isrc = Song.where('? = ANY(isrcs)', isrc_code).first
       return song_by_isrc if song_by_isrc&.id_on_spotify.present?
     end
 

--- a/script/fix_mismatched_songs.rb
+++ b/script/fix_mismatched_songs.rb
@@ -253,7 +253,7 @@ class SongFixer
   end
 
   def clear_incorrect_song_data
-    @song.update!(id_on_spotify: nil, isrc: nil, spotify_song_url: nil, spotify_artwork_url: nil)
+    @song.update!(id_on_spotify: nil, isrcs: [], spotify_song_url: nil, spotify_artwork_url: nil)
     @song.artists.clear
   end
 
@@ -267,7 +267,7 @@ class SongFixer
   def update_song_attributes
     @song.update!(
       title: @info[:spotify_title],
-      isrc: @spotify_data.dig('external_ids', 'isrc'),
+      isrcs: [@spotify_data.dig('external_ids', 'isrc')].compact,
       spotify_song_url: @spotify_data.dig('external_urls', 'spotify'),
       spotify_artwork_url: @spotify_data.dig('album', 'images', 0, 'url'),
       spotify_preview_url: @spotify_data['preview_url']

--- a/spec/factories/song.rb
+++ b/spec/factories/song.rb
@@ -27,7 +27,7 @@
 FactoryBot.define do
   factory :song do
     title { Faker::Music::RockBand.song }
-    isrc { Faker::Alphanumeric.alphanumeric(number: 12).upcase }
+    isrcs { [Faker::Alphanumeric.alphanumeric(number: 12).upcase] }
     id_on_spotify { Faker::Alphanumeric.alphanumeric(number: 22) }
     spotify_song_url { Faker::Internet.url(host: 'open.spotify.com', path: "/track/#{id_on_spotify}") }
     spotify_artwork_url { Faker::Internet.url(host: 'i.scdn.co', path: '/image/random') }

--- a/spec/jobs/song_external_ids_enrichment_job_spec.rb
+++ b/spec/jobs/song_external_ids_enrichment_job_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe SongExternalIdsEnrichmentJob do
     let(:job) { described_class.new }
 
     context 'when song exists', :use_vcr do
-      let(:song) { create(:song, title: 'Test Song', isrc: 'USRC12345678', id_on_deezer: nil, id_on_itunes: nil) }
+      let(:song) { create(:song, title: 'Test Song', isrcs: ['USRC12345678'], id_on_deezer: nil, id_on_itunes: nil) }
 
       before do
         allow(Deezer::SongEnricher).to receive(:new).and_return(instance_double(Deezer::SongEnricher, enrich: true))
@@ -31,7 +31,7 @@ RSpec.describe SongExternalIdsEnrichmentJob do
     end
 
     context 'when song is missing deezer id', :use_vcr do
-      let(:song) { create(:song, title: 'Test Song', isrc: 'USRC12345678', id_on_deezer: nil, id_on_itunes: '123') }
+      let(:song) { create(:song, title: 'Test Song', isrcs: ['USRC12345678'], id_on_deezer: nil, id_on_itunes: '123') }
 
       before do
         allow(Deezer::SongEnricher).to receive(:new).and_return(instance_double(Deezer::SongEnricher, enrich: true))
@@ -59,7 +59,7 @@ RSpec.describe SongExternalIdsEnrichmentJob do
     end
 
     context 'when song already has all external ids' do
-      let(:song) { create(:song, title: 'Test Song', id_on_deezer: '123456', id_on_itunes: '789012', isrcs: %w[USRC12345678]) }
+      let(:song) { create(:song, title: 'Test Song', id_on_deezer: '123456', id_on_itunes: '789012', isrcs: %w[USRC12345678 GBABC1234567]) }
 
       it 'does not call enrichment services', :aggregate_failures do
         allow(Deezer::SongEnricher).to receive(:new)
@@ -79,8 +79,8 @@ RSpec.describe SongExternalIdsEnrichmentJob do
     let!(:song_missing_deezer) { create(:song, id_on_deezer: nil, id_on_itunes: '123') }
     let!(:song_missing_itunes) { create(:song, id_on_deezer: '456', id_on_itunes: nil) }
     let!(:song_missing_both) { create(:song, id_on_deezer: nil, id_on_itunes: nil) }
-    let!(:song_missing_isrcs) { create(:song, id_on_deezer: '111', id_on_itunes: '222', isrc: 'USRC12345678', isrcs: []) }
-    let!(:song_complete) { create(:song, id_on_deezer: '789', id_on_itunes: '012', isrcs: %w[USRC12345678]) }
+    let!(:song_missing_isrcs) { create(:song, id_on_deezer: '111', id_on_itunes: '222', isrcs: ['USRC12345678']) }
+    let!(:song_complete) { create(:song, id_on_deezer: '789', id_on_itunes: '012', isrcs: %w[USRC12345678 GBABC1234567]) }
 
     it 'enqueues jobs for songs missing external IDs', :aggregate_failures do
       allow(described_class).to receive(:perform_async)

--- a/spec/models/song_spec.rb
+++ b/spec/models/song_spec.rb
@@ -596,7 +596,7 @@ describe Song do
 
     context 'when song has no searchable data' do
       it 'does not call update_youtube_from_wikipedia' do
-        song = build(:song, title: nil, id_on_youtube: nil, id_on_spotify: nil, isrc: nil)
+        song = build(:song, title: nil, id_on_youtube: nil, id_on_spotify: nil, isrcs: [])
         allow(song).to receive(:update_youtube_from_wikipedia)
         song.save!
         expect(song).not_to have_received(:update_youtube_from_wikipedia)
@@ -605,16 +605,16 @@ describe Song do
 
     context 'when song has only title' do
       it 'calls update_youtube_from_wikipedia' do
-        song = build(:song, title: 'Some Title', id_on_youtube: nil, id_on_spotify: nil, isrc: nil)
+        song = build(:song, title: 'Some Title', id_on_youtube: nil, id_on_spotify: nil, isrcs: [])
         allow(song).to receive(:update_youtube_from_wikipedia)
         song.save!
         expect(song).to have_received(:update_youtube_from_wikipedia)
       end
     end
 
-    context 'when song has only isrc' do
+    context 'when song has only isrcs' do
       it 'calls update_youtube_from_wikipedia' do
-        song = build(:song, title: nil, id_on_youtube: nil, id_on_spotify: nil, isrc: 'USRC12345678')
+        song = build(:song, title: nil, id_on_youtube: nil, id_on_spotify: nil, isrcs: ['USRC12345678'])
         allow(song).to receive(:update_youtube_from_wikipedia)
         song.save!
         expect(song).to have_received(:update_youtube_from_wikipedia)
@@ -658,7 +658,7 @@ describe Song do
                title: 'Rolling in the Deep',
                artists: [artist],
                id_on_youtube: nil,
-               isrc: 'GBBKS1000094')
+               isrcs: ['GBBKS1000094'])
       end
 
       it 'updates id_on_youtube if found' do

--- a/spec/services/music_brainz/recording_finder_spec.rb
+++ b/spec/services/music_brainz/recording_finder_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe MusicBrainz::RecordingFinder, type: :service do
-  let(:song) { create(:song, title: 'Test Song', isrc: 'USRC12345678') }
+  let(:song) { create(:song, title: 'Test Song', isrcs: ['USRC12345678']) }
   let(:artist) { create(:artist, name: 'Test Artist') }
   let(:finder) { described_class.new(song) }
   let(:successful_response) do
@@ -50,7 +50,7 @@ RSpec.describe MusicBrainz::RecordingFinder, type: :service do
     end
 
     context 'when ISRC search returns no results but title/artist search succeeds' do
-      let(:song) { create(:song, title: 'Another Song', isrc: 'NORC00000000') }
+      let(:song) { create(:song, title: 'Another Song', isrcs: ['NORC00000000']) }
 
       before do
         stub_request(:get, /musicbrainz.org.*isrc/)
@@ -65,7 +65,7 @@ RSpec.describe MusicBrainz::RecordingFinder, type: :service do
     end
 
     context 'when song has no ISRC' do
-      let(:song) { create(:song, title: 'No ISRC Song', isrc: nil) }
+      let(:song) { create(:song, title: 'No ISRC Song', isrcs: []) }
 
       before do
         stub_request(:get, /musicbrainz.org/)

--- a/spec/services/music_brainz/song_enricher_spec.rb
+++ b/spec/services/music_brainz/song_enricher_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe MusicBrainz::SongEnricher, type: :service do
-  let(:song) { create(:song, isrc: 'USRC12345678', isrcs: []) }
+  let(:song) { create(:song, isrcs: ['USRC12345678']) }
   let(:enricher) { described_class.new(song) }
 
   describe '#enrich' do
@@ -18,7 +18,7 @@ RSpec.describe MusicBrainz::SongEnricher, type: :service do
     end
 
     context 'when song has no ISRC' do
-      let(:song) { create(:song, isrc: nil, isrcs: []) }
+      let(:song) { create(:song, isrcs: []) }
 
       it 'does not call IsrcsFinder' do
         allow(MusicBrainz::IsrcsFinder).to receive(:new)
@@ -28,7 +28,7 @@ RSpec.describe MusicBrainz::SongEnricher, type: :service do
     end
 
     context 'when song already has ISRCs populated' do
-      let(:song) { create(:song, isrc: 'USRC12345678', isrcs: ['USRC12345678', 'GBABC1234567']) }
+      let(:song) { create(:song, isrcs: ['USRC12345678', 'GBABC1234567']) }
 
       it 'does not call IsrcsFinder' do
         allow(MusicBrainz::IsrcsFinder).to receive(:new)

--- a/spec/services/track_extractor/song_extractor_spec.rb
+++ b/spec/services/track_extractor/song_extractor_spec.rb
@@ -49,7 +49,7 @@ describe TrackExtractor::SongExtractor do
       end
 
       it 'sets the isrc code' do
-        expect(song.isrc).to eq('ISRC123')
+        expect(song.isrcs).to include('ISRC123')
       end
 
       it 'sets the spotify preview URL' do
@@ -105,7 +105,7 @@ describe TrackExtractor::SongExtractor do
       let!(:existing_song) do
         create(:song,
                title: 'Test Song',
-               isrc: 'ISRC123',
+               isrcs: ['ISRC123'],
                id_on_spotify: nil,
                spotify_song_url: nil,
                spotify_artwork_url: nil,
@@ -196,7 +196,7 @@ describe TrackExtractor::SongExtractor do
         create(:song,
                title: 'Different Song',
                id_on_spotify: nil,
-               isrc: nil,
+               isrcs: [],
                artists: [create(:artist, name: 'Other Artist')])
       end
 
@@ -209,7 +209,7 @@ describe TrackExtractor::SongExtractor do
       end
     end
 
-    context 'when track has nil isrc but song exists with nil isrc' do
+    context 'when track has nil isrc but song exists with empty isrcs' do
       let(:track) do
         OpenStruct.new(
           title: 'Another Song',
@@ -237,10 +237,10 @@ describe TrackExtractor::SongExtractor do
                id_on_spotify: nil,
                id_on_deezer: nil,
                id_on_itunes: nil,
-               isrc: nil)
+               isrcs: [])
       end
 
-      it 'does not match songs by nil isrc' do
+      it 'does not match songs by empty isrcs' do
         expect(song).not_to eq(song_with_nil_isrc)
       end
     end
@@ -373,7 +373,7 @@ describe TrackExtractor::SongExtractor do
         create(:song,
                title: 'Zwart Wit',
                id_on_spotify: 'spotify_band_version',
-               isrc: 'NLA200200321',
+               isrcs: ['NLA200200321'],
                artists: [create(:artist, name: 'Frank Boeijen Groep')])
       end
 

--- a/spec/services/track_extractor/spotify_track_finder_spec.rb
+++ b/spec/services/track_extractor/spotify_track_finder_spec.rb
@@ -285,7 +285,7 @@ describe TrackExtractor::SpotifyTrackFinder do
         )
       end
 
-      before { create(:song, title: 'Original Title', isrc: 'USRC12345678', id_on_spotify: 'isrc_match123', artists: [artist]) }
+      before { create(:song, title: 'Original Title', isrcs: ['USRC12345678'], id_on_spotify: 'isrc_match123', artists: [artist]) }
 
       it 'finds the existing song by ISRC even when artist names do not match' do
         finder.find
@@ -306,7 +306,7 @@ describe TrackExtractor::SpotifyTrackFinder do
         )
       end
 
-      before { create(:song, title: 'Test Song', isrc: 'USRC12345678', id_on_spotify: nil, artists: [artist]) }
+      before { create(:song, title: 'Test Song', isrcs: ['USRC12345678'], id_on_spotify: nil, artists: [artist]) }
 
       it 'falls back to artist + title matching' do
         finder.find


### PR DESCRIPTION
## Summary
- Updated all internal Song model references from the `isrc` (string) column to the `isrcs` (array) column
- ISRC lookups now use `WHERE ? = ANY(isrcs)` to match against any element in the array
- External API field names (Spotify, Deezer, Shazam, Wikidata) are preserved as-is
- MusicBrainz enrichment now triggers when a song has exactly 1 ISRC (needs expansion) instead of checking the old `isrc` column

## Test plan
- [x] All 177 affected specs pass (0 failures)
- [x] Rubocop passes with no offenses
- [x] Verified ISRC array lookup works against live DB (matches any position in array)
- [ ] Verify song import flow works end-to-end in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)