### PR TITLE
Sort similar artists by similarity, break ties with popularity

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -110,7 +110,7 @@ class Artist < ApplicationRecord
         "COALESCE(cardinality(ARRAY(SELECT unnest(lastfm_tags) INTERSECT SELECT unnest(#{sanitized_sql_array(lastfm_tags)}))), 0) " \
         'AS similarity_score'
       )
-      .order(Arel.sql('COALESCE(spotify_popularity, 0) DESC, similarity_score DESC'))
+      .order(Arel.sql('similarity_score DESC, COALESCE(spotify_popularity, 0) * 0.1 DESC'))
       .limit(limit)
   end
 

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -418,17 +418,17 @@ describe Artist do
       end
     end
 
-    context 'when ordering by popularity' do
-      let!(:popular_match) do
+    context 'when ordering by similarity with popularity tiebreaker' do
+      let!(:low_similarity_popular) do
         create(:artist, name: 'Jay-Z', genres: %w[pop], lastfm_tags: [], spotify_popularity: 95)
       end
-      let!(:unpopular_match) do
+      let!(:high_similarity_unpopular) do
         create(:artist, name: 'Oasis', genres: %w[rock britpop], lastfm_tags: %w[rock british], spotify_popularity: 50)
       end
 
-      it 'ranks higher popularity above higher similarity', :aggregate_failures do
+      it 'ranks higher similarity above higher popularity', :aggregate_failures do
         results = artist.similar_artists
-        expect(results.index(popular_match)).to be < results.index(unpopular_match)
+        expect(results.index(high_similarity_unpopular)).to be < results.index(low_similarity_popular)
       end
     end
   end


### PR DESCRIPTION
## Summary
- Changed `similar_artists` ordering to use similarity score as the primary sort
- Popularity is now a tiebreaker weighted at 0.1 (`COALESCE(spotify_popularity, 0) * 0.1`)
- Updated specs to reflect the new ordering behavior

Closes #1913

## Test plan
- [ ] CI passes with updated spec expectations
- [ ] Verify similar artists endpoint returns results ordered by similarity first

🤖 Generated with [Claude Code](https://claude.com/claude-code)