### PR TITLE
Use lightweight serializer for autocomplete endpoints

### DIFF
--- a/app/controllers/api/v1/charts_controller.rb
+++ b/app/controllers/api/v1/charts_controller.rb
@@ -23,8 +23,9 @@ module Api
         songs = autocomplete_songs
         chart_data = autocomplete_chart_data(songs.map(&:id))
 
-        render json: SongSerializer.new(songs, params: { chart_data: chart_data })
+        render json: AutocompleteSongSerializer.new(songs, params: { chart_data: chart_data })
                        .serializable_hash
+                       .merge(pagination_data(songs))
                        .to_json
       end
 
@@ -69,13 +70,12 @@ module Api
 
       def autocomplete_songs
         Song.matching(params[:q])
-          .select('songs.*, MAX(air_plays.created_at) AS last_played_at')
+          .select('songs.id, songs.title, songs.spotify_artwork_url, MAX(air_plays.created_at) AS last_played_at')
           .left_joins(:air_plays)
           .group('songs.id')
           .order(Arel.sql('MAX(air_plays.created_at) DESC NULLS LAST, COALESCE(songs.popularity, 0) DESC'))
           .includes(:artists)
-          .limit(autocomplete_limit)
-          .to_a
+          .paginate(page: params[:page], per_page: autocomplete_limit)
       end
 
       def autocomplete_chart_data(song_ids)

--- a/app/controllers/api/v1/songs_controller.rb
+++ b/app/controllers/api/v1/songs_controller.rb
@@ -30,10 +30,11 @@ module Api
       # }
       def autocomplete
         results = Song.search_by_text(params[:q])
+                    .select(:id, :title, :spotify_artwork_url)
                     .includes(:artists)
                     .limit(autocomplete_limit)
 
-        render json: SongSerializer.new(results).serializable_hash.to_json
+        render json: AutocompleteSongSerializer.new(results).serializable_hash.to_json
       end
 
       def graph_data

--- a/app/serializers/autocomplete_song_serializer.rb
+++ b/app/serializers/autocomplete_song_serializer.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class AutocompleteSongSerializer
+  include FastJsonapi::ObjectSerializer
+
+  attributes :id,
+             :title,
+             :spotify_artwork_url
+
+  attribute :artists do |object|
+    object.artists.map { |artist| { id: artist.id, name: artist.name } }
+  end
+
+  attribute :in_chart do |object, params|
+    params.dig(:chart_data, object.id, :in_chart)
+  end
+
+  attribute :last_chart_date do |object, params|
+    params.dig(:chart_data, object.id, :last_chart_date)
+  end
+end


### PR DESCRIPTION
## Summary
- Introduce `AutocompleteSongSerializer` that only returns `id`, `title`, `spotify_artwork_url`, and artist `id`/`name` — replacing the full `SongSerializer` (25+ attributes, music_profile, etc.) for autocomplete
- Narrow `SELECT` to only needed columns in both songs and charts autocomplete queries
- Add pagination support to charts autocomplete endpoint (`total_entries`, `total_pages`, `current_page`)

## Test plan
- [x] `bundle exec rspec spec/controllers/api/v1/songs_controller_spec.rb` — 25 examples, 0 failures
- [x] `bundle exec rspec spec/controllers/api/v1/charts_controller_spec.rb` — 25 examples, 0 failures
- [x] `bundle exec rubocop` — no offenses
- [ ] Verify autocomplete response times in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)