### PR TITLE
Update Yoursafe Radio stream URL to new HLS endpoint

### DIFF
--- a/db/fixtures/001_radio_stations.rb
+++ b/db/fixtures/001_radio_stations.rb
@@ -127,7 +127,7 @@ RadioStation.seed(
     name: 'Yoursafe Radio',
     url: '',
     processor: '',
-    direct_stream_url: 'https://stream.yoursaferadio.nl/audio',
+    direct_stream_url: 'https://4e2623dcced8.eu-central-1.playback.live-video.net/api/video/v1/eu-central-1.384301552878.channel.qoqD1R97L2kw.m3u8',
     slug: 'yoursafe-radio',
     country_code: 'NLD'
   },


### PR DESCRIPTION
## Summary
- Yoursafe Radio's old stream URL (`stream.yoursaferadio.nl/audio`) returns 404, causing song recognition to fail
- Updated `direct_stream_url` to their new Amazon IVS HLS stream endpoint

## Test plan
- [ ] Verify PersistentStream connects to the new m3u8 stream and produces segments
- [ ] Verify SongRecognizer can identify songs from the new stream
- [ ] Update production database with the new URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)