### PR TITLE
Add day_chart type to bar chart race endpoint

### DIFF
--- a/app/controllers/api/v1/radio_stations_controller.rb
+++ b/app/controllers/api/v1/radio_stations_controller.rb
@@ -72,7 +72,7 @@ module Api
       def bar_chart_race
         return render json: { error: 'Period or start_time parameter is required' }, status: :bad_request if time_param_blank?
 
-        race = BarChartRace.new(radio_station: @radio_station, params: params)
+        race = BarChartRace.for(type: params[:type], radio_station: @radio_station, params: params)
 
         render json: { data: race.frames, meta: race.meta }.to_json
       end

--- a/app/services/bar_chart_race.rb
+++ b/app/services/bar_chart_race.rb
@@ -1,85 +1,14 @@
 # frozen_string_literal: true
 
-class BarChartRace
+module BarChartRace
   TOP_N = 10
 
-  include DateConcern
-
-  def initialize(radio_station:, params:)
-    @radio_station = radio_station
-    @params = params
-    @start_time, @end_time = self.class.time_range_from_params(params, default_period: 'week')
-  end
-
-  def frames
-    daily_counts = fetch_daily_counts
-    songs_by_id = fetch_songs(daily_counts)
-    build_frames(daily_counts, songs_by_id)
-  end
-
-  def meta
-    {
-      period: @params[:period],
-      start_time: @start_time.iso8601,
-      end_time: @end_time.iso8601
-    }
-  end
-
-  private
-
-  def fetch_daily_counts
-    counts = AirPlay.confirmed
-               .where(radio_station: @radio_station)
-               .where(broadcasted_at: @start_time..@end_time)
-               .group(:song_id, Arel.sql('DATE(broadcasted_at)'))
-               .count
-
-    counts.each_with_object({}) do |((song_id, date), count), hash|
-      hash[date.to_s] ||= {}
-      hash[date.to_s][song_id] = count
+  def self.for(type:, radio_station:, params:)
+    case type.to_s
+    when 'day_chart'
+      DayChart.new(radio_station:, params:)
+    else
+      CumulativeFrames.new(radio_station:, params:)
     end
-  end
-
-  def fetch_songs(daily_counts)
-    song_ids = daily_counts.values.flat_map(&:keys).uniq
-    Song.where(id: song_ids).preload(:artists).index_by(&:id)
-  end
-
-  def build_frames(daily_counts, songs_by_id)
-    dates = (@start_time.to_date..@end_time.to_date).map(&:to_s)
-    cumulative = Hash.new(0)
-
-    dates.filter_map do |date|
-      day_counts = daily_counts[date]
-      next if day_counts.blank? && cumulative.empty?
-
-      day_counts&.each { |song_id, count| cumulative[song_id] += count }
-
-      build_frame(date, cumulative, songs_by_id)
-    end
-  end
-
-  def build_frame(date, cumulative, songs_by_id)
-    top_songs = cumulative.sort_by { |_, count| -count }.first(TOP_N)
-    return if top_songs.empty?
-
-    {
-      date: date,
-      entries: top_songs.filter_map.with_index do |(song_id, count), index|
-        song = songs_by_id[song_id]
-        next unless song
-
-        { position: index + 1, count: count, song: serialize_song(song) }
-      end
-    }
-  end
-
-  def serialize_song(song)
-    {
-      id: song.id,
-      title: song.title,
-      spotify_artwork_url: song.spotify_artwork_url,
-      artists: song.artists.map { |a| { id: a.id, name: a.name } }
-    }
   end
 end

