### PR TITLE
Add charts API endpoint for top songs and artists

### DIFF
--- a/app/controllers/api/v1/charts_controller.rb
+++ b/app/controllers/api/v1/charts_controller.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    class ChartsController < ApiController
+      def index
+        render json: ChartPositionSerializer.new(chart_positions, params: { previous_positions: previous_positions })
+                       .serializable_hash
+                       .merge(chart_metadata)
+                       .merge(pagination_data(chart_positions))
+                       .to_json
+      end
+
+      private
+
+      def chart
+        @chart ||= if params[:date].present?
+                     Chart.where(chart_type: chart_type).find_by!(date: params[:date])
+                   else
+                     Chart.where(chart_type: chart_type).order(date: :desc).first!
+                   end
+      end
+
+      def chart_positions
+        @chart_positions ||= chart.chart_positions
+                               .includes(positianable: :artists)
+                               .order(position: :asc)
+                               .paginate(page: params[:page], per_page: 24)
+      end
+
+      def previous_positions
+        @previous_positions ||= begin
+          previous_chart = Chart.where(chart_type: chart_type)
+                             .where('date < ?', chart.date)
+                             .order(date: :desc)
+                             .first
+          return {} unless previous_chart
+
+          previous_chart.chart_positions.pluck(:positianable_id, :position).to_h
+        end
+      end
+
+      def chart_type
+        params[:type].presence || 'songs'
+      end
+
+      def chart_metadata
+        { chart_date: chart.date, chart_type: chart.chart_type }
+      end
+    end
+  end
+end

--- a/app/serializers/chart_position_serializer.rb
+++ b/app/serializers/chart_position_serializer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ChartPositionSerializer
+  include FastJsonapi::ObjectSerializer
+
+  set_type :chart_position
+
+  attributes :position, :counts
+
+  attribute :previous_position do |object, params|
+    params[:previous_positions]&.dig(object.positianable_id)
+  end
+
+  attribute :song do |object|
+    SongSerializer.new(object.positianable).serializable_hash[:data] if object.positianable_type == 'Song'
+  end
+
+  attribute :artist do |object|
+    ArtistSerializer.new(object.positianable).serializable_hash[:data] if object.positianable_type == 'Artist'
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,7 @@ Rails.application.routes.draw do
       resources :radio_station_classifiers, only: %i[index] do
         get :descriptions, on: :collection
       end
+      resources :charts, only: %i[index]
       resources :song_import_logs, only: %i[index]
     end
   end

--- a/spec/factories/chart_positions.rb
+++ b/spec/factories/chart_positions.rb
@@ -22,5 +22,9 @@
 #
 FactoryBot.define do
   factory :chart_position do
+    chart
+    sequence(:position) { |n| n }
+    counts { 10 }
+    positianable { association :song }
   end
 end

