### PR TITLE
Sort similar artists by popularity

### DIFF
--- a/app/controllers/api/v1/artists_controller.rb
+++ b/app/controllers/api/v1/artists_controller.rb
@@ -115,8 +115,8 @@ module Api
       # Parameters:
       #   - limit (optional, default: 10): Maximum number of results (max: 20)
       #
-      # Returns artists with the most overlapping genres and Last.fm tags,
-      # using Spotify popularity as tiebreaker.
+      # Returns artists with overlapping genres and Last.fm tags,
+      # sorted by Spotify popularity, using similarity score as tiebreaker.
       def similar_artists
         results = artist.similar_artists(limit: similar_artists_limit)
         render json: ArtistSerializer.new(results).serializable_hash.to_json

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -110,7 +110,7 @@ class Artist < ApplicationRecord
         "COALESCE(cardinality(ARRAY(SELECT unnest(lastfm_tags) INTERSECT SELECT unnest(#{sanitized_sql_array(lastfm_tags)}))), 0) " \
         'AS similarity_score'
       )
-      .order(Arel.sql('similarity_score DESC, COALESCE(spotify_popularity, 0) DESC'))
+      .order(Arel.sql('COALESCE(spotify_popularity, 0) DESC, similarity_score DESC'))
       .limit(limit)
   end
 

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -418,17 +418,17 @@ describe Artist do
       end
     end
 
-    context 'when ordering by similarity score' do
-      let!(:high_match) do
-        create(:artist, name: 'Oasis', genres: %w[rock britpop], lastfm_tags: %w[rock british], spotify_popularity: 50)
-      end
-      let!(:low_match) do
+    context 'when ordering by popularity' do
+      let!(:popular_match) do
         create(:artist, name: 'Jay-Z', genres: %w[pop], lastfm_tags: [], spotify_popularity: 95)
       end
+      let!(:unpopular_match) do
+        create(:artist, name: 'Oasis', genres: %w[rock britpop], lastfm_tags: %w[rock british], spotify_popularity: 50)
+      end
 
-      it 'ranks higher similarity above higher popularity', :aggregate_failures do
+      it 'ranks higher popularity above higher similarity', :aggregate_failures do
         results = artist.similar_artists
-        expect(results.index(high_match)).to be < results.index(low_match)
+        expect(results.index(popular_match)).to be < results.index(unpopular_match)
       end
     end
   end


### PR DESCRIPTION
## Summary
- Sort similar artists primarily by Spotify popularity (high to low) instead of similarity score
- Similarity score is now used as a tiebreaker instead of the primary sort
- Updated specs to reflect the new ordering

## Test plan
- [ ] Existing similar_artists specs pass with updated expectations
- [ ] Popularity-based ordering returns most popular matching artists first

🤖 Generated with [Claude Code](https://claude.com/claude-code)