### PR TITLE
Expose country_of_origin in nested artist API responses

### DIFF
--- a/app/serializers/air_play_serializer.rb
+++ b/app/serializers/air_play_serializer.rb
@@ -50,7 +50,7 @@ class AirPlaySerializer
 
   attributes :artists do |object|
     object.song.artists.map do |artist|
-      options = { fields: { artist: %i[id name] } }
+      options = { fields: { artist: %i[id name country_of_origin] } }
       ArtistSerializer.new(artist, options)
     end
   end

--- a/app/serializers/song_serializer.rb
+++ b/app/serializers/song_serializer.rb
@@ -87,7 +87,7 @@ class SongSerializer
 
   attribute :artists do |object|
     object.artists.map do |artist|
-      options = { fields: { artist: %i[id name] } }
+      options = { fields: { artist: %i[id name country_of_origin] } }
       ArtistSerializer.new(artist, options)
     end
   end

--- a/spec/requests/api/v1/artists_spec.rb
+++ b/spec/requests/api/v1/artists_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe 'Artists API', type: :request do
                 lastfm_playcount: 5_500_000,
                 lastfm_tags: %w[rock classic-rock],
                 counter: 42,
-                artists: [{ id: 1, name: 'Queen' }]
+                artists: [{ id: 1, name: 'Queen', country_of_origin: ['United Kingdom'] }]
               }
             },
             {
@@ -211,7 +211,7 @@ RSpec.describe 'Artists API', type: :request do
                 lastfm_playcount: 4_200_000,
                 lastfm_tags: %w[rock classic-rock],
                 counter: 38,
-                artists: [{ id: 1, name: 'Queen' }]
+                artists: [{ id: 1, name: 'Queen', country_of_origin: ['United Kingdom'] }]
               }
             }
           ]

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -93,7 +93,8 @@ RSpec.configure do |config|
                     type: :object,
                     properties: {
                       id: { type: :integer },
-                      name: { type: :string }
+                      name: { type: :string },
+                      country_of_origin: { type: :array, items: { type: :string }, nullable: true }
                     }
                   }
                 }

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -527,6 +527,8 @@ paths:
                         artists:
                         - id: 1
                           name: Queen
+                          country_of_origin:
+                          - United Kingdom
                     - id: '2'
                       type: song
                       attributes:
@@ -544,6 +546,8 @@ paths:
                         artists:
                         - id: 1
                           name: Queen
+                          country_of_origin:
+                          - United Kingdom
   "/api/v1/artists/{id}/chart_positions":
     get:
       summary: Get artist chart positions over time
@@ -2673,6 +2677,11 @@ components:
                   type: integer
                 name:
                   type: string
+                country_of_origin:
+                  type: array
+                  items:
+                    type: string
+                  nullable: true
     AirPlay:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- Add `country_of_origin` to compact artist fields in `SongSerializer` and `AirPlaySerializer`, so the field is available wherever artists are nested (songs, air plays, charts)
- Update `ArtistCompact` Swagger schema and spec examples to document the new field
- `country_of_origin` was already exposed on the top-level Artist endpoint — this extends it to nested representations

## Test plan
- [x] All 81 API request specs pass
- [x] Rubocop clean
- [x] Swagger regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)