### PR TITLE
Unpin connection_pool and upgrade to 3.0.2 with sidekiq 8.1.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'pg_search'
 gem 'puma', '~> 7.0'
 gem 'rack-cors', '~> 3.0', '>= 2.0.2'
 gem 'rails', '~> 8.0', '>= 8.0.1'
-gem 'connection_pool', '~> 2.5' # Pinned until Rails 8.1 is compatible with connection_pool 3.0
+gem 'connection_pool'
 gem 'redis'
 gem 'sentry-ruby'
 gem 'sentry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
     circuitbox (2.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.6)
-    connection_pool (2.5.5)
+    connection_pool (3.0.2)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -383,7 +383,7 @@ GEM
       tsort
     redis (5.4.1)
       redis-client (>= 0.22.0)
-    redis-client (0.26.3)
+    redis-client (0.28.0)
       connection_pool
     regexp_parser (2.11.3)
     reline (0.6.3)
@@ -478,12 +478,12 @@ GEM
     shellany (0.0.1)
     shoulda-matchers (7.0.1)
       activesupport (>= 7.1)
-    sidekiq (8.0.10)
-      connection_pool (>= 2.5.0)
-      json (>= 2.9.0)
-      logger (>= 1.6.2)
-      rack (>= 3.1.0)
-      redis-client (>= 0.23.2)
+    sidekiq (8.1.1)
+      connection_pool (>= 3.0.0)
+      json (>= 2.16.0)
+      logger (>= 1.7.0)
+      rack (>= 3.2.0)
+      redis-client (>= 0.26.0)
     sidekiq-scheduler (6.0.1)
       rufus-scheduler (~> 3.2)
       sidekiq (>= 7.3, < 9)
@@ -568,7 +568,7 @@ DEPENDENCIES
   charlock_holmes (~> 0.7.7)
   circuitbox (~> 2.0)
   concurrent-ruby
-  connection_pool (~> 2.5)
+  connection_pool
   csv (~> 3.3, >= 3.3.2)
   database_cleaner
   devise


### PR DESCRIPTION
## Summary

- Remove `connection_pool` `~> 2.5` pin — Rails 8.1.2 resolved the incompatibilities (rails/rails#56305, rails/rails#56291)
- Upgrade `sidekiq` to 8.1.1 which officially supports `connection_pool` 3.0
- `connection_pool`: 2.5.5 → 3.0.2
- `sidekiq`: 8.0.10 → 8.1.1
- `redis-client`: 0.26.3 → 0.28.0 (transitive)

## Test plan

- [x] Full test suite passes locally (1279 examples, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)