### PR TITLE
Refactor classifiers controller to use PeriodParser

### DIFF
--- a/app/controllers/api/v1/radio_station_classifiers_controller.rb
+++ b/app/controllers/api/v1/radio_station_classifiers_controller.rb
@@ -3,8 +3,6 @@
 module Api
   module V1
     class RadioStationClassifiersController < ApiController
-      VALID_TIME_PERIODS = %w[day week month year].freeze
-
       def index
         start_time, end_time = time_range_from_period
 
@@ -46,17 +44,10 @@ module Api
 
       def time_range_from_period
         period = params[:time_period]
-        return [nil, nil] if period.blank? || !VALID_TIME_PERIODS.include?(period)
+        duration = PeriodParser.parse_duration(period) if period.present?
+        return [nil, nil] unless duration
 
-        end_time = Time.current
-        start_time = case period
-                     when 'day' then 1.day.ago
-                     when 'week' then 1.week.ago
-                     when 'month' then 1.month.ago
-                     when 'year' then 1.year.ago
-                     end
-
-        [start_time, end_time]
+        [duration.ago, Time.current]
       end
     end
   end

--- a/app/models/concerns/period_parser.rb
+++ b/app/models/concerns/period_parser.rb
@@ -2,7 +2,7 @@
 
 module PeriodParser
   VALID_UNITS = %w[day days week weeks month months year years].freeze
-  LEGACY_PERIODS = { 'week' => '1_week', 'month' => '1_month', 'year' => '1_year' }.freeze
+  LEGACY_PERIODS = { 'day' => '1_day', 'week' => '1_week', 'month' => '1_month', 'year' => '1_year' }.freeze
 
   AGGREGATION_CONFIG = {
     days: { strftime: '%Y-%m-%dT%H:00', time_step: 1.hour },


### PR DESCRIPTION
## Summary
- Replaced hardcoded `VALID_TIME_PERIODS` constant and `case` statement in `RadioStationClassifiersController` with `PeriodParser.parse_duration`
- Added `'day'` to `PeriodParser::LEGACY_PERIODS` for backward compatibility
- Classifiers endpoint now supports granular time periods (e.g. `3_days`, `2_weeks`, `6_months`) in addition to legacy formats

## Test plan
- [x] Existing `RadioStationClassifiersController` specs pass
- [x] Existing `PeriodParser` specs pass
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)