### PR TITLE
Fix audio_file_path to use persistent directory

### DIFF
--- a/app/models/radio_station.rb
+++ b/app/models/radio_station.rb
@@ -124,7 +124,7 @@ class RadioStation < ActiveRecord::Base
   end
 
   def audio_file_path
-    Rails.root.join("tmp/audio/#{audio_file_name}.mp3")
+    Rails.root.join("tmp/audio/persistent/#{audio_file_name}.mp3")
   end
 
   def logo_path

--- a/spec/models/radio_station_spec.rb
+++ b/spec/models/radio_station_spec.rb
@@ -384,14 +384,14 @@ describe RadioStation, :use_vcr, :with_valid_token do
     it 'returns a path under tmp/audio with the sanitized name' do
       radio_station = build(:radio_station, name: 'Radio 538')
 
-      expect(radio_station.audio_file_path).to eq(Rails.root.join('tmp/audio/radio538.mp3'))
+      expect(radio_station.audio_file_path).to eq(Rails.root.join('tmp/audio/persistent/radio538.mp3'))
     end
 
     context 'when name contains special characters' do
       it 'returns a clean file path' do
         radio_station = build(:radio_station, name: 'Q-Music!')
 
-        expect(radio_station.audio_file_path).to eq(Rails.root.join('tmp/audio/qmusic.mp3'))
+        expect(radio_station.audio_file_path).to eq(Rails.root.join('tmp/audio/persistent/qmusic.mp3'))
       end
     end
   end


### PR DESCRIPTION
## Summary
- Fixed `RadioStation#audio_file_path` to point to `tmp/audio/persistent/` instead of `tmp/audio/`, matching the persistent stream segment directory used by `PersistentStream::Process`

## Test plan
- [x] Updated `radio_station_spec.rb` expectations to match new path
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)