### PR TITLE
Add granular period parsing for chart time selection

### DIFF
--- a/app/models/concerns/chart_concern.rb
+++ b/app/models/concerns/chart_concern.rb
@@ -1,32 +1,21 @@
 module ChartConcern
   extend ActiveSupport::Concern
 
-  PERIOD_RANGES = {
-    'week' => 1.week,
-    'month' => 1.month,
-    'year' => 1.year,
-    'all' => nil
-  }.freeze
-
   # Returns chart positions for a given time period
   #
-  # @param period [String] one of 'week', 'month', 'year', 'all' (default: 'month')
+  # @param period [String] e.g. '3_days', '2_weeks', '6_months', 'year', 'all' (default: '1_month')
   # @return [Array<Hash>] array of hashes with keys date, position, and counts
-  def chart_positions_for_period(period = 'month')
-    period = 'month' unless PERIOD_RANGES.key?(period)
+  def chart_positions_for_period(period = '1_month')
+    duration = PeriodParser.parse_duration(period)
+    duration = 1.month if duration.nil? && period != 'all'
 
-    start_date = calculate_start_date(period)
+    start_date = duration ? Time.zone.today - duration : nil
     positions = chart_positions_in_range(start_date)
 
     format_positions(positions, start_date)
   end
 
   private
-
-  def calculate_start_date(period)
-    duration = PERIOD_RANGES[period]
-    duration ? Time.zone.today - duration : nil
-  end
 
   def chart_positions_in_range(start_date)
     scope = chart_positions.joins(:chart).order('charts.date ASC')

--- a/app/models/concerns/graph_concern.rb
+++ b/app/models/concerns/graph_concern.rb
@@ -3,37 +3,27 @@
 module GraphConcern
   extend ActiveSupport::Concern
 
-  STRFTIME_VALUES = {
-    day: '%Y-%m-%dT%H:00',
-    week: '%Y-%m-%d',
-    month: '%Y-%m-%d',
-    year: '%Y-%m-01',
-    all: '%Y-%m-01'
-  }.freeze
-  TIME_STEPS = {
-    day: 1.hour,
-    week: 1.day,
-    month: 1.day,
-    year: 1.month,
-    all: 1.month
-  }.freeze
-
   included do
-    def graph_data(time_value)
-      strftime_value = STRFTIME_VALUES[time_value.to_sym]
-      air_plays = get_air_plays(time_value)
+    def graph_data(period)
+      aggregation = PeriodParser.aggregation_for(period)
+      strftime_value = aggregation[:strftime]
+      duration = PeriodParser.parse_duration(period)
+
+      air_plays = get_air_plays(duration)
       min_date, max_date = min_max_date(air_plays, strftime_value)
       air_plays = format_graph_data(air_plays, strftime_value)
-      air_plays = graph_data_series(air_plays, min_date, max_date, time_value)
+      air_plays = graph_data_series(air_plays, min_date, max_date, strftime_value, aggregation[:time_step])
       air_plays << legend_data_column
       air_plays
     end
 
-    def get_air_plays(time_value)
-      begin_date = graph_begin_date(time_value) unless time_value == 'all'
+    def get_air_plays(duration)
       end_date = 1.day.ago.end_of_day
       result = air_plays.where.not(broadcasted_at: nil)
-      result = result.where(air_plays_time_slot_query, begin_date, end_date) unless time_value == 'all'
+      if duration
+        begin_date = duration.ago.beginning_of_day
+        result = result.where(air_plays_time_slot_query, begin_date, end_date)
+      end
       result.order(:broadcasted_at)
     end
 
@@ -41,16 +31,11 @@ module GraphConcern
       results.map { |result| result.broadcasted_at.strftime(strftime_value) }.minmax
     end
 
-    def graph_begin_date(time_value)
-      1.send(time_value.to_sym).ago.beginning_of_day
-    end
-
     def air_plays_time_slot_query
       'air_plays.created_at > ? AND air_plays.created_at < ?'
     end
 
     def format_graph_data(air_plays, strftime_value)
-      # result['2022-01-01'][radio_station_id] = count
       air_plays.each_with_object({}) do |air_play, result|
         broadcasted_at, radio_station_id = air_play.values_at(:broadcasted_at, :radio_station_id)
         date_key = broadcasted_at.strftime(strftime_value)
@@ -60,13 +45,10 @@ module GraphConcern
       end
     end
 
-    def graph_data_series(air_plays, min_date, max_date, time_value)
-      strftime_value = STRFTIME_VALUES[time_value.to_sym]
-      time_step = TIME_STEPS[time_value.to_sym]
+    def graph_data_series(air_plays, min_date, max_date, strftime_value, time_step)
       min_date_i = min_date.present? ? min_date.to_datetime.beginning_of_day.to_i : time_step.send(:ago).beginning_of_day.to_i
       max_date_i = max_date.present? ? max_date.to_datetime.end_of_day.to_i : Time.zone.now.end_of_day.to_i
 
-      # Cache radio stations to avoid repeated queries
       radio_stations = RadioStation.unscoped.pluck(:id, :name).to_h
 
       (min_date_i..max_date_i).step(time_step).map do |date|

