### PR TITLE
Remove ActiveStorage dependency from audio_file_path

### DIFF
--- a/app/models/radio_station.rb
+++ b/app/models/radio_station.rb
@@ -124,8 +124,7 @@ class RadioStation < ActiveRecord::Base
   end
 
   def audio_file_path
-    sanitize_file_name = ActiveStorage::Filename.new("#{audio_file_name}.mp3").sanitized
-    Rails.root.join("tmp/audio/#{sanitize_file_name}")
+    Rails.root.join("tmp/audio/#{audio_file_name}.mp3")
   end
 
   def logo_path

--- a/spec/models/radio_station_spec.rb
+++ b/spec/models/radio_station_spec.rb
@@ -356,6 +356,46 @@ describe RadioStation, :use_vcr, :with_valid_token do
     end
   end
 
+  describe '#audio_file_name' do
+    it 'returns downcased name with non-word characters removed' do
+      radio_station = build(:radio_station, name: 'Radio 538')
+
+      expect(radio_station.audio_file_name).to eq('radio538')
+    end
+
+    context 'when name contains special characters' do
+      it 'strips all non-word characters' do
+        radio_station = build(:radio_station, name: 'Q-Music!')
+
+        expect(radio_station.audio_file_name).to eq('qmusic')
+      end
+    end
+
+    context 'when name is nil' do
+      it 'returns nil' do
+        radio_station = build(:radio_station, name: nil)
+
+        expect(radio_station.audio_file_name).to be_nil
+      end
+    end
+  end
+
+  describe '#audio_file_path' do
+    it 'returns a path under tmp/audio with the sanitized name' do
+      radio_station = build(:radio_station, name: 'Radio 538')
+
+      expect(radio_station.audio_file_path).to eq(Rails.root.join('tmp/audio/radio538.mp3'))
+    end
+
+    context 'when name contains special characters' do
+      it 'returns a clean file path' do
+        radio_station = build(:radio_station, name: 'Q-Music!')
+
+        expect(radio_station.audio_file_path).to eq(Rails.root.join('tmp/audio/qmusic.mp3'))
+      end
+    end
+  end
+
   describe '#npo_api_processor' do
     let(:radio_1) { described_class.find_by(name: 'Radio 1') || create(:radio_1) }
 


### PR DESCRIPTION
## Summary
- Removes `ActiveStorage::Filename` usage in `RadioStation#audio_file_path` which causes `NameError` in API-only mode
- The sanitization was redundant since `audio_file_name` already strips all non-word characters via `gsub(/\W/, '')`
- Adds tests for `#audio_file_name` and `#audio_file_path`

## Test plan
- [x] CI passes: new tests for `audio_file_name` and `audio_file_path` cover normal names, special characters, and nil
- [x] Verify song recognition works in production console without `ActiveStorage` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)