--- a/app/services/bar_chart_race/cumulative_frames.rb
+++ b/app/services/bar_chart_race/cumulative_frames.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+module BarChartRace
+  class CumulativeFrames
+    include DateConcern
+
+    def initialize(radio_station:, params:)
+      @radio_station = radio_station
+      @params = params
+      @start_time, @end_time = self.class.time_range_from_params(params, default_period: 'week')
+    end
+
+    def frames
+      daily_counts = fetch_daily_counts
+      songs_by_id = fetch_songs(daily_counts)
+      build_frames(daily_counts, songs_by_id)
+    end
+
+    def meta
+      {
+        type: 'cumulative_frames',
+        period: @params[:period],
+        start_time: @start_time.iso8601,
+        end_time: @end_time.iso8601
+      }
+    end
+
+    private
+
+    def fetch_daily_counts
+      counts = AirPlay.confirmed
+                 .where(radio_station: @radio_station)
+                 .where(broadcasted_at: @start_time..@end_time)
+                 .group(:song_id, Arel.sql('DATE(broadcasted_at)'))
+                 .count
+
+      counts.each_with_object({}) do |((song_id, date), count), hash|
+        hash[date.to_s] ||= {}
+        hash[date.to_s][song_id] = count
+      end
+    end
+
+    def fetch_songs(daily_counts)
+      song_ids = daily_counts.values.flat_map(&:keys).uniq
+      Song.where(id: song_ids).preload(:artists).index_by(&:id)
+    end
+
+    def build_frames(daily_counts, songs_by_id)
+      dates = (@start_time.to_date..@end_time.to_date).map(&:to_s)
+      cumulative = Hash.new(0)
+
+      dates.filter_map do |date|
+        day_counts = daily_counts[date]
+        next if day_counts.blank? && cumulative.empty?
+
+        day_counts&.each { |song_id, count| cumulative[song_id] += count }
+
+        build_frame(date, cumulative, songs_by_id)
+      end
+    end
+
+    def build_frame(date, cumulative, songs_by_id)
+      top_songs = cumulative.sort_by { |_, count| -count }.first(TOP_N)
+      return if top_songs.empty?
+
+      {
+        date: date,
+        entries: top_songs.filter_map.with_index do |(song_id, count), index|
+          song = songs_by_id[song_id]
+          next unless song
+
+          { position: index + 1, count: count, song: serialize_song(song) }
+        end
+      }
+    end
+
+    def serialize_song(song)
+      {
+        id: song.id,
+        title: song.title,
+        spotify_artwork_url: song.spotify_artwork_url,
+        artists: song.artists.map { |a| { id: a.id, name: a.name } }
+      }
+    end
+  end
+end

--- a/app/services/bar_chart_race/day_chart.rb
+++ b/app/services/bar_chart_race/day_chart.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module BarChartRace
+  class DayChart
+    include DateConcern
+
+    def initialize(radio_station:, params:)
+      @radio_station = radio_station
+      @params = params
+      @start_time, @end_time = self.class.time_range_from_params(params, default_period: 'day')
+    end
+
+    def frames
+      song_counts = fetch_song_counts
+      return [] if song_counts.empty?
+
+      songs_by_id = fetch_songs(song_counts)
+      top_songs = song_counts.sort_by { |_, count| -count }.first(TOP_N)
+
+      [build_frame(top_songs, songs_by_id)]
+    end
+
+    def meta
+      {
+        type: 'day_chart',
+        period: @params[:period],
+        start_time: @start_time.iso8601,
+        end_time: @end_time.iso8601
+      }
+    end
+
+    private
+
+    def fetch_song_counts
+      AirPlay.confirmed
+        .where(radio_station: @radio_station)
+        .where(broadcasted_at: @start_time..@end_time)
+        .group(:song_id)
+        .count
+    end
+
+    def fetch_songs(song_counts)
+      Song.where(id: song_counts.keys).preload(:artists).index_by(&:id)
+    end
+
+    def build_frame(top_songs, songs_by_id)
+      {
+        date: @end_time.to_date.to_s,
+        entries: top_songs.filter_map.with_index do |(song_id, count), index|
+          song = songs_by_id[song_id]
+          next unless song
+
+          { position: index + 1, count: count, song: serialize_song(song) }
+        end
+      }
+    end
+
+    def serialize_song(song)
+      {
+        id: song.id,
+        title: song.title,
+        spotify_artwork_url: song.spotify_artwork_url,
+        artists: song.artists.map { |a| { id: a.id, name: a.name } }
+      }
+    end
+  end
+end