--- a/spec/requests/api/v1/charts_spec.rb
+++ b/spec/requests/api/v1/charts_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'Charts API', type: :request do
+  path '/api/v1/charts' do
+    get 'List chart positions' do
+      tags 'Charts'
+      produces 'application/json'
+      description 'Returns chart positions with optional type, date, and pagination. ' \
+                  'Includes previous_position from the prior chart for movement indicators.'
+      parameter name: :type, in: :query, type: :string, required: false,
+                description: 'Chart type: songs (default) or artists'
+      parameter name: :date, in: :query, type: :string, format: :date, required: false,
+                description: 'Chart date (YYYY-MM-DD). Defaults to latest available'
+      parameter name: :page, in: :query, type: :integer, required: false, description: 'Page number'
+
+      response '200', 'Chart positions retrieved successfully' do
+        example 'application/json', :example, {
+          data: [
+            {
+              id: '1',
+              type: 'chart_position',
+              attributes: {
+                position: 1,
+                counts: 42,
+                previous_position: 3,
+                song: {
+                  id: '5',
+                  type: 'song',
+                  attributes: {
+                    id: 5,
+                    title: 'Bohemian Rhapsody',
+                    spotify_artwork_url: 'https://i.scdn.co/image/abc123',
+                    artists: [{ id: 1, name: 'Queen' }]
+                  }
+                },
+                artist: nil
+              }
+            }
+          ],
+          chart_date: '2026-03-01',
+          chart_type: 'songs',
+          total_entries: 150,
+          total_pages: 7,
+          current_page: 1
+        }
+
+        let!(:chart) { create(:chart, chart_type: 'songs', date: 1.day.ago.to_date) }
+        let!(:song) { create(:song, title: 'Test Song') }
+        let!(:chart_position) { create(:chart_position, chart: chart, positianable: song, position: 1, counts: 42) }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['data'].first['attributes']['position']).to eq(1)
+        end
+      end
+
+      context 'with artist chart type' do
+        response '200', 'Artist chart positions retrieved' do
+          let(:type) { 'artists' }
+          let!(:chart) { create(:chart, chart_type: 'artists', date: 1.day.ago.to_date) }
+          let!(:artist) { create(:artist, name: 'Test Artist') }
+          let!(:chart_position) { create(:chart_position, chart: chart, positianable: artist, position: 1, counts: 30) }
+
+          run_test! do |response|
+            data = JSON.parse(response.body)
+            expect(data['chart_type']).to eq('artists')
+          end
+        end
+      end
+
+      context 'with specific date' do
+        response '200', 'Chart for specific date' do
+          let(:date) { 3.days.ago.to_date.to_s }
+          let!(:chart) { create(:chart, chart_type: 'songs', date: 3.days.ago.to_date) }
+          let!(:chart_position) { create(:chart_position, chart: chart, position: 1, counts: 20) }
+
+          run_test! do |response|
+            data = JSON.parse(response.body)
+            expect(data['chart_date']).to eq(3.days.ago.to_date.to_s)
+          end
+        end
+      end
+
+      context 'with previous positions' do
+        response '200', 'Chart with previous position data' do
+          let!(:song) { create(:song) }
+          let!(:previous_chart) { create(:chart, chart_type: 'songs', date: 2.days.ago.to_date) }
+          let!(:previous_position) { create(:chart_position, chart: previous_chart, positianable: song, position: 3, counts: 30) }
+          let!(:chart) { create(:chart, chart_type: 'songs', date: 1.day.ago.to_date) }
+          let!(:chart_position) { create(:chart_position, chart: chart, positianable: song, position: 1, counts: 42) }
+
+          run_test! do |response|
+            data = JSON.parse(response.body)
+            expect(data['data'].first['attributes']['previous_position']).to eq(3)
+          end
+        end
+      end
+
+      context 'without previous chart' do
+        response '200', 'Chart with nil previous positions' do
+          let!(:chart) { create(:chart, chart_type: 'songs', date: 1.day.ago.to_date) }
+          let!(:chart_position) { create(:chart_position, chart: chart, position: 1, counts: 42) }
+
+          run_test! do |response|
+            data = JSON.parse(response.body)
+            expect(data['data'].first['attributes']['previous_position']).to be_nil
+          end
+        end
+      end
+
+      context 'with pagination' do
+        response '200', 'Paginated chart positions' do
+          let(:page) { 2 }
+          let!(:chart) { create(:chart, chart_type: 'songs', date: 1.day.ago.to_date) }
+          let!(:chart_positions) { create_list(:chart_position, 25, chart: chart) }
+
+          run_test! do |response|
+            data = JSON.parse(response.body)
+            expect(data['current_page']).to eq(2)
+            expect(data['total_pages']).to eq(2)
+          end
+        end
+      end
+
+      response '404', 'Chart not found for given date' do
+        example 'application/json', :example, {
+          status: 404,
+          error: 'Not Found'
+        }
+
+        let(:date) { '2020-01-01' }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -196,6 +196,34 @@ RSpec.configure do |config|
               counts: { type: :integer }
             }
           },
