### PR TITLE
Add combined artist splitter service and rake task

### DIFF
--- a/app/services/combined_artist_splitter.rb
+++ b/app/services/combined_artist_splitter.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class CombinedArtistSplitter
+  attr_reader :combined_artist, :individual_artists
+
+  def initialize(combined_artist)
+    @combined_artist = combined_artist
+    @individual_artists = []
+  end
+
+  def split
+    artist_names = extract_artist_names
+    raise ArgumentError, "Could not split '#{combined_artist.name}' into multiple artists" if artist_names.size < 2
+
+    @individual_artists = find_or_create_artists(artist_names)
+
+    ActiveRecord::Base.transaction do
+      reassign_songs
+      reassign_chart_positions
+      combined_artist.reload.destroy!
+    end
+
+    @individual_artists
+  end
+
+  private
+
+  def extract_artist_names
+    regex = Regexp.new(Song::MULTIPLE_ARTIST_REGEX, Regexp::IGNORECASE)
+    combined_artist.name.split(regex).map(&:strip).reject(&:blank?)
+  end
+
+  def find_or_create_artists(names)
+    names.map do |name|
+      Artist.find_or_create_by!(name:)
+    end
+  end
+
+  def reassign_songs
+    song_ids = combined_artist.artists_songs.pluck(:song_id)
+    valid_song_ids = Song.where(id: song_ids).pluck(:id)
+
+    ArtistsSong.where(artist_id: combined_artist.id).delete_all
+
+    individual_artists.each do |artist|
+      existing_song_ids = ArtistsSong.where(artist_id: artist.id, song_id: valid_song_ids).pluck(:song_id)
+      (valid_song_ids - existing_song_ids).each do |song_id|
+        ArtistsSong.create!(artist_id: artist.id, song_id:)
+      end
+    end
+  end
+
+  def reassign_chart_positions
+    combined_artist.chart_positions.each do |cp|
+      individual_artists.each do |artist|
+        existing = ChartPosition.find_by(positianable: artist, chart_id: cp.chart_id)
+        next if existing
+
+        cp.update!(positianable: artist)
+        break
+      end
+    end
+
+    # Delete any remaining chart positions still on the combined artist
+    combined_artist.chart_positions.reload.destroy_all
+  end
+end

--- a/lib/tasks/data_repair.rake
+++ b/lib/tasks/data_repair.rake
@@ -1131,6 +1131,48 @@ namespace :data_repair do
     d[m][n]
   end
 
+  desc 'Split a combined artist into individual artists. Usage: rake data_repair:split_combined_artist[1037]'
+  task :split_combined_artist, [:artist_id] => :environment do |_t, args|
+    abort 'Please provide an artist ID' if args[:artist_id].blank?
+
+    artist = Artist.find(args[:artist_id])
+    puts "Splitting combined artist: '#{artist.name}' (ID: #{artist.id})"
+    puts "  Songs: #{artist.songs.count}"
+    puts "  Chart positions: #{artist.chart_positions.count}"
+
+    splitter = CombinedArtistSplitter.new(artist)
+    individual_artists = splitter.split
+
+    puts "\nSplit into #{individual_artists.size} artists:"
+    individual_artists.each do |a|
+      puts "  - '#{a.name}' (ID: #{a.id}, songs: #{a.songs.count})"
+    end
+    puts "\nDone! Combined artist '#{artist.name}' has been removed."
+  end
+
+  desc 'Dry run: Show what a combined artist split would do. Usage: rake data_repair:split_combined_artist_dry_run[1037]'
+  task :split_combined_artist_dry_run, [:artist_id] => :environment do |_t, args|
+    abort 'Please provide an artist ID' if args[:artist_id].blank?
+
+    artist = Artist.find(args[:artist_id])
+    regex = Regexp.new(Song::MULTIPLE_ARTIST_REGEX, Regexp::IGNORECASE)
+    names = artist.name.split(regex).map(&:strip).reject(&:blank?)
+
+    puts "Combined artist: '#{artist.name}' (ID: #{artist.id})"
+    puts "  Songs: #{artist.songs.count}"
+    puts "  Chart positions: #{artist.chart_positions.count}"
+    puts "\nWould split into:"
+    names.each do |name|
+      existing = Artist.find_by(name:)
+      if existing
+        puts "  - '#{name}' (existing, ID: #{existing.id}, songs: #{existing.songs.count})"
+      else
+        puts "  - '#{name}' (new artist, will be created)"
+      end
+    end
+    puts "\nRun 'rake data_repair:split_combined_artist[#{artist.id}]' to perform the split."
+  end
+
   def print_mismatch_report(mismatches)
     if mismatches.empty?
       puts 'No mismatches found. All verified songs match Spotify data.'