--- a/app/models/concerns/period_parser.rb
+++ b/app/models/concerns/period_parser.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module PeriodParser
+  VALID_UNITS = %w[day days week weeks month months year years].freeze
+  LEGACY_PERIODS = { 'week' => '1_week', 'month' => '1_month', 'year' => '1_year' }.freeze
+
+  AGGREGATION_CONFIG = {
+    days: { strftime: '%Y-%m-%dT%H:00', time_step: 1.hour },
+    weeks: { strftime: '%Y-%m-%d', time_step: 1.day },
+    months: { strftime: '%Y-%m-%d', time_step: 1.day },
+    years: { strftime: '%Y-%m-01', time_step: 1.month }
+  }.freeze
+
+  class << self
+    def parse_duration(period)
+      return nil if period == 'all'
+
+      period = normalize(period)
+      number, unit = period.match(/\A(\d+)_(#{VALID_UNITS.join('|')})\z/)&.captures
+      return nil unless number
+
+      number.to_i.public_send(unit.to_sym)
+    end
+
+    def aggregation_for(period)
+      return AGGREGATION_CONFIG[:years] if period == 'all'
+
+      period = normalize(period)
+      unit = period.match(/\A\d+_(#{VALID_UNITS.join('|')})\z/)&.captures&.first
+      return AGGREGATION_CONFIG[:months] unless unit
+
+      plural_unit = unit.to_s.pluralize.to_sym
+      AGGREGATION_CONFIG[plural_unit] || AGGREGATION_CONFIG[:months]
+    end
+
+    private
+
+    def normalize(period)
+      LEGACY_PERIODS.fetch(period, period)
+    end
+  end
+end

--- a/spec/models/concerns/period_parser_spec.rb
+++ b/spec/models/concerns/period_parser_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PeriodParser do
+  describe '.parse_duration' do
+    context 'with granular periods' do
+      it 'parses day periods', :aggregate_failures do
+        expect(described_class.parse_duration('1_day')).to eq(1.day)
+        expect(described_class.parse_duration('3_days')).to eq(3.days)
+        expect(described_class.parse_duration('7_days')).to eq(7.days)
+      end
+
+      it 'parses week periods', :aggregate_failures do
+        expect(described_class.parse_duration('1_week')).to eq(1.week)
+        expect(described_class.parse_duration('2_weeks')).to eq(2.weeks)
+        expect(described_class.parse_duration('4_weeks')).to eq(4.weeks)
+      end
+
+      it 'parses month periods', :aggregate_failures do
+        expect(described_class.parse_duration('1_month')).to eq(1.month)
+        expect(described_class.parse_duration('6_months')).to eq(6.months)
+        expect(described_class.parse_duration('12_months')).to eq(12.months)
+      end
+
+      it 'parses year periods', :aggregate_failures do
+        expect(described_class.parse_duration('1_year')).to eq(1.year)
+        expect(described_class.parse_duration('2_years')).to eq(2.years)
+      end
+    end
+
+    context 'with legacy periods' do
+      it 'normalizes legacy period names', :aggregate_failures do
+        expect(described_class.parse_duration('week')).to eq(1.week)
+        expect(described_class.parse_duration('month')).to eq(1.month)
+        expect(described_class.parse_duration('year')).to eq(1.year)
+      end
+    end
+
+    context 'with all period' do
+      it 'returns nil' do
+        expect(described_class.parse_duration('all')).to be_nil
+      end
+    end
+
+    context 'with invalid periods' do
+      it 'returns nil', :aggregate_failures do
+        expect(described_class.parse_duration('invalid')).to be_nil
+        expect(described_class.parse_duration('3_bananas')).to be_nil
+        expect(described_class.parse_duration('')).to be_nil
+      end
+    end
+  end
+
+  describe '.aggregation_for' do
+    it 'returns hourly aggregation for day periods', :aggregate_failures do
+      result = described_class.aggregation_for('3_days')
+      expect(result[:strftime]).to eq('%Y-%m-%dT%H:00')
+      expect(result[:time_step]).to eq(1.hour)
+    end
+
+    it 'returns daily aggregation for week periods', :aggregate_failures do
+      result = described_class.aggregation_for('2_weeks')
+      expect(result[:strftime]).to eq('%Y-%m-%d')
+      expect(result[:time_step]).to eq(1.day)
+    end
+
+    it 'returns daily aggregation for month periods', :aggregate_failures do
+      result = described_class.aggregation_for('6_months')
+      expect(result[:strftime]).to eq('%Y-%m-%d')
+      expect(result[:time_step]).to eq(1.day)
+    end
+
+    it 'returns monthly aggregation for year periods', :aggregate_failures do
+      result = described_class.aggregation_for('1_year')
+      expect(result[:strftime]).to eq('%Y-%m-01')
+      expect(result[:time_step]).to eq(1.month)
+    end
+
+    it 'returns monthly aggregation for all', :aggregate_failures do
+      result = described_class.aggregation_for('all')
+      expect(result[:strftime]).to eq('%Y-%m-01')
+      expect(result[:time_step]).to eq(1.month)
+    end
+
+    it 'handles legacy period names', :aggregate_failures do
+      expect(described_class.aggregation_for('week')[:time_step]).to eq(1.day)
+      expect(described_class.aggregation_for('month')[:time_step]).to eq(1.day)
+      expect(described_class.aggregation_for('year')[:time_step]).to eq(1.month)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `PeriodParser` module that dynamically parses `{n}_{unit}` period strings (e.g. `3_days`, `2_weeks`, `6_months`) with automatic aggregation granularity selection
- Update `ChartConcern` and `GraphConcern` to use `PeriodParser` instead of static period hashes
- Backward compatible: legacy values (`week`, `month`, `year`, `all`) still work

## Supported period values
```
1_day, 2_days, ... 7_days        → hourly aggregation
1_week, 2_weeks, 3_weeks, 4_weeks → daily aggregation
1_month, 2_months, ... 12_months  → daily aggregation
1_year, 2_years                   → monthly aggregation
all                               → monthly aggregation
```

## Test plan
- [x] All existing request specs pass (23 examples, 0 failures)
- [x] New `PeriodParser` specs pass (13 examples covering parsing, legacy support, aggregation)
- [x] RuboCop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)