### PR TITLE
Add granular period support to air_plays endpoints

### DIFF
--- a/app/controllers/api/v1/artists_controller.rb
+++ b/app/controllers/api/v1/artists_controller.rb
@@ -73,11 +73,8 @@ module Api
       #
       # Parameters:
       #   - period (optional, default: 'day'): Time period for air plays
-      #     - 'day': last 24 hours
-      #     - 'week': last 7 days
-      #     - 'month': last 30 days
-      #     - 'year': last 365 days
-      #     - 'all': all time
+      #     Legacy: 'day', 'week', 'month', 'year', 'all'
+      #     Granular: '1_day', '3_days', '2_weeks', '6_months', '1_year', etc.
       #   - radio_station_ids[] (optional): Filter by specific radio stations
       def air_plays
         render json: AirPlaySerializer.new(artist_air_plays)

--- a/app/controllers/api/v1/songs_controller.rb
+++ b/app/controllers/api/v1/songs_controller.rb
@@ -106,11 +106,8 @@ module Api
       #
       # Parameters:
       #   - period (optional, default: 'day'): Time period for air plays
-      #     - 'day': last 24 hours
-      #     - 'week': last 7 days
-      #     - 'month': last 30 days
-      #     - 'year': last 365 days
-      #     - 'all': all time
+      #     Legacy: 'day', 'week', 'month', 'year', 'all'
+      #     Granular: '1_day', '3_days', '2_weeks', '6_months', '1_year', etc.
       #   - radio_station_ids[] (optional): Filter by specific radio stations
       def air_plays
         render json: AirPlaySerializer.new(song_air_plays)

--- a/app/models/concerns/date_concern.rb
+++ b/app/models/concerns/date_concern.rb
@@ -27,7 +27,13 @@ module DateConcern
       return fallback if time.blank?
       return time if time.is_a?(Time)
 
-      TIME_MAPPINGS[time]&.() || Time.zone.strptime(time, '%Y-%m-%dT%R')
+      if TIME_MAPPINGS.key?(time)
+        TIME_MAPPINGS[time].()
+      elsif (duration = PeriodParser.parse_duration(time))
+        duration.ago
+      else
+        Time.zone.strptime(time, '%Y-%m-%dT%R')
+      end
     end
 
     def self.time_range_from_params(params, default_period: 'day')

--- a/spec/controllers/api/v1/artists_controller_spec.rb
+++ b/spec/controllers/api/v1/artists_controller_spec.rb
@@ -239,6 +239,24 @@ describe Api::V1::ArtistsController do
       end
     end
 
+    context 'with granular period=3_days' do
+      subject(:get_air_plays_granular) do
+        get :air_plays, params: { id: artist_one.id, period: '3_days', format: :json }
+      end
+
+      let!(:old_air_play) do
+        air_play = create(:air_play, song: song_one, radio_station: radio_station_one, broadcasted_at: 5.days.ago)
+        air_play.update_column(:created_at, 5.days.ago) # rubocop:disable Rails/SkipsModelValidations
+        air_play
+      end
+
+      it 'excludes air plays older than 3 days' do
+        get_air_plays_granular
+        air_play_ids = json[:data].map { |ap| ap[:id].to_i }
+        expect(air_play_ids).not_to include(old_air_play.id)
+      end
+    end
+
     context 'with radio_station_ids filter' do
       subject(:get_air_plays_filtered) do
         get :air_plays, params: { id: artist_three.id, radio_station_ids: [radio_station_three.id], format: :json }

--- a/spec/controllers/api/v1/songs_controller_spec.rb
+++ b/spec/controllers/api/v1/songs_controller_spec.rb
@@ -247,6 +247,24 @@ describe Api::V1::SongsController do
       end
     end
 
+    context 'with granular period=3_days' do
+      subject(:get_air_plays_granular) do
+        get :air_plays, params: { id: song.id, period: '3_days', format: :json }
+      end
+
+      let!(:old_air_play) do
+        air_play = create(:air_play, song:, radio_station: radio_station_one, broadcasted_at: 5.days.ago)
+        air_play.update_column(:created_at, 5.days.ago) # rubocop:disable Rails/SkipsModelValidations
+        air_play
+      end
+
+      it 'excludes air plays older than 3 days' do
+        get_air_plays_granular
+        air_play_ids = json[:data].map { |ap| ap[:id].to_i }
+        expect(air_play_ids).not_to include(old_air_play.id)
+      end
+    end
+
     context 'with radio_station_ids filter' do
       subject(:get_air_plays_filtered) do
         get :air_plays, params: { id: song.id, radio_station_ids: [radio_station_one.id], format: :json }


### PR DESCRIPTION
## Summary
- Update `DateConcern#date_from_params` to support `PeriodParser` granular periods (e.g. `3_days`, `2_weeks`, `6_months`) in addition to legacy periods
- Enables granular time control on `Songs#air_plays` and `Artists#air_plays` endpoints, consistent with the graphs endpoint
- Add tests for granular period filtering on both controller specs

## Test plan
- [x] Existing air_plays tests pass (legacy periods still work)
- [x] New granular period tests pass on both songs and artists controllers
- [x] Rubocop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)