### PR TITLE
Add CORS origins for admin.airplays.nl

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -32,4 +32,23 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
              methods: [:get, :post, :put, :patch, :delete, :options, :head],
              expose: %w[Authorization]
   end
+
+  allow do
+    origins 'https://admin.airplays.nl'
+
+    resource '*',
+             headers: :any,
+             methods: [:get, :post, :put, :patch, :delete, :options, :head],
+             expose: %w[Authorization]
+  end
+
+  allow do
+    origins(%r{\Ahttps://deploy-preview-\d+--playlists-admin\.netlify\.app\z},
+            %r{\Ahttps://[a-z0-9-]+--playlists-admin\.netlify\.app\z})
+
+    resource '*',
+             headers: :any,
+             methods: [:get, :post, :put, :patch, :delete, :options, :head],
+             expose: %w[Authorization]
+  end
 end


### PR DESCRIPTION
## Summary
- Add `https://admin.airplays.nl` as an allowed CORS origin
- Add regex patterns for Netlify deploy previews (`deploy-preview-*--playlists-admin.netlify.app`)
- Add regex patterns for Netlify branch deploys (`*--playlists-admin.netlify.app`)

## Test plan
- [ ] Verify CORS headers are returned for requests from `https://admin.airplays.nl`
- [ ] Verify deploy preview origins are accepted (e.g. `deploy-preview-123--playlists-admin.netlify.app`)
- [ ] Verify branch deploy origins are accepted (e.g. `branch-name--playlists-admin.netlify.app`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)