### PR TITLE
Switch SongImporter to scraper-first approach

### DIFF
--- a/app/services/song_importer.rb
+++ b/app/services/song_importer.rb
@@ -10,11 +10,11 @@ class SongImporter
 
   def import
     safe_start_log
-    @played_song = recognize_song || scrape_song
+    @played_song = scrape_song || recognize_song
 
     if @played_song.blank?
       Broadcaster.no_importing_song
-      @import_logger.skip_log(reason: 'No song recognized or scraped')
+      @import_logger.skip_log(reason: 'No song scraped or recognized')
       return false
     elsif artist_name.blank?
       Broadcaster.no_importing_artists

--- a/spec/services/song_importer_spec.rb
+++ b/spec/services/song_importer_spec.rb
@@ -5,6 +5,77 @@ describe SongImporter do
   let(:artist) { create(:artist, name: 'Test Artist') }
   let(:song) { create(:song, title: 'Test Song', artists: [artist]) }
 
+  describe '#import' do
+    let(:station) { create(:radio_station, url: 'https://example.com/api', processor: 'npo_api_processor') }
+    let(:importer) { described_class.new(radio_station: station) }
+    let(:scraper) do
+      instance_double(
+        TrackScraper::NpoApiProcessor,
+        last_played_song: true,
+        title: 'Test Song',
+        artist_name: 'Test Artist',
+        spotify_url: nil,
+        isrc_code: nil,
+        broadcasted_at: Time.current,
+        raw_response: {},
+        is_a?: false
+      )
+    end
+
+    before do
+      allow(SongImportLogger).to receive(:new).and_return(
+        instance_double(SongImportLogger, start_log: nil, log_scraping: nil, skip_log: nil,
+                                          complete_log: nil, log_recognition: nil, log_acoustid: nil,
+                                          fail_log: nil, log_spotify: nil, log_deezer: nil, log_itunes: nil)
+      )
+    end
+
+    context 'when scraper returns a result' do
+      before do
+        allow(TrackScraper::NpoApiProcessor).to receive(:new).and_return(scraper)
+      end
+
+      it 'does not attempt audio recognition' do
+        allow(importer).to receive_messages(artists: [artist], song: song, create_air_play: true,
+                                            deezer_track: nil, itunes_track: nil)
+        allow(SongRecognizer).to receive(:new)
+        importer.import
+        expect(SongRecognizer).not_to have_received(:new)
+      end
+    end
+
+    context 'when scraper returns nil' do
+      before do
+        allow(TrackScraper::NpoApiProcessor).to receive(:new).and_return(
+          instance_double(TrackScraper::NpoApiProcessor, last_played_song: nil)
+        )
+        allow(importer).to receive(:recognize_song).and_return(nil)
+        allow(Broadcaster).to receive(:no_importing_song)
+      end
+
+      it 'attempts audio recognition as fallback' do
+        importer.import
+        expect(importer).to have_received(:recognize_song)
+      end
+    end
+
+    context 'when both scraper and recognizer return nil' do
+      before do
+        allow(TrackScraper::NpoApiProcessor).to receive(:new).and_return(
+          instance_double(TrackScraper::NpoApiProcessor, last_played_song: nil)
+        )
+        allow(importer).to receive(:recognize_song).and_return(nil)
+        allow(Broadcaster).to receive(:no_importing_song)
+      end
+
+      it 'returns false', :aggregate_failures do
+        result = importer.import
+        expect(result).to be false
+        expect(Broadcaster).to have_received(:no_importing_song)
+      end
+    end
+  end
+
   describe '#should_update_artists?' do
     subject(:song_importer) do
       importer = described_class.new(radio_station: radio_station)


### PR DESCRIPTION
## Summary
Closes https://github.com/samuelvaneck/radio_playlists/issues/1840

- Swap import order in `SongImporter#import` from `recognize_song || scrape_song` to `scrape_song || recognize_song`, making scraping the primary method and audio recognition the fallback
- Scraping is cheaper (HTTP call vs audio capture + SongRec + AcoustID) and with fuzzy search now reliable, scraped data maps well to existing songs
- Add tests for `#import` verifying the scraper-first ordering: scraper skips recognition, nil scraper falls back to recognition, both nil returns false

## Test plan
- [x] `bundle exec rspec spec/services/song_importer_spec.rb` — 33 examples, 0 failures
- [x] `bundle exec rubocop app/services/song_importer.rb spec/services/song_importer_spec.rb` — no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)