### PR TITLE
Add song_id filter to song import logs

### DIFF
--- a/app/controllers/api/v1/song_import_logs_controller.rb
+++ b/app/controllers/api/v1/song_import_logs_controller.rb
@@ -15,10 +15,17 @@ module Api
       def song_import_logs
         @song_import_logs ||= SongImportLog.includes(:radio_station, :song, :air_play)
                                 .by_radio_station(params[:radio_station_id])
+                                .then { |scope| filter_by_song(scope) }
                                 .then { |scope| filter_by_status(scope) }
                                 .then { |scope| filter_by_import_source(scope) }
                                 .order(created_at: :desc)
                                 .paginate(page: params[:page], per_page: params[:per_page] || 25)
+      end
+
+      def filter_by_song(scope)
+        return scope if params[:song_id].blank?
+
+        scope.where(song_id: params[:song_id])
       end
 
       def filter_by_status(scope)

--- a/spec/requests/api/v1/song_import_logs_spec.rb
+++ b/spec/requests/api/v1/song_import_logs_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe 'SongImportLogs API', type: :request do
                 description: 'Filter by status: pending, success, failed, skipped'
       parameter name: :import_source, in: :query, type: :string, required: false,
                 description: 'Filter by import source: recognition, scraping'
+      parameter name: :song_id, in: :query, type: :integer, required: false,
+                description: 'Filter by song ID'
 
       response '200', 'Song import logs retrieved successfully' do
         let!(:song_import_log) { create(:song_import_log, :with_recognition) }
@@ -32,6 +34,19 @@ RSpec.describe 'SongImportLogs API', type: :request do
           json = JSON.parse(response.body)
           expect(json['data'].length).to eq(1)
           expect(json['data'].first['attributes']['status']).to eq('failed')
+        end
+      end
+
+      response '200', 'Filtered by song' do
+        let(:song) { create(:song) }
+        let!(:log1) { create(:song_import_log, :with_recognition, song:) }
+        let!(:log2) { create(:song_import_log, :with_recognition) }
+        let(:song_id) { song.id }
+
+        run_test! do |response|
+          json = JSON.parse(response.body)
+          expect(json['data'].length).to eq(1)
+          expect(json['data'].first['attributes']['song']['id']).to eq(song.id)
         end
       end
 

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1838,6 +1838,12 @@ paths:
         description: 'Filter by import source: recognition, scraping'
         schema:
           type: string
+      - name: song_id
+        in: query
+        required: false
+        description: Filter by song ID
+        schema:
+          type: integer
       responses:
         '200':
           description: Filtered by radio station


### PR DESCRIPTION
## Summary
- Add `song_id` query parameter filter to `GET /api/v1/song_import_logs` for debugging import logs of specific songs
- Add request spec covering the new filter
- Regenerate swagger docs

## Test plan
- [x] Existing specs pass
- [x] New filter spec passes
- [x] Rubocop clean
- [x] Swagger regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)