### PR TITLE
Verify title similarity on ISRC matches during import

### DIFF
--- a/app/services/track_extractor/song_extractor.rb
+++ b/app/services/track_extractor/song_extractor.rb
@@ -122,11 +122,40 @@ class TrackExtractor::SongExtractor < TrackExtractor
   # which platform version is found. This prevents duplicate songs when the scraper
   # and recognizer find different platform versions of the same recording
   # (e.g., "Frank Boeijen" vs "Frank Boeijen Groep" versions with same ISRC).
+  # Title similarity is verified on ISRC matches to guard against cross-contaminated
+  # ISRCs where a foreign ISRC was incorrectly added to an unrelated song.
   def find_by_track
-    @find_by_track ||= (isrc.present? && Song.where('? = ANY(isrcs)', isrc).first) ||
+    @find_by_track ||= find_by_isrc ||
                        (id_on_spotify.present? && Song.find_by(id_on_spotify:)) ||
                        (id_on_deezer.present? && Song.find_by(id_on_deezer:)) ||
                        (id_on_itunes.present? && Song.find_by(id_on_itunes:))
+  end
+
+  def find_by_isrc
+    return nil if isrc.blank?
+
+    song = Song.where('? = ANY(isrcs)', isrc).first
+    return nil if song.blank?
+    return song if isrc_title_match?(song)
+
+    nil
+  end
+
+  def isrc_title_match?(song)
+    return true if title.blank? || song.title.blank?
+
+    normalized_import = normalize_title_for_comparison(title)
+    normalized_song = normalize_title_for_comparison(song.title)
+    (JaroWinkler.similarity(normalized_import.downcase, normalized_song.downcase) * 100).to_i >= TITLE_SIMILARITY_THRESHOLD
+  end
+
+  def normalize_title_for_comparison(raw_title)
+    normalized = raw_title.dup
+    # Strip featured artist parentheticals: (feat. ...), (ft. ...), (featuring ...)
+    normalized.gsub!(/\s*\((?:feat|ft|featuring)\.?\s+[^)]+\)/i, '')
+    # Strip subtitle suffixes after " - " (Spotify format for remasters, movie credits, etc.)
+    normalized.sub!(/\s+-\s+.+$/, '')
+    normalized.strip
   end
 
   def title

--- a/spec/services/track_extractor/song_extractor_spec.rb
+++ b/spec/services/track_extractor/song_extractor_spec.rb
@@ -793,7 +793,7 @@ describe TrackExtractor::SongExtractor do
       end
     end
 
-    context 'when song found by ISRC has a different Spotify ID and track brings a new ISRC' do
+    context 'when ISRC matches a song with a completely different title (cross-contamination)' do
       subject(:extractor) { described_class.new(played_song:, track:, artists: [snelle]) }
 
       let(:snelle) { create(:artist, name: 'Snelle') }
@@ -827,15 +827,19 @@ describe TrackExtractor::SongExtractor do
       end
       let(:zoe) { create(:artist, name: 'Zoë Livay') }
 
-      it 'does not add the track ISRC to a song with a different Spotify ID' do
-        extractor.extract
-        ik_zing_song.reload
-        expect(ik_zing_song.isrcs).to eq(%w[NLA802500027 NLS242600073])
+      it 'skips the contaminated ISRC match and creates the correct song', :aggregate_failures do
+        song = extractor.extract
+
+        expect(song).not_to eq(ik_zing_song)
+        expect(song.title).to eq('Laat Het Licht Aan')
+        expect(song.id_on_spotify).to eq('laat_het_licht_aan_spotify')
       end
 
-      it 'does not overwrite the existing Spotify ID' do
+      it 'does not modify the contaminated song', :aggregate_failures do
         extractor.extract
         ik_zing_song.reload
+
+        expect(ik_zing_song.isrcs).to eq(%w[NLA802500027 NLS242600073])
         expect(ik_zing_song.id_on_spotify).to eq('ik_zing_spotify')
       end
     end