--- a/spec/services/bar_chart_race/cumulative_frames_spec.rb
+++ b/spec/services/bar_chart_race/cumulative_frames_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BarChartRace::CumulativeFrames do
+  let(:radio_station) { create(:radio_station) }
+  let(:song_a) { create(:song, title: 'Song A') }
+  let(:song_b) { create(:song, title: 'Song B') }
+  let(:song_c) { create(:song, title: 'Song C') }
+
+  describe '#frames' do
+    context 'with period parameter' do
+      let(:params) { { period: 'week' } }
+      let(:race) { described_class.new(radio_station:, params:) }
+
+      before do
+        5.times { |i| create(:air_play, song: song_a, radio_station:, broadcasted_at: 2.days.ago.midday + i.minutes) }
+        4.times { |i| create(:air_play, song: song_b, radio_station:, broadcasted_at: 2.days.ago.midday + i.minutes) }
+        3.times { |i| create(:air_play, song: song_b, radio_station:, broadcasted_at: 1.day.ago.midday + i.minutes) }
+      end
+
+      it 'returns frames as a non-empty array' do
+        expect(race.frames).not_to be_empty
+      end
+
+      it 'ranks songs by cumulative count', :aggregate_failures do
+        frames = race.frames
+        last_frame = frames.last
+
+        first_entry = last_frame[:entries].first
+        expect(first_entry[:song][:title]).to eq('Song B')
+        expect(first_entry[:count]).to eq(7)
+        expect(first_entry[:position]).to eq(1)
+      end
+
+      it 'includes song details in entries', :aggregate_failures do
+        frames = race.frames
+        entry = frames.first[:entries].first
+
+        expect(entry[:song]).to include(:id, :title, :spotify_artwork_url, :artists)
+      end
+
+      it 'includes date in each frame' do
+        frames = race.frames
+
+        expect(frames.first[:date]).to match(/\A\d{4}-\d{2}-\d{2}\z/)
+      end
+    end
+
+    context 'with cumulative counting across days' do
+      let(:params) { { period: 'week' } }
+      let(:race) { described_class.new(radio_station:, params:) }
+
+      before do
+        3.times { |i| create(:air_play, song: song_a, radio_station:, broadcasted_at: 3.days.ago.midday + i.minutes) }
+        2.times { |i| create(:air_play, song: song_a, radio_station:, broadcasted_at: 2.days.ago.midday + i.minutes) }
+      end
+
+      it 'accumulates counts across days' do
+        frames = race.frames
+        last_frame = frames.last
+
+        expect(last_frame[:entries].first[:count]).to eq(5)
+      end
+    end
+
+    context 'with more than 10 songs' do
+      let(:params) { { period: 'week' } }
+      let(:race) { described_class.new(radio_station:, params:) }
+
+      before do
+        12.times do |i|
+          song = create(:song, title: "Song #{i}")
+          create(:air_play, song:, radio_station:, broadcasted_at: 1.day.ago.midday + i.minutes)
+        end
+      end
+
+      it 'limits to top 10 per frame' do
+        frames = race.frames
+
+        expect(frames.last[:entries].size).to eq(10)
+      end
+    end
+
+    context 'with no air plays' do
+      let(:params) { { period: 'week' } }
+      let(:race) { described_class.new(radio_station:, params:) }
+
+      it 'returns empty array' do
+        expect(race.frames).to be_empty
+      end
+    end
+
+    context 'with custom date range' do
+      let(:params) { { start_time: 4.days.ago.strftime('%Y-%m-%dT%H:%M'), end_time: 1.day.ago.strftime('%Y-%m-%dT%H:%M') } }
+      let(:race) { described_class.new(radio_station:, params:) }
+
+      before do
+        3.times { |i| create(:air_play, song: song_a, radio_station:, broadcasted_at: 2.days.ago.midday + i.minutes) }
+        2.times { |i| create(:air_play, song: song_a, radio_station:, broadcasted_at: 10.days.ago.midday + i.minutes) }
+      end
+
+      it 'only includes plays within the date range' do
+        frames = race.frames
+        total_count = frames.last[:entries].first[:count]
+
+        expect(total_count).to eq(3)
+      end
+    end
+  end
+
+  describe '#meta' do
+    let(:params) { { period: 'week' } }
+    let(:race) { described_class.new(radio_station:, params:) }
+
+    it 'returns period and time range', :aggregate_failures do
+      meta = race.meta
+
+      expect(meta[:type]).to eq('cumulative_frames')
+      expect(meta[:period]).to eq('week')
+      expect(meta[:start_time]).to be_present
+      expect(meta[:end_time]).to be_present
+    end
+
+    it 'returns ISO8601 formatted times', :aggregate_failures do
+      meta = race.meta
+
+      expect { Time.iso8601(meta[:start_time]) }.not_to raise_error
+      expect { Time.iso8601(meta[:end_time]) }.not_to raise_error
+    end
+  end
+end