--- a/spec/services/combined_artist_splitter_spec.rb
+++ b/spec/services/combined_artist_splitter_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CombinedArtistSplitter do
+  describe '#split' do
+    let(:combined_artist) { create(:artist, name: 'David Guetta FT Sia') }
+    let(:song) { create(:song) }
+
+    before do
+      ArtistsSong.create!(artist: combined_artist, song:)
+    end
+
+    context 'when individual artists do not exist yet' do
+      it 'creates individual artists and reassigns songs', :aggregate_failures do
+        result = described_class.new(combined_artist).split
+
+        expect(result.map(&:name)).to contain_exactly('David Guetta', 'Sia')
+        expect(Artist.find_by(name: 'David Guetta').songs).to include(song)
+        expect(Artist.find_by(name: 'Sia').songs).to include(song)
+        expect(Artist.find_by(id: combined_artist.id)).to be_nil
+      end
+    end
+
+    context 'when individual artists already exist' do
+      let!(:david_guetta) { create(:artist, name: 'David Guetta') }
+      let!(:sia) { create(:artist, name: 'Sia') }
+
+      it 'reuses existing artists', :aggregate_failures do
+        result = described_class.new(combined_artist).split
+
+        expect(result).to contain_exactly(david_guetta, sia)
+        expect(david_guetta.songs.reload).to include(song)
+        expect(sia.songs.reload).to include(song)
+      end
+    end
+
+    context 'when an individual artist already has the song' do
+      let!(:david_guetta) { create(:artist, name: 'David Guetta') }
+
+      before do
+        ArtistsSong.create!(artist: david_guetta, song:)
+      end
+
+      it 'does not create duplicate join records', :aggregate_failures do
+        described_class.new(combined_artist).split
+
+        expect(ArtistsSong.where(artist_id: david_guetta.id, song_id: song.id).count).to eq(1)
+      end
+    end
+
+    context 'when combined artist has chart positions' do
+      let(:chart) { create(:chart) }
+      let!(:chart_position) { create(:chart_position, positianable: combined_artist, chart:) }
+
+      it 'reassigns chart positions to individual artists', :aggregate_failures do
+        described_class.new(combined_artist).split
+
+        expect(ChartPosition.find_by(id: chart_position.id).positianable.name).to eq('David Guetta').or eq('Sia')
+      end
+    end
+
+    context 'when artist name cannot be split' do
+      let(:single_artist) { create(:artist, name: 'Madonna') }
+
+      it 'raises an error' do
+        expect { described_class.new(single_artist).split }.to raise_error(ArgumentError, /Could not split/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Add `CombinedArtistSplitter` service to split combined artists (e.g. "David Guetta FT Sia") into individual artist records
- Reassigns songs and chart positions to the individual artists, then removes the combined artist
- Add `rake data_repair:split_combined_artist[ID]` and dry run variant
- Includes RSpec tests for the service

## Usage
```bash
rake data_repair:split_combined_artist_dry_run[1037]  # preview
rake data_repair:split_combined_artist[1037]           # execute
```

## Test plan
- [ ] CI passes (rspec + rubocop)
- [ ] Run dry run against production to verify artist 1037 splits correctly
- [ ] Execute split and verify "David Guetta" and "Sia" have the correct songs

🤖 Generated with [Claude Code](https://claude.com/claude-code)