@@ -882,6 +886,78 @@ describe TrackExtractor::SongExtractor do
         expect(song_result).not_to eq(existing_song)
         existing_song.reload
         expect(existing_song.isrcs).to eq(['EXISTING_ISRC'])
+      end
+    end
+
+    context 'when ISRC matches a song with subtitle differences in title' do
+      let(:track) do
+        OpenStruct.new(
+          track: { 'id' => 'spotify_good' },
+          title: "I'm Good - From The Movie \"GOAT\"",
+          id: 'spotify_good',
+          isrc: 'USRC12345',
+          spotify_song_url: 'https://open.spotify.com/track/spotify_good',
+          spotify_artwork_url: nil,
+          spotify_preview_url: nil,
+          release_date: nil,
+          release_date_precision: nil
+        )
+      end
+      let(:played_song) do
+        OpenStruct.new(
+          title: "I'm Good - From The Movie \"GOAT\"",
+          artist_name: artist.name,
+          spotify_url: nil,
+          isrc_code: 'USRC12345'
+        )
+      end
+
+      let!(:existing_song) do
+        create(:song,
+               title: "I'm Good",
+               id_on_spotify: 'spotify_good',
+               isrcs: ['USRC12345'],
+               artists: [artist])
+      end
+
+      it 'matches the existing song despite subtitle differences' do
+        expect(song).to eq(existing_song)
+      end
+    end
+
+    context 'when ISRC matches a song with featured artist differences in title' do
+      let(:track) do
+        OpenStruct.new(
+          track: { 'id' => 'spotify_pgd' },
+          title: 'PGD (feat. Kyle Richh & ZEDDY WILL)',
+          id: 'spotify_pgd',
+          isrc: 'USRC67890',
+          spotify_song_url: 'https://open.spotify.com/track/spotify_pgd',
+          spotify_artwork_url: nil,
+          spotify_preview_url: nil,
+          release_date: nil,
+          release_date_precision: nil
+        )
+      end
+      let(:played_song) do
+        OpenStruct.new(
+          title: 'PGD (feat. Kyle Richh & ZEDDY WILL)',
+          artist_name: artist.name,
+          spotify_url: nil,
+          isrc_code: 'USRC67890'
+        )
+      end
+
+      let!(:existing_song) do
+        create(:song,
+               title: 'Pgd',
+               id_on_spotify: 'spotify_pgd',
+               isrcs: ['USRC67890'],
+               artists: [artist])
+      end
+
+      it 'matches the existing song despite featured artist differences' do
+        expect(song).to eq(existing_song)
       end
     end
 


### PR DESCRIPTION
## Summary
- `find_by_track` in `SongExtractor` trusted ISRCs blindly — when a song had a cross-contaminated ISRC (from before the `should_add_isrc?` fix), importing a different song with that ISRC would match the wrong song (e.g., importing "Lune de miel" by Zaho matched "Special" by Don Choa, Zaho)
- Added `find_by_isrc` which verifies title similarity (JaroWinkler >= 70%) after normalizing away featured artist parentheticals (`feat.`/`ft.`/`featuring`) and subtitle suffixes (` - From The Movie "GOAT"`, ` - 2009 Remaster`) before accepting an ISRC match
- If the title doesn't match, the ISRC is skipped and lookup falls through to Spotify ID / Deezer ID / iTunes ID / title matching — preventing wrong song linkages while preserving correct matches like "Frank Boeijen" vs "Frank Boeijen Groep" (same title, same ISRC)

## Test plan
- [x] Existing "Frank Boeijen" ISRC test still passes (same title, different artist credits)
- [x] Cross-contamination test updated: "Laat Het Licht Aan" no longer incorrectly matches "Ik Zing" via shared ISRC
- [x] New test: subtitle differences ("I'm Good - From The Movie 'GOAT'" matches "I'm Good" by ISRC)
- [x] New test: featured artist differences ("PGD (feat. Kyle Richh & ZEDDY WILL)" matches "Pgd" by ISRC)
- [x] All 51 SongExtractor specs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)