--- a/spec/services/bar_chart_race/day_chart_spec.rb
+++ b/spec/services/bar_chart_race/day_chart_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe BarChartRace::DayChart do
+  let(:radio_station) { create(:radio_station) }
+  let(:song_a) { create(:song, title: 'Song A') }
+  let(:song_b) { create(:song, title: 'Song B') }
+  let(:song_c) { create(:song, title: 'Song C') }
+
+  describe '#frames' do
+    context 'with period parameter' do
+      let(:params) { { period: 'day' } }
+      let(:chart) { described_class.new(radio_station:, params:) }
+
+      before do
+        5.times { |i| create(:air_play, song: song_a, radio_station:, broadcasted_at: 2.hours.ago + i.minutes) }
+        3.times { |i| create(:air_play, song: song_b, radio_station:, broadcasted_at: 2.hours.ago + i.minutes) }
+        create(:air_play, song: song_c, radio_station:, broadcasted_at: 2.hours.ago)
+      end
+
+      it 'returns a single frame' do
+        expect(chart.frames.size).to eq(1)
+      end
+
+      it 'ranks songs by play count', :aggregate_failures do
+        frame = chart.frames.first
+        entries = frame[:entries]
+
+        expect(entries.first[:song][:title]).to eq('Song A')
+        expect(entries.first[:count]).to eq(5)
+        expect(entries.first[:position]).to eq(1)
+        expect(entries.second[:song][:title]).to eq('Song B')
+        expect(entries.second[:count]).to eq(3)
+        expect(entries.second[:position]).to eq(2)
+      end
+
+      it 'includes song details in entries', :aggregate_failures do
+        entry = chart.frames.first[:entries].first
+
+        expect(entry[:song]).to include(:id, :title, :spotify_artwork_url, :artists)
+      end
+
+      it 'includes date in the frame' do
+        expect(chart.frames.first[:date]).to match(/\A\d{4}-\d{2}-\d{2}\z/)
+      end
+    end
+
+    context 'with week period' do
+      let(:params) { { period: 'week' } }
+      let(:chart) { described_class.new(radio_station:, params:) }
+
+      before do
+        3.times { |i| create(:air_play, song: song_a, radio_station:, broadcasted_at: 3.days.ago.midday + i.minutes) }
+        2.times { |i| create(:air_play, song: song_a, radio_station:, broadcasted_at: 1.day.ago.midday + i.minutes) }
+      end
+
+      it 'sums all plays within the period into a single frame' do
+        frame = chart.frames.first
+
+        expect(frame[:entries].first[:count]).to eq(5)
+      end
+    end
+
+    context 'with more than 10 songs' do
+      let(:params) { { period: 'day' } }
+      let(:chart) { described_class.new(radio_station:, params:) }
+
+      before do
+        12.times do |i|
+          song = create(:song, title: "Song #{i}")
+          create(:air_play, song:, radio_station:, broadcasted_at: 2.hours.ago + i.minutes)
+        end
+      end
+
+      it 'limits to top 10' do
+        expect(chart.frames.first[:entries].size).to eq(10)
+      end
+    end
+
+    context 'with no air plays' do
+      let(:params) { { period: 'day' } }
+      let(:chart) { described_class.new(radio_station:, params:) }
+
+      it 'returns empty array' do
+        expect(chart.frames).to be_empty
+      end
+    end
+
+    context 'with custom date range' do
+      let(:params) { { start_time: 4.days.ago.strftime('%Y-%m-%dT%H:%M'), end_time: 1.day.ago.strftime('%Y-%m-%dT%H:%M') } }
+      let(:chart) { described_class.new(radio_station:, params:) }
+
+      before do
+        3.times { |i| create(:air_play, song: song_a, radio_station:, broadcasted_at: 2.days.ago.midday + i.minutes) }
+        2.times { |i| create(:air_play, song: song_a, radio_station:, broadcasted_at: 10.days.ago.midday + i.minutes) }
+      end
+
+      it 'only includes plays within the date range' do
+        frame = chart.frames.first
+
+        expect(frame[:entries].first[:count]).to eq(3)
+      end
+    end
+  end
+
+  describe '#meta' do
+    let(:params) { { period: 'day' } }
+    let(:chart) { described_class.new(radio_station:, params:) }
+
+    it 'returns type, period, and time range', :aggregate_failures do
+      meta = chart.meta
+
+      expect(meta[:type]).to eq('day_chart')
+      expect(meta[:period]).to eq('day')
+      expect(meta[:start_time]).to be_present
+      expect(meta[:end_time]).to be_present
+    end
+
+    it 'returns ISO8601 formatted times', :aggregate_failures do
+      meta = chart.meta
+
+      expect { Time.iso8601(meta[:start_time]) }.not_to raise_error
+      expect { Time.iso8601(meta[:end_time]) }.not_to raise_error
+    end
+  end
+end

--- a/spec/services/bar_chart_race_spec.rb
+++ b/spec/services/bar_chart_race_spec.rb
@@ -3,129 +3,20 @@
 require 'rails_helper'
 
 RSpec.describe BarChartRace do
-  let(:radio_station) { create(:radio_station) }
-  let(:song_a) { create(:song, title: 'Song A') }
-  let(:song_b) { create(:song, title: 'Song B') }
-  let(:song_c) { create(:song, title: 'Song C') }
-
-  describe '#frames' do
-    context 'with period parameter' do
-      let(:params) { { period: 'week' } }
-      let(:race) { described_class.new(radio_station:, params:) }
-
-      before do
-        5.times { |i| create(:air_play, song: song_a, radio_station:, broadcasted_at: 2.days.ago.midday + i.minutes) }
-        4.times { |i| create(:air_play, song: song_b, radio_station:, broadcasted_at: 2.days.ago.midday + i.minutes) }
-        3.times { |i| create(:air_play, song: song_b, radio_station:, broadcasted_at: 1.day.ago.midday + i.minutes) }
-      end
-
-      it 'returns frames as a non-empty array' do
-        expect(race.frames).not_to be_empty
-      end
-
-      it 'ranks songs by cumulative count', :aggregate_failures do
-        frames = race.frames
-        last_frame = frames.last
-
-        first_entry = last_frame[:entries].first
-        expect(first_entry[:song][:title]).to eq('Song B')
-        expect(first_entry[:count]).to eq(7)
-        expect(first_entry[:position]).to eq(1)
-      end
-
-      it 'includes song details in entries', :aggregate_failures do
-        frames = race.frames
-        entry = frames.first[:entries].first
-
-        expect(entry[:song]).to include(:id, :title, :spotify_artwork_url, :artists)
-      end
-
-      it 'includes date in each frame' do
-        frames = race.frames
-
-        expect(frames.first[:date]).to match(/\A\d{4}-\d{2}-\d{2}\z/)
-      end
-    end
-
-    context 'with cumulative counting across days' do
-      let(:params) { { period: 'week' } }
-      let(:race) { described_class.new(radio_station:, params:) }
-
-      before do
-        3.times { |i| create(:air_play, song: song_a, radio_station:, broadcasted_at: 3.days.ago.midday + i.minutes) }
-        2.times { |i| create(:air_play, song: song_a, radio_station:, broadcasted_at: 2.days.ago.midday + i.minutes) }
-      end
-
-      it 'accumulates counts across days' do
-        frames = race.frames
-        last_frame = frames.last
-
-        expect(last_frame[:entries].first[:count]).to eq(5)
-      end
-    end
-
-    context 'with more than 10 songs' do
-      let(:params) { { period: 'week' } }
-      let(:race) { described_class.new(radio_station:, params:) }
-
-      before do
-        12.times do |i|
-          song = create(:song, title: "Song #{i}")
-          create(:air_play, song:, radio_station:, broadcasted_at: 1.day.ago.midday + i.minutes)
-        end
-      end
-
-      it 'limits to top 10 per frame' do
-        frames = race.frames
-
-        expect(frames.last[:entries].size).to eq(10)
-      end
-    end
-
-    context 'with no air plays' do
-      let(:params) { { period: 'week' } }
-      let(:race) { described_class.new(radio_station:, params:) }
-
-      it 'returns empty array' do
-        expect(race.frames).to be_empty
-      end
-    end
-
-    context 'with custom date range' do
-      let(:params) { { start_time: 4.days.ago.strftime('%Y-%m-%dT%H:%M'), end_time: 1.day.ago.strftime('%Y-%m-%dT%H:%M') } }
-      let(:race) { described_class.new(radio_station:, params:) }
-
-      before do
-        3.times { |i| create(:air_play, song: song_a, radio_station:, broadcasted_at: 2.days.ago.midday + i.minutes) }
-        2.times { |i| create(:air_play, song: song_a, radio_station:, broadcasted_at: 10.days.ago.midday + i.minutes) }
-      end
-
-      it 'only includes plays within the date range' do
-        frames = race.frames
-        total_count = frames.last[:entries].first[:count]
-
-        expect(total_count).to eq(3)
-      end
-    end
-  end
-
-  describe '#meta' do
+  describe '.for' do
+    let(:radio_station) { create(:radio_station) }
     let(:params) { { period: 'week' } }
