### PR TITLE
Sort charts autocomplete by most recent airplay and popularity

### DIFF
--- a/app/controllers/api/v1/charts_controller.rb
+++ b/app/controllers/api/v1/charts_controller.rb
@@ -68,16 +68,11 @@ module Api
       end
 
       def autocomplete_songs
-        songs = Song.matching(params[:q]).includes(:artists).limit(autocomplete_limit).to_a
-        aired_today_songs = songs_aired_today
-        combined = songs | aired_today_songs
-        combined.first(autocomplete_limit)
-      end
-
-      def songs_aired_today
         Song.matching(params[:q])
-          .joins(:air_plays)
-          .where(air_plays: { created_at: Time.current.beginning_of_day.. })
+          .select('songs.*, MAX(air_plays.created_at) AS last_played_at')
+          .left_joins(:air_plays)
+          .group('songs.id')
+          .order(Arel.sql('MAX(air_plays.created_at) DESC NULLS LAST, COALESCE(songs.popularity, 0) DESC'))
           .includes(:artists)
           .limit(autocomplete_limit)
           .to_a

--- a/spec/controllers/api/v1/charts_controller_spec.rb
+++ b/spec/controllers/api/v1/charts_controller_spec.rb
@@ -212,6 +212,35 @@ describe Api::V1::ChartsController do
       end
     end
 
+    context 'when sorting by most recent airplay and popularity' do
+      let(:query) { 'Adele' }
+      let!(:radio_station) { create :radio_station }
+      let!(:popular_song) { create :song, title: 'Someone Like You', artists: [artist], search_text: 'Adele Someone Like You', popularity: 90 }
+      let!(:recently_played_song) { create :song, title: 'Easy On Me', artists: [artist], search_text: 'Adele Easy On Me', popularity: 50 }
+
+      before do
+        non_chart_song
+        create :air_play, song: recently_played_song, radio_station: radio_station, created_at: 1.hour.ago
+        create :air_play, song: popular_song, radio_station: radio_station, created_at: 1.day.ago
+      end
+
+      it 'returns recently played songs before older popular songs', :aggregate_failures do
+        get_autocomplete
+        titles = json[:data].map { |s| s[:attributes][:title] }
+        recently_played_index = titles.index('Easy On Me')
+        popular_index = titles.index('Someone Like You')
+        expect(recently_played_index).to be < popular_index
+      end
+
+      it 'returns songs with airplays before songs without airplays', :aggregate_failures do
+        get_autocomplete
+        titles = json[:data].map { |s| s[:attributes][:title] }
+        played_index = titles.index('Easy On Me')
+        unplayed_index = titles.index('Hometown Glory')
+        expect(played_index).to be < unplayed_index
+      end
+    end
+
     context 'when query matches nothing' do
       let(:query) { 'Nonexistent Song' }
 


### PR DESCRIPTION
## Summary
- Replace two separate queries (matching + aired today) with a single query using `LEFT JOIN air_plays`, sorted by most recent airplay time then popularity
- Fixes inconsistent autocomplete result ordering by using deterministic `ORDER BY MAX(air_plays.created_at) DESC NULLS LAST, popularity DESC`
- Remove unused `songs_aired_today` method

## Test plan
- [x] All existing autocomplete tests pass (25 controller + 14 request specs)
- [x] Added 2 new tests verifying sort order (recently played before older, played before unplayed)
- [x] Rubocop passes with no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)