+          ChartPositionEntry: {
+            type: :object,
+            properties: {
+              id: { type: :string },
+              type: { type: :string, example: 'chart_position' },
+              attributes: {
+                type: :object,
+                properties: {
+                  position: { type: :integer },
+                  counts: { type: :integer },
+                  previous_position: { type: :integer, nullable: true },
+                  song: { '$ref' => '#/components/schemas/Song', nullable: true },
+                  artist: { '$ref' => '#/components/schemas/Artist', nullable: true }
+                }
+              }
+            }
+          },
+          ChartResponse: {
+            type: :object,
+            properties: {
+              data: { type: :array, items: { '$ref' => '#/components/schemas/ChartPositionEntry' } },
+              chart_date: { type: :string, format: :date },
+              chart_type: { type: :string, enum: %w[songs artists] },
+              total_entries: { type: :integer },
+              total_pages: { type: :integer },
+              current_page: { type: :integer }
+            }
+          },
           TimeAnalytics: {
             type: :object,
             properties: {

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -756,6 +756,73 @@ paths:
                         source: https://upload.wikimedia.org/coldplay.jpg
                         width: 320
                         height: 240
+  "/api/v1/charts":
+    get:
+      summary: List chart positions
+      tags:
+      - Charts
+      description: Returns chart positions with optional type, date, and pagination.
+        Includes previous_position from the prior chart for movement indicators.
+      parameters:
+      - name: type
+        in: query
+        required: false
+        description: 'Chart type: songs (default) or artists'
+        schema:
+          type: string
+      - name: date
+        in: query
+        format: date
+        required: false
+        description: Chart date (YYYY-MM-DD). Defaults to latest available
+        schema:
+          type: string
+      - name: page
+        in: query
+        required: false
+        description: Page number
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: Paginated chart positions
+          content:
+            application/json:
+              examples:
+                example:
+                  value:
+                    data:
+                    - id: '1'
+                      type: chart_position
+                      attributes:
+                        position: 1
+                        counts: 42
+                        previous_position: 3
+                        song:
+                          id: '5'
+                          type: song
+                          attributes:
+                            id: 5
+                            title: Bohemian Rhapsody
+                            spotify_artwork_url: https://i.scdn.co/image/abc123
+                            artists:
+                            - id: 1
+                              name: Queen
+                        artist:
+                    chart_date: '2026-03-01'
+                    chart_type: songs
+                    total_entries: 150
+                    total_pages: 7
+                    current_page: 1
+        '404':
+          description: Chart not found for given date
+          content:
+            application/json:
+              examples:
+                example:
+                  value:
+                    status: 404
+                    error: Not Found
   "/api/v1/radio_station_classifiers":
     get:
       summary: List all radio station classifiers
@@ -2641,6 +2708,51 @@ components:
         position:
           type: integer
         counts:
+          type: integer
+    ChartPositionEntry:
+      type: object
+      properties:
+        id:
+          type: string
+        type:
+          type: string
+          example: chart_position
+        attributes:
+          type: object
+          properties:
+            position:
+              type: integer
+            counts:
+              type: integer
+            previous_position:
+              type: integer
+              nullable: true
+            song:
+              "$ref": "#/components/schemas/Song"
+              nullable: true
+            artist:
+              "$ref": "#/components/schemas/Artist"
+              nullable: true
+    ChartResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            "$ref": "#/components/schemas/ChartPositionEntry"
+        chart_date:
+          type: string
+          format: date
+        chart_type:
+          type: string
+          enum:
+          - songs
+          - artists
+        total_entries:
+          type: integer
+        total_pages:
+          type: integer
+        current_page:
           type: integer
     TimeAnalytics:
       type: object


### PR DESCRIPTION
## Summary

- Adds `GET /api/v1/charts` endpoint that exposes daily chart positions with popularity boost tiebreakers, replacing raw airplay count ranking for the frontend's "top songs" page
- Supports `type` (songs/artists), `date` (specific chart date or latest), and `page` query params
- Includes `previous_position` per entry (from prior day's chart) so the frontend can show movement indicators (up/down/new)

## Test plan

- [x] 7 new request specs pass (default, artist type, specific date, previous positions, nil previous, pagination, 404)
- [x] Full test suite passes (1088 examples, 0 failures)
- [x] Rubocop: no offenses
- [x] Swagger docs regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)