### PR TITLE
Add granular time range support to radio station classifiers

### DIFF
--- a/app/controllers/api/v1/radio_station_classifiers_controller.rb
+++ b/app/controllers/api/v1/radio_station_classifiers_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class RadioStationClassifiersController < ApiController
       def index
-        start_time, end_time = time_range_from_period
+        start_time, end_time = classifiers_time_range
 
         hour = params[:hour].presence&.to_i
 
@@ -42,12 +42,16 @@ module Api
 
       private
 
-      def time_range_from_period
-        period = params[:time_period]
-        duration = PeriodParser.parse_duration(period) if period.present?
-        return [nil, nil] unless duration
+      def classifiers_time_range
+        normalized_params = normalize_time_params
+        return [nil, nil] if normalized_params[:period].blank? && normalized_params[:start_time].blank?
 
-        [duration.ago, Time.current]
+        RadioStation.time_range_from_params(normalized_params, default_period: 'day')
+      end
+
+      def normalize_time_params
+        period = params[:period] || params[:time_period]
+        { period:, start_time: params[:start_time], end_time: params[:end_time] }
       end
     end
   end

--- a/spec/requests/api/v1/radio_station_classifiers_spec.rb
+++ b/spec/requests/api/v1/radio_station_classifiers_spec.rb
@@ -14,8 +14,15 @@ RSpec.describe 'RadioStationClassifiers API', type: :request do
                 description: 'Filter by radio station ID'
       parameter name: :hour, in: :query, type: :integer, required: false,
                 description: 'Filter by hour (0-23)'
+      parameter name: :period, in: :query, type: :string, required: false,
+                description: 'Time period for analysis. Legacy: day, week, month, year. ' \
+                             'Granular: 1_day, 3_days, 2_weeks, 6_months, 1_year, etc.'
+      parameter name: :start_time, in: :query, type: :string, required: false,
+                description: 'Start time (ISO8601 or period string). Cannot be combined with period.'
+      parameter name: :end_time, in: :query, type: :string, required: false,
+                description: 'End time (ISO8601 or period string). Defaults to now.'
       parameter name: :time_period, in: :query, type: :string, required: false,
-                description: 'Time period for analysis (day, week, month, year). Defaults to day if not specified.'
+                description: 'Deprecated: use period instead. Time period for analysis (day, week, month, year).'
 
       response '200', 'Classifiers retrieved successfully' do
         example 'application/json', :example, {
@@ -287,7 +294,7 @@ RSpec.describe 'RadioStationClassifiers API', type: :request do
         end
       end
 
-      response '200', 'Classifiers filtered by time period' do
+      response '200', 'Classifiers filtered by time period (legacy time_period param)' do
         example 'application/json', :filtered_by_time_period, {
           data: [
             {
@@ -319,6 +326,24 @@ RSpec.describe 'RadioStationClassifiers API', type: :request do
         run_test! do |response|
           json = JSON.parse(response.body)
           # With time_period=week, only the recent air_play should be included (not the 2 weeks old one)
+          expect(json['data'].length).to eq(1)
+          expect(json['data'].first['attributes']['counter']).to eq(1)
+        end
+      end
+
+      response '200', 'Classifiers filtered by granular period param' do
+        let!(:radio_station) { create(:radio_station) }
+        let!(:song_recent) { create(:song, :with_music_profile) }
+        let!(:song_old) { create(:song, :with_music_profile) }
+        let!(:recent_air_play) { create(:air_play, :morning, song: song_recent, radio_station: radio_station) }
+        let!(:old_air_play) do
+          create(:air_play, song: song_old, radio_station: radio_station, broadcasted_at: 2.weeks.ago.change(hour: 10, min: 30))
+        end
+        let(:radio_station_id) { radio_station.id }
+        let(:period) { '3_days' }
+
+        run_test! do |response|
+          json = JSON.parse(response.body)
           expect(json['data'].length).to eq(1)
           expect(json['data'].first['attributes']['counter']).to eq(1)
         end


### PR DESCRIPTION
## Summary
- Replace custom `time_range_from_period` (PeriodParser-only) with `DateConcern`'s `time_range_from_params` in the radio station classifiers endpoint
- Now supports granular periods (`3_days`, `2_weeks`, `6_months`, etc.), legacy periods (`day`, `week`), and `start_time`/`end_time` ISO8601 timestamps
- Keeps backward compatibility with the existing `time_period` param

## Test plan
- [ ] Verify `period=3_days` returns classifiers for the last 3 days
- [ ] Verify legacy `time_period=week` still works
- [ ] Verify `start_time`/`end_time` timestamp params work
- [ ] Verify no params returns default (nil start/end, calculator defaults to 24h)

🤖 Generated with [Claude Code](https://claude.com/claude-code)