### PR TITLE
Return one frame per day in bar chart race day_chart

### DIFF
--- a/app/services/bar_chart_race/day_chart.rb
+++ b/app/services/bar_chart_race/day_chart.rb
@@ -11,13 +11,11 @@ module BarChartRace
     end
 
     def frames
-      song_counts = fetch_song_counts
-      return [] if song_counts.empty?
+      daily_counts = fetch_daily_counts
+      return [] if daily_counts.empty?
 
-      songs_by_id = fetch_songs(song_counts)
-      top_songs = song_counts.sort_by { |_, count| -count }.first(TOP_N)
-
-      [build_frame(top_songs, songs_by_id)]
+      songs_by_id = fetch_songs(daily_counts)
+      build_frames(daily_counts, songs_by_id)
     end
 
     def meta
@@ -31,21 +29,39 @@ module BarChartRace
 
     private
 
-    def fetch_song_counts
-      AirPlay.confirmed
-        .where(radio_station: @radio_station)
-        .where(broadcasted_at: @start_time..@end_time)
-        .group(:song_id)
-        .count
+    def fetch_daily_counts
+      counts = AirPlay.confirmed
+                 .where(radio_station: @radio_station)
+                 .where(broadcasted_at: @start_time..@end_time)
+                 .group(:song_id, Arel.sql('DATE(broadcasted_at)'))
+                 .count
+
+      counts.each_with_object({}) do |((song_id, date), count), hash|
+        hash[date.to_s] ||= {}
+        hash[date.to_s][song_id] = count
+      end
     end
 
-    def fetch_songs(song_counts)
-      Song.where(id: song_counts.keys).preload(:artists).index_by(&:id)
+    def fetch_songs(daily_counts)
+      song_ids = daily_counts.values.flat_map(&:keys).uniq
+      Song.where(id: song_ids).preload(:artists).index_by(&:id)
     end
 
-    def build_frame(top_songs, songs_by_id)
+    def build_frames(daily_counts, songs_by_id)
+      dates = (@start_time.to_date..@end_time.to_date).map(&:to_s)
+
+      dates.filter_map do |date|
+        day_counts = daily_counts[date]
+        next if day_counts.blank?
+
+        top_songs = day_counts.sort_by { |_, count| -count }.first(TOP_N)
+        build_frame(date, top_songs, songs_by_id)
+      end
+    end
+
+    def build_frame(date, top_songs, songs_by_id)
       {
-        date: @end_time.to_date.to_s,
+        date: date,
         entries: top_songs.filter_map.with_index do |(song_id, count), index|
           song = songs_by_id[song_id]
           next unless song

--- a/db/migrate/20260321134953_add_composite_index_to_air_plays.rb
+++ b/db/migrate/20260321134953_add_composite_index_to_air_plays.rb
@@ -1,0 +1,9 @@
+class AddCompositeIndexToAirPlays < ActiveRecord::Migration[8.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :air_plays, [:radio_station_id, :status, :broadcasted_at],
+              name: 'index_air_plays_on_station_status_broadcasted',
+              algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_18_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_21_134953) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -77,6 +77,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_18_120000) do
     t.integer "status", default: 1, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["broadcasted_at"], name: "index_air_plays_on_broadcasted_at"
+    t.index ["radio_station_id", "status", "broadcasted_at"], name: "index_air_plays_on_station_status_broadcasted"
     t.index ["radio_station_id"], name: "index_air_plays_on_radio_station_id"
     t.index ["song_id", "radio_station_id", "broadcasted_at"], name: "air_play_radio_song_time", unique: true
     t.index ["song_id"], name: "index_air_plays_on_song_id"

--- a/spec/services/bar_chart_race/day_chart_spec.rb
+++ b/spec/services/bar_chart_race/day_chart_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe BarChartRace::DayChart do
         create(:air_play, song: song_c, radio_station:, broadcasted_at: 2.hours.ago)
       end
 
-      it 'returns a single frame' do
+      it 'returns a single frame for a single day' do
         expect(chart.frames.size).to eq(1)
       end
 
@@ -52,13 +52,17 @@ RSpec.describe BarChartRace::DayChart do
 
       before do
         3.times { |i| create(:air_play, song: song_a, radio_station:, broadcasted_at: 3.days.ago.midday + i.minutes) }
-        2.times { |i| create(:air_play, song: song_a, radio_station:, broadcasted_at: 1.day.ago.midday + i.minutes) }
+        2.times { |i| create(:air_play, song: song_b, radio_station:, broadcasted_at: 1.day.ago.midday + i.minutes) }
       end
 
-      it 'sums all plays within the period into a single frame' do
-        frame = chart.frames.first
+      it 'returns one frame per day with plays', :aggregate_failures do
+        frames = chart.frames
 
-        expect(frame[:entries].first[:count]).to eq(5)
+        expect(frames.size).to eq(2)
+        expect(frames.first[:entries].first[:song][:title]).to eq('Song A')
+        expect(frames.first[:entries].first[:count]).to eq(3)
+        expect(frames.last[:entries].first[:song][:title]).to eq('Song B')
+        expect(frames.last[:entries].first[:count]).to eq(2)
       end
     end
 
@@ -73,7 +77,7 @@ RSpec.describe BarChartRace::DayChart do
         end
       end
 
-      it 'limits to top 10' do
+      it 'limits to top 10 per frame' do
         expect(chart.frames.first[:entries].size).to eq(10)
       end
     end


### PR DESCRIPTION
## Summary
- DayChart now returns one frame per day within the requested period instead of a single aggregated frame (e.g. 7 frames for a week, ~30 for a month)
- Adds composite index on `(radio_station_id, status, broadcasted_at)` for faster grouped queries
- Updates specs to cover multi-day frame output

## Test plan
- [x] All existing day_chart specs pass
- [ ] Verify week/month periods return correct number of daily frames via API

🤖 Generated with [Claude Code](https://claude.com/claude-code)