-    let(:race) { described_class.new(radio_station:, params:) }
 
-    it 'returns period and time range', :aggregate_failures do
-      meta = race.meta
-
-      expect(meta[:period]).to eq('week')
-      expect(meta[:start_time]).to be_present
-      expect(meta[:end_time]).to be_present
+    it 'returns CumulativeFrames by default' do
+      expect(described_class.for(type: nil, radio_station:, params:)).to be_a(BarChartRace::CumulativeFrames)
     end
 
-    it 'returns ISO8601 formatted times', :aggregate_failures do
-      meta = race.meta
+    it 'returns CumulativeFrames for cumulative_frames type' do
+      expect(described_class.for(type: 'cumulative_frames', radio_station:, params:)).to be_a(BarChartRace::CumulativeFrames)
+    end
 
-      expect { Time.iso8601(meta[:start_time]) }.not_to raise_error
-      expect { Time.iso8601(meta[:end_time]) }.not_to raise_error
+    it 'returns DayChart for day_chart type' do
+      expect(described_class.for(type: 'day_chart', radio_station:, params:)).to be_a(BarChartRace::DayChart)
     end
   end
 end


### PR DESCRIPTION
## Summary

- Restructure `BarChartRace` from a single class into a module with two classes:
  - `CumulativeFrames` — existing animated cumulative bar chart race
  - `DayChart` — new single-frame snapshot of top 10 songs for the given period
- Add `BarChartRace.for` factory method that dispatches on the `type` query parameter
- Backwards compatible: no `type` param defaults to existing cumulative frames behavior

## Usage

```
GET /api/v1/radio_stations/:id/bar_chart_race?period=day&type=day_chart
GET /api/v1/radio_stations/:id/bar_chart_race?period=week  # default cumulative frames
```

## Related

- Frontend issue: samuelvaneck/playlists-interface#341

## Test plan

- [x] All existing bar chart race specs pass (moved to `CumulativeFrames`)
- [x] New `DayChart` specs cover ranking, top 10 limit, empty state, custom date range
- [x] Factory `.for` specs cover all type dispatching
- [x] Request specs pass
- [x] Rubocop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)