### PR TITLE
Fix similar_artists crash for artists with empty genres

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -106,8 +106,8 @@ class Artist < ApplicationRecord
       .where('genres && ARRAY[:genres]::varchar[] OR lastfm_tags && ARRAY[:tags]::varchar[]', genres:, tags: lastfm_tags)
       .select(
         'artists.*',
-        "COALESCE(cardinality(ARRAY(SELECT unnest(genres) INTERSECT SELECT unnest(ARRAY[#{sanitized_array(genres)}]))), 0) + " \
-        "COALESCE(cardinality(ARRAY(SELECT unnest(lastfm_tags) INTERSECT SELECT unnest(ARRAY[#{sanitized_array(lastfm_tags)}]))), 0) " \
+        "COALESCE(cardinality(ARRAY(SELECT unnest(genres) INTERSECT SELECT unnest(#{sanitized_sql_array(genres)}))), 0) + " \
+        "COALESCE(cardinality(ARRAY(SELECT unnest(lastfm_tags) INTERSECT SELECT unnest(#{sanitized_sql_array(lastfm_tags)}))), 0) " \
         'AS similarity_score'
       )
       .order(Arel.sql('similarity_score DESC, COALESCE(spotify_popularity, 0) DESC'))
@@ -122,10 +122,10 @@ class Artist < ApplicationRecord
     air_plays.size
   end
 
-  def sanitized_array(array)
-    return '' if array.blank?
+  def sanitized_sql_array(array)
+    return 'ARRAY[]::varchar[]' if array.blank?
 
-    array.map { |element| ActiveRecord::Base.connection.quote(element) }.join(', ')
+    "ARRAY[#{array.map { |element| ActiveRecord::Base.connection.quote(element) }.join(', ')}]"
   end
 
   def update_website_from_wikipedia

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -380,6 +380,16 @@ describe Artist do
       end
     end
 
+    context 'when the artist has tags but no genres' do
+      let(:tags_only_artist) { create(:artist, name: 'Taylor Swift', genres: [], lastfm_tags: %w[pop country]) }
+      let!(:tag_match) { create(:artist, name: 'Kacey Musgraves', genres: %w[country], lastfm_tags: %w[country americana]) }
+
+      it 'returns artists matching on tags' do
+        results = tags_only_artist.similar_artists
+        expect(results).to include(tag_match)
+      end
+    end
+
     it 'excludes the artist itself' do
       create(:artist, name: 'Clone', genres: %w[rock pop britpop], lastfm_tags: %w[rock british alternative])
       results = artist.similar_artists


### PR DESCRIPTION
## Summary
- Fix `PG::IndeterminateDatatype` error in `Artist#similar_artists` when an artist has `lastfm_tags` but empty `genres` (e.g. Taylor Swift)
- PostgreSQL cannot infer the type of an uncast `ARRAY[]` — now explicitly returns `ARRAY[]::varchar[]` for empty arrays
- Add test coverage for the tags-only artist case

## Test plan
- [x] Verify `Artist#similar_artists` returns results for artists with empty genres but populated lastfm_tags
- [x] Verify existing similar_artists tests still pass
- [x] Verify the similar_artists API endpoint works for affected artists

🤖 Generated with [Claude Code](https://claude.com/claude-code)