### PR TITLE
Add faceted search endpoints for songs and artists

### DIFF
--- a/app/controllers/api/v1/artists_controller.rb
+++ b/app/controllers/api/v1/artists_controller.rb
@@ -46,13 +46,7 @@ module Api
       #   - country (optional): Filter by country of origin
       #   - limit (optional, default: 10): Maximum number of results (max: 20)
       def search
-        results = Artist.order(spotify_popularity: :desc)
-        results = results.search_by_name(params[:q]) if params[:q].present?
-        results = filter_by_name(results)
-        results = filter_by_genre(results)
-        results = filter_by_country(results)
-        results = results.limit(search_limit)
-
+        results = Artist.faceted_search(search_filter_params)
         render json: ArtistSerializer.new(results).serializable_hash.to_json
       end
 
@@ -65,13 +59,7 @@ module Api
       #   - q (optional): Partial input to filter suggestions
       #   - limit (optional, default: 5): Maximum suggestions (max: 10)
       def search_suggestions
-        suggestions = case params[:field]
-                      when 'name' then name_suggestions
-                      when 'genre' then genre_suggestions
-                      when 'country' then country_suggestions
-                      else available_fields_response
-                      end
-
+        suggestions = Artist.suggest(field: params[:field], query: params[:q], limit: suggestion_limit)
         render json: { suggestions: suggestions, field: params[:field] }
       end
 
@@ -223,73 +211,18 @@ module Api
         [params.fetch(:limit, 10).to_i, 20].min
       end
 
-      def search_limit
-        [params.fetch(:limit, 10).to_i, 20].min
+      def search_filter_params
+        {
+          q: params[:q],
+          name: params[:name],
+          genre: params[:genre],
+          country: params[:country],
+          limit: [params.fetch(:limit, 10).to_i, 20].min
+        }
       end
 
       def suggestion_limit
         [params.fetch(:limit, 5).to_i, 10].min
-      end
-
-      def filter_by_name(scope)
-        return scope if params[:name].blank?
-
-        name_col = Artist.arel_table[:name]
-        scope.where(
-          trigram_match(name_col, params[:name]).or(name_col.matches("%#{Artist.sanitize_sql_like(params[:name])}%"))
-        )
-      end
-
-      def filter_by_genre(scope)
-        return scope if params[:genre].blank?
-
-        scope.where(array_contains(Artist.arel_table[:genres], params[:genre]))
-      end
-
-      def filter_by_country(scope)
-        return scope if params[:country].blank?
-
-        scope.where(array_contains(Artist.arel_table[:country_of_origin], params[:country]))
-      end
-
-      def name_suggestions
-        query = params[:q]
-        scope = Artist.order(spotify_popularity: :desc)
-        if query.present?
-          name_col = Artist.arel_table[:name]
-          scope = scope.where(
-            trigram_match(name_col, query).or(name_col.matches("%#{Artist.sanitize_sql_like(query)}%"))
-          )
-        end
-        scope.limit(suggestion_limit).pluck(:name).uniq
-      end
-
-      def genre_suggestions
-        query = params[:q]
-        scope = Artist.where.not(genres: [])
-        genres = scope.pluck(:genres).flatten.tally.sort_by { |_genre, count| -count }.map(&:first)
-        genres = genres.select { |g| g.downcase.include?(query.downcase) } if query.present?
-        genres.first(suggestion_limit)
-      end
-
-      def country_suggestions
-        query = params[:q]
-        scope = Artist.where.not(country_of_origin: [])
-        countries = scope.pluck(:country_of_origin).flatten.tally.sort_by { |_c, count| -count }.map(&:first)
-        countries = countries.select { |c| c.downcase.include?(query.downcase) } if query.present?
-        countries.first(suggestion_limit)
-      end
-
-      def trigram_match(column, value)
-        Arel::Nodes::InfixOperation.new('%', column, Arel::Nodes.build_quoted(value))
-      end
-
-      def array_contains(column, value)
-        Arel::Nodes::InfixOperation.new('@>', column, Arel::Nodes.build_quoted("{#{value}}"))
-      end
-
-      def available_fields_response
-        %w[name genre country]
       end
     end
   end

--- a/app/controllers/api/v1/artists_controller.rb
+++ b/app/controllers/api/v1/artists_controller.rb
@@ -35,6 +35,46 @@ module Api
         render json: ArtistSerializer.new(results).serializable_hash.to_json
       end
 
+      # GET /api/v1/artists/search
+      #
+      # Faceted search for artists. All filters are optional and combinable.
+      #
+      # Parameters:
+      #   - q (optional): Free text search on artist name
+      #   - name (optional): Filter by artist name (fuzzy match)
+      #   - genre (optional): Filter by genre (array overlap)
+      #   - country (optional): Filter by country of origin
+      #   - limit (optional, default: 10): Maximum number of results (max: 20)
+      def search
+        results = Artist.order(spotify_popularity: :desc)
+        results = results.search_by_name(params[:q]) if params[:q].present?
+        results = filter_by_name(results)
+        results = filter_by_genre(results)
+        results = filter_by_country(results)
+        results = results.limit(search_limit)
+
+        render json: ArtistSerializer.new(results).serializable_hash.to_json
+      end
+
+      # GET /api/v1/artists/search_suggestions
+      #
+      # Returns autocomplete suggestions for a specific search field.
+      #
+      # Parameters:
+      #   - field (required): Field to suggest values for (name, genre, country)
+      #   - q (optional): Partial input to filter suggestions
+      #   - limit (optional, default: 5): Maximum suggestions (max: 10)
+      def search_suggestions
+        suggestions = case params[:field]
+                      when 'name' then name_suggestions
+                      when 'genre' then genre_suggestions
+                      when 'country' then country_suggestions
+                      else available_fields_response
+                      end
+
+        render json: { suggestions: suggestions, field: params[:field] }
+      end
+
       def graph_data
         render json: artist.graph_data(params[:period])
       end
@@ -181,6 +221,75 @@ module Api
 
       def autocomplete_limit
         [params.fetch(:limit, 10).to_i, 20].min
+      end
+
+      def search_limit
+        [params.fetch(:limit, 10).to_i, 20].min
+      end
+
+      def suggestion_limit
+        [params.fetch(:limit, 5).to_i, 10].min
+      end
+
+      def filter_by_name(scope)
+        return scope if params[:name].blank?
+
+        name_col = Artist.arel_table[:name]
+        scope.where(
+          trigram_match(name_col, params[:name]).or(name_col.matches("%#{Artist.sanitize_sql_like(params[:name])}%"))
+        )
+      end
+
+      def filter_by_genre(scope)
+        return scope if params[:genre].blank?
+
+        scope.where(array_contains(Artist.arel_table[:genres], params[:genre]))
+      end
+
+      def filter_by_country(scope)
+        return scope if params[:country].blank?
+
+        scope.where(array_contains(Artist.arel_table[:country_of_origin], params[:country]))
+      end
+
+      def name_suggestions
+        query = params[:q]
+        scope = Artist.order(spotify_popularity: :desc)
+        if query.present?
+          name_col = Artist.arel_table[:name]
+          scope = scope.where(
+            trigram_match(name_col, query).or(name_col.matches("%#{Artist.sanitize_sql_like(query)}%"))
+          )
+        end
+        scope.limit(suggestion_limit).pluck(:name).uniq
+      end
+
+      def genre_suggestions
+        query = params[:q]
+        scope = Artist.where.not(genres: [])
+        genres = scope.pluck(:genres).flatten.tally.sort_by { |_genre, count| -count }.map(&:first)
+        genres = genres.select { |g| g.downcase.include?(query.downcase) } if query.present?
+        genres.first(suggestion_limit)
+      end
+
+      def country_suggestions
+        query = params[:q]
+        scope = Artist.where.not(country_of_origin: [])
+        countries = scope.pluck(:country_of_origin).flatten.tally.sort_by { |_c, count| -count }.map(&:first)
+        countries = countries.select { |c| c.downcase.include?(query.downcase) } if query.present?
+        countries.first(suggestion_limit)
+      end
+
+      def trigram_match(column, value)
+        Arel::Nodes::InfixOperation.new('%', column, Arel::Nodes.build_quoted(value))
+      end
+
+      def array_contains(column, value)
+        Arel::Nodes::InfixOperation.new('@>', column, Arel::Nodes.build_quoted("{#{value}}"))
+      end
+
+      def available_fields_response
+        %w[name genre country]
       end
     end
   end

--- a/app/controllers/api/v1/songs_controller.rb
+++ b/app/controllers/api/v1/songs_controller.rb
@@ -38,6 +38,50 @@ module Api
         render json: AutocompleteSongSerializer.new(results).serializable_hash.to_json
       end
 
+      # GET /api/v1/songs/search
+      #
+      # Faceted search for songs. All filters are optional and combinable.
+      #
+      # Parameters:
+      #   - q (optional): Free text search across title and artist
+      #   - artist (optional): Filter by artist name (fuzzy match)
+      #   - title (optional): Filter by song title (fuzzy match)
+      #   - album (optional): Filter by album name (fuzzy match)
+      #   - year_from (optional): Filter songs released in or after this year
+      #   - year_to (optional): Filter songs released in or before this year
+      #   - limit (optional, default: 10): Maximum number of results (max: 20)
+      def search
+        results = Song.includes(:artists).order(popularity: :desc)
+        results = results.search_by_text(params[:q]) if params[:q].present?
+        results = filter_by_artist(results)
+        results = filter_by_title(results)
+        results = filter_by_album(results)
+        results = filter_by_year(results)
+        results = results.limit(search_limit)
+
+        render json: AutocompleteSongSerializer.new(results).serializable_hash.to_json
+      end
+
+      # GET /api/v1/songs/search_suggestions
+      #
+      # Returns autocomplete suggestions for a specific search field.
+      #
+      # Parameters:
+      #   - field (required): Field to suggest values for (artist, title, album, year)
+      #   - q (optional): Partial input to filter suggestions
+      #   - limit (optional, default: 5): Maximum suggestions (max: 10)
+      def search_suggestions
+        suggestions = case params[:field]
+                      when 'artist' then artist_suggestions
+                      when 'title' then title_suggestions
+                      when 'album' then album_suggestions
+                      when 'year' then year_suggestions
+                      else available_fields_response
+                      end
+
+        render json: { suggestions: suggestions, field: params[:field] }
+      end
+
       def graph_data
         render json: song.graph_data(params[:period])
       end
@@ -256,6 +300,93 @@ module Api
 
       def autocomplete_limit
         [params.fetch(:limit, 10).to_i, 20].min
+      end
+
+      def search_limit
+        [params.fetch(:limit, 10).to_i, 20].min
+      end
+
+      def suggestion_limit
+        [params.fetch(:limit, 5).to_i, 10].min
+      end
+
+      def filter_by_artist(scope)
+        return scope if params[:artist].blank?
+
+        name_col = Artist.arel_table[:name]
+        scope.joins(:artists).where(
+          trigram_match(name_col, params[:artist]).or(name_col.matches("%#{Song.sanitize_sql_like(params[:artist])}%"))
+        )
+      end
+
+      def filter_by_title(scope)
+        return scope if params[:title].blank?
+
+        title_col = Song.arel_table[:title]
+        scope.where(
+          trigram_match(title_col, params[:title]).or(title_col.matches("%#{Song.sanitize_sql_like(params[:title])}%"))
+        )
+      end
+
+      def filter_by_album(scope)
+        return scope if params[:album].blank?
+
+        scope.where(Song.arel_table[:album_name].matches("%#{Song.sanitize_sql_like(params[:album])}%"))
+      end
+
+      def filter_by_year(scope)
+        scope = scope.where(release_date: Date.new(params[:year_from].to_i)..) if params[:year_from].present?
+        scope = scope.where(release_date: ..Date.new(params[:year_to].to_i).end_of_year) if params[:year_to].present?
+        scope
+      end
+
+      def artist_suggestions
+        query = params[:q]
+        scope = Artist.order(spotify_popularity: :desc)
+        if query.present?
+          name_col = Artist.arel_table[:name]
+          scope = scope.where(
+            trigram_match(name_col, query).or(name_col.matches("%#{Artist.sanitize_sql_like(query)}%"))
+          )
+        end
+        scope.limit(suggestion_limit).pluck(:name).uniq
+      end
+
+      def title_suggestions
+        query = params[:q]
+        scope = Song.order(popularity: :desc)
+        if query.present?
+          title_col = Song.arel_table[:title]
+          scope = scope.where(
+            trigram_match(title_col, query).or(title_col.matches("%#{Song.sanitize_sql_like(query)}%"))
+          )
+        end
+        scope.limit(suggestion_limit).pluck(:title).uniq
+      end
+
+      def album_suggestions
+        query = params[:q]
+        scope = Song.where.not(album_name: [nil, ''])
+        scope = scope.where(Song.arel_table[:album_name].matches("%#{Song.sanitize_sql_like(query)}%")) if query.present?
+        scope.distinct.order(:album_name).limit(suggestion_limit).pluck(:album_name)
+      end
+
+      def year_suggestions
+        year_col = Arel.sql('EXTRACT(YEAR FROM release_date)::integer')
+        Song.where.not(release_date: nil)
+          .select(year_col.as('year'))
+          .distinct
+          .order(year: :desc)
+          .limit(suggestion_limit)
+          .map(&:year)
+      end
+
+      def trigram_match(column, value)
+        Arel::Nodes::InfixOperation.new('%', column, Arel::Nodes.build_quoted(value))
+      end
+
+      def available_fields_response
+        %w[artist title album year_from year_to]
       end
     end
   end

--- a/app/controllers/api/v1/songs_controller.rb
+++ b/app/controllers/api/v1/songs_controller.rb
@@ -51,14 +51,7 @@ module Api
       #   - year_to (optional): Filter songs released in or before this year
       #   - limit (optional, default: 10): Maximum number of results (max: 20)
       def search
-        results = Song.includes(:artists).order(popularity: :desc)
-        results = results.search_by_text(params[:q]) if params[:q].present?
-        results = filter_by_artist(results)
-        results = filter_by_title(results)
-        results = filter_by_album(results)
-        results = filter_by_year(results)
-        results = results.limit(search_limit)
-
+        results = Song.faceted_search(search_filter_params)
         render json: AutocompleteSongSerializer.new(results).serializable_hash.to_json
       end
 
@@ -71,14 +64,7 @@ module Api
       #   - q (optional): Partial input to filter suggestions
       #   - limit (optional, default: 5): Maximum suggestions (max: 10)
       def search_suggestions
-        suggestions = case params[:field]
-                      when 'artist' then artist_suggestions
-                      when 'title' then title_suggestions
-                      when 'album' then album_suggestions
-                      when 'year' then year_suggestions
-                      else available_fields_response
-                      end
-
+        suggestions = Song.suggest(field: params[:field], query: params[:q], limit: suggestion_limit)
         render json: { suggestions: suggestions, field: params[:field] }
       end
 
@@ -302,91 +288,20 @@ module Api
         [params.fetch(:limit, 10).to_i, 20].min
       end
 
-      def search_limit
-        [params.fetch(:limit, 10).to_i, 20].min
+      def search_filter_params
+        {
+          q: params[:q],
+          artist: params[:artist],
+          title: params[:title],
+          album: params[:album],
+          year_from: params[:year_from],
+          year_to: params[:year_to],
+          limit: [params.fetch(:limit, 10).to_i, 20].min
+        }
       end
 
       def suggestion_limit
         [params.fetch(:limit, 5).to_i, 10].min
-      end
-
-      def filter_by_artist(scope)
-        return scope if params[:artist].blank?
-
-        name_col = Artist.arel_table[:name]
-        scope.joins(:artists).where(
-          trigram_match(name_col, params[:artist]).or(name_col.matches("%#{Song.sanitize_sql_like(params[:artist])}%"))
-        )
-      end
-
-      def filter_by_title(scope)
-        return scope if params[:title].blank?
-
-        title_col = Song.arel_table[:title]
-        scope.where(
-          trigram_match(title_col, params[:title]).or(title_col.matches("%#{Song.sanitize_sql_like(params[:title])}%"))
-        )
-      end
-
-      def filter_by_album(scope)
-        return scope if params[:album].blank?
-
-        scope.where(Song.arel_table[:album_name].matches("%#{Song.sanitize_sql_like(params[:album])}%"))
-      end
-
-      def filter_by_year(scope)
-        scope = scope.where(release_date: Date.new(params[:year_from].to_i)..) if params[:year_from].present?
-        scope = scope.where(release_date: ..Date.new(params[:year_to].to_i).end_of_year) if params[:year_to].present?
-        scope
-      end
-
-      def artist_suggestions
-        query = params[:q]
-        scope = Artist.order(spotify_popularity: :desc)
-        if query.present?
-          name_col = Artist.arel_table[:name]
-          scope = scope.where(
-            trigram_match(name_col, query).or(name_col.matches("%#{Artist.sanitize_sql_like(query)}%"))
-          )
-        end
-        scope.limit(suggestion_limit).pluck(:name).uniq
-      end
-
-      def title_suggestions
-        query = params[:q]
-        scope = Song.order(popularity: :desc)
-        if query.present?
-          title_col = Song.arel_table[:title]
-          scope = scope.where(
-            trigram_match(title_col, query).or(title_col.matches("%#{Song.sanitize_sql_like(query)}%"))
-          )
-        end
-        scope.limit(suggestion_limit).pluck(:title).uniq
-      end
-
-      def album_suggestions
-        query = params[:q]
-        scope = Song.where.not(album_name: [nil, ''])
-        scope = scope.where(Song.arel_table[:album_name].matches("%#{Song.sanitize_sql_like(query)}%")) if query.present?
-        scope.distinct.order(:album_name).limit(suggestion_limit).pluck(:album_name)
-      end
-
-      def year_suggestions
-        year_col = Arel.sql('EXTRACT(YEAR FROM release_date)::integer')
-        Song.where.not(release_date: nil)
-          .select(year_col.as('year'))
-          .distinct
-          .order(year: :desc)
-          .limit(suggestion_limit)
-          .map(&:year)
-      end
-
-      def trigram_match(column, value)
-        Arel::Nodes::InfixOperation.new('%', column, Arel::Nodes.build_quoted(value))
-      end
-
-      def available_fields_response
-        %w[artist title album year_from year_to]
       end
     end
   end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -36,6 +36,7 @@ class Artist < ApplicationRecord
   include DateConcern
   include ChartConcern
   include TimeAnalyticsConcern
+  include ArtistSearchConcern
 
   pg_search_scope :search_by_name,
                   against: :name,

--- a/app/models/concerns/artist_search_concern.rb
+++ b/app/models/concerns/artist_search_concern.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module ArtistSearchConcern
+  extend ActiveSupport::Concern
+
+  SEARCH_FIELDS = %w[name genre country].freeze
+
+  included do
+    scope :filter_by_name, lambda { |name|
+      return all if name.blank?
+
+      name_col = arel_table[:name]
+      trigram = Arel::Nodes::InfixOperation.new('%', name_col, Arel::Nodes.build_quoted(name))
+      where(trigram.or(name_col.matches("%#{sanitize_sql_like(name)}%")))
+    }
+    scope :filter_by_genre, lambda { |genre|
+      return all if genre.blank?
+
+      where(Arel::Nodes::InfixOperation.new('@>', arel_table[:genres], Arel::Nodes.build_quoted("{#{genre}}")))
+    }
+    scope :filter_by_country, lambda { |country|
+      return all if country.blank?
+
+      where(Arel::Nodes::InfixOperation.new('@>', arel_table[:country_of_origin], Arel::Nodes.build_quoted("{#{country}}")))
+    }
+  end
+
+  class_methods do
+    def faceted_search(filters = {})
+      scope = order(spotify_popularity: :desc)
+      scope = scope.search_by_name(filters[:q]) if filters[:q].present?
+      scope.filter_by_name(filters[:name])
+        .filter_by_genre(filters[:genre])
+        .filter_by_country(filters[:country])
+        .limit(filters.fetch(:limit, 10))
+    end
+
+    def suggest(field:, query: nil, limit: 5)
+      case field
+      when 'name' then suggest_names(query, limit)
+      when 'genre' then suggest_genres(query, limit)
+      when 'country' then suggest_countries(query, limit)
+      else SEARCH_FIELDS
+      end
+    end
+
+    private
+
+    def suggest_names(query, limit)
+      scope = order(spotify_popularity: :desc)
+      if query.present?
+        name_col = arel_table[:name]
+        scope = scope.where(trigram_or_ilike(name_col, query))
+      end
+      scope.limit(limit).pluck(:name).uniq
+    end
+
+    def suggest_genres(query, limit)
+      scope = where.not(genres: [])
+      genres = scope.pluck(:genres).flatten.tally.sort_by { |_genre, count| -count }.map(&:first)
+      genres = genres.select { |g| g.downcase.include?(query.downcase) } if query.present?
+      genres.first(limit)
+    end
+
+    def suggest_countries(query, limit)
+      scope = where.not(country_of_origin: [])
+      countries = scope.pluck(:country_of_origin).flatten.tally.sort_by { |_c, count| -count }.map(&:first)
+      countries = countries.select { |c| c.downcase.include?(query.downcase) } if query.present?
+      countries.first(limit)
+    end
+
+    def trigram_or_ilike(column, value)
+      trigram = Arel::Nodes::InfixOperation.new('%', column, Arel::Nodes.build_quoted(value))
+      trigram.or(column.matches("%#{sanitize_sql_like(value)}%"))
+    end
+  end
+end

--- a/app/models/concerns/song_search_concern.rb
+++ b/app/models/concerns/song_search_concern.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module SongSearchConcern
+  extend ActiveSupport::Concern
+
+  SEARCH_FIELDS = %w[artist title album year_from year_to].freeze
+
+  included do
+    scope :filter_by_artist, lambda { |artist_name|
+      return all if artist_name.blank?
+
+      name_col = Artist.arel_table[:name]
+      trigram = Arel::Nodes::InfixOperation.new('%', name_col, Arel::Nodes.build_quoted(artist_name))
+      joins(:artists).where(trigram.or(name_col.matches("%#{sanitize_sql_like(artist_name)}%")))
+    }
+    scope :filter_by_title, lambda { |title|
+      return all if title.blank?
+
+      title_col = arel_table[:title]
+      trigram = Arel::Nodes::InfixOperation.new('%', title_col, Arel::Nodes.build_quoted(title))
+      where(trigram.or(title_col.matches("%#{sanitize_sql_like(title)}%")))
+    }
+    scope :filter_by_album, lambda { |album|
+      return all if album.blank?
+
+      where(arel_table[:album_name].matches("%#{sanitize_sql_like(album)}%"))
+    }
+    scope :filter_by_year_range, lambda { |year_from: nil, year_to: nil|
+      scope = all
+      scope = scope.where(release_date: Date.new(year_from.to_i)..) if year_from.present?
+      scope = scope.where(release_date: ..Date.new(year_to.to_i).end_of_year) if year_to.present?
+      scope
+    }
+  end
+
+  class_methods do
+    def faceted_search(filters = {})
+      scope = includes(:artists).order(popularity: :desc)
+      scope = scope.search_by_text(filters[:q]) if filters[:q].present?
+      scope.filter_by_artist(filters[:artist])
+        .filter_by_title(filters[:title])
+        .filter_by_album(filters[:album])
+        .filter_by_year_range(year_from: filters[:year_from], year_to: filters[:year_to])
+        .limit(filters.fetch(:limit, 10))
+    end
+
+    def suggest(field:, query: nil, limit: 5)
+      case field
+      when 'artist' then suggest_artists(query, limit)
+      when 'title' then suggest_titles(query, limit)
+      when 'album' then suggest_albums(query, limit)
+      when 'year' then suggest_years(limit)
+      else SEARCH_FIELDS
+      end
+    end
+
+    private
+
+    def suggest_artists(query, limit)
+      scope = Artist.order(spotify_popularity: :desc)
+      if query.present?
+        name_col = Artist.arel_table[:name]
+        scope = scope.where(trigram_or_ilike(name_col, query))
+      end
+      scope.limit(limit).pluck(:name).uniq
+    end
+
+    def suggest_titles(query, limit)
+      scope = order(popularity: :desc)
+      if query.present?
+        title_col = arel_table[:title]
+        scope = scope.where(trigram_or_ilike(title_col, query))
+      end
+      scope.limit(limit).pluck(:title).uniq
+    end
+
+    def suggest_albums(query, limit)
+      scope = where.not(album_name: [nil, ''])
+      scope = scope.where(arel_table[:album_name].matches("%#{sanitize_sql_like(query)}%")) if query.present?
+      scope.distinct.order(:album_name).limit(limit).pluck(:album_name)
+    end
+
+    def suggest_years(limit)
+      year_col = Arel.sql('EXTRACT(YEAR FROM release_date)::integer')
+      where.not(release_date: nil)
+        .select(year_col.as('year'))
+        .distinct
+        .order(year: :desc)
+        .limit(limit)
+        .map(&:year)
+    end
+
+    def trigram_or_ilike(column, value)
+      trigram = Arel::Nodes::InfixOperation.new('%', column, Arel::Nodes.build_quoted(value))
+      trigram.or(column.matches("%#{sanitize_sql_like(value)}%"))
+    end
+  end
+end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -54,6 +54,7 @@ class Song < ApplicationRecord
   include DateConcern
   include ChartConcern
   include TimeAnalyticsConcern
+  include SongSearchConcern
 
   pg_search_scope :search_by_text,
                   against: :search_text,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,8 +9,8 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   mount Rswag::Ui::Engine => '/api-docs'
   mount Rswag::Api::Engine => '/api-docs'
   devise_for :admins
-  namespace :api, defaults: { format: :json } do
-    namespace :v1 do
+  namespace :api, defaults: { format: :json } do # rubocop:disable Metrics/BlockLength
+    namespace :v1 do # rubocop:disable Metrics/BlockLength
       devise_for :admins, controllers: { sessions: 'api/v1/admins/auth_token' }
       get 'admins/current', to: 'admins/current_admin#show'
       get 'admins/songs', to: 'admins/songs#index'
@@ -23,6 +23,8 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
       get '/playlists', to: redirect('/api/v1/air_plays')
       resources :artists, only: %i[index show] do
         get :autocomplete, on: :collection
+        get :search, on: :collection
+        get :search_suggestions, on: :collection
         get :graph_data, on: :member
         get :songs, on: :member
         get :chart_positions, on: :member
@@ -34,6 +36,8 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
       end
       resources :songs, only: %i[index show] do
         get :autocomplete, on: :collection
+        get :search, on: :collection
+        get :search_suggestions, on: :collection
         get :graph_data, on: :member
         get :chart_positions, on: :member
         get :time_analytics, on: :member

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -66,6 +66,77 @@ describe Artist do
     end
   end
 
+  describe '.faceted_search' do
+    let!(:coldplay) { create(:artist, name: 'Coldplay', genres: %w[rock pop], country_of_origin: ['United Kingdom'], spotify_popularity: 90) }
+    let!(:drake) { create(:artist, name: 'Drake', genres: %w[hip-hop rap], country_of_origin: ['Canada'], spotify_popularity: 95) }
+
+    it 'filters by name', :aggregate_failures do
+      results = Artist.faceted_search(name: 'Coldplay')
+      expect(results).to include(coldplay)
+      expect(results).not_to include(drake)
+    end
+
+    it 'filters by genre', :aggregate_failures do
+      results = Artist.faceted_search(genre: 'rock')
+      expect(results).to include(coldplay)
+      expect(results).not_to include(drake)
+    end
+
+    it 'filters by country', :aggregate_failures do
+      results = Artist.faceted_search(country: 'Canada')
+      expect(results).to include(drake)
+      expect(results).not_to include(coldplay)
+    end
+
+    it 'combines multiple filters' do
+      results = Artist.faceted_search(genre: 'rock', country: 'United Kingdom')
+      expect(results).to contain_exactly(coldplay)
+    end
+
+    it 'returns all artists when no filters given' do
+      results = Artist.faceted_search
+      expect(results).to include(coldplay, drake)
+    end
+
+    it 'respects limit' do
+      results = Artist.faceted_search(limit: 1)
+      expect(results.length).to eq(1)
+    end
+
+    context 'with blank filter values' do
+      it 'ignores blank genre' do
+        results = Artist.faceted_search(genre: '')
+        expect(results).to include(coldplay, drake)
+      end
+    end
+  end
+
+  describe '.suggest' do
+    let(:coldplay) do
+      create(:artist, name: 'Coldplay', genres: %w[rock pop],
+                      country_of_origin: ['United Kingdom'], spotify_popularity: 90)
+    end
+
+    it 'suggests artist names matching query' do
+      coldplay
+      expect(Artist.suggest(field: 'name', query: 'Cold')).to include('Coldplay')
+    end
+
+    it 'suggests genres matching query' do
+      coldplay
+      expect(Artist.suggest(field: 'genre', query: 'ro')).to include('rock')
+    end
+
+    it 'suggests countries matching query' do
+      coldplay
+      expect(Artist.suggest(field: 'country', query: 'United')).to include('United Kingdom')
+    end
+
+    it 'returns available field names for unknown field' do
+      expect(Artist.suggest(field: nil)).to eq(%w[name genre country])
+    end
+  end
+
   describe '.search_by_name' do
     let!(:coldplay) { create(:artist, name: 'Coldplay', spotify_popularity: 90) }
 

--- a/spec/models/song_spec.rb
+++ b/spec/models/song_spec.rb
@@ -250,6 +250,104 @@ describe Song do
     end
   end
 
+  describe '.faceted_search' do
+    let(:drake) { create(:artist, name: 'Drake') }
+    let(:adele) { create(:artist, name: 'Adele') }
+    let!(:hotline) do
+      create(:song, title: 'Hotline Bling', artists: [drake],
+                    album_name: 'Views', release_date: Date.new(2016, 4, 29), popularity: 90)
+    end
+    let!(:rolling) do
+      create(:song, title: 'Rolling in the Deep', artists: [adele],
+                    album_name: '21', release_date: Date.new(2011, 1, 24), popularity: 85)
+    end
+
+    it 'filters by artist name', :aggregate_failures do
+      results = Song.faceted_search(artist: 'Drake')
+      expect(results).to include(hotline)
+      expect(results).not_to include(rolling)
+    end
+
+    it 'filters by title', :aggregate_failures do
+      results = Song.faceted_search(title: 'Rolling')
+      expect(results).to include(rolling)
+      expect(results).not_to include(hotline)
+    end
+
+    it 'filters by album', :aggregate_failures do
+      results = Song.faceted_search(album: 'Views')
+      expect(results).to include(hotline)
+      expect(results).not_to include(rolling)
+    end
+
+    it 'filters by year_from', :aggregate_failures do
+      results = Song.faceted_search(year_from: '2015')
+      expect(results).to include(hotline)
+      expect(results).not_to include(rolling)
+    end
+
+    it 'filters by year_to', :aggregate_failures do
+      results = Song.faceted_search(year_to: '2012')
+      expect(results).to include(rolling)
+      expect(results).not_to include(hotline)
+    end
+
+    it 'combines multiple filters' do
+      results = Song.faceted_search(artist: 'Adele', year_from: '2010', year_to: '2012')
+      expect(results).to contain_exactly(rolling)
+    end
+
+    it 'returns all songs when no filters given' do
+      results = Song.faceted_search
+      expect(results).to include(hotline, rolling)
+    end
+
+    it 'respects limit' do
+      results = Song.faceted_search(limit: 1)
+      expect(results.length).to eq(1)
+    end
+
+    context 'with blank filter values' do
+      it 'ignores blank artist' do
+        results = Song.faceted_search(artist: '')
+        expect(results).to include(hotline, rolling)
+      end
+
+      it 'ignores nil year_from' do
+        results = Song.faceted_search(year_from: nil)
+        expect(results).to include(hotline, rolling)
+      end
+    end
+  end
+
+  describe '.suggest' do
+    let(:drake) { create(:artist, name: 'Drake', spotify_popularity: 95) }
+    let!(:hotline) do
+      create(:song, title: 'Hotline Bling', artists: [drake],
+                    album_name: 'Views', release_date: Date.new(2016, 4, 29), popularity: 90)
+    end
+
+    it 'suggests artist names matching query' do
+      expect(Song.suggest(field: 'artist', query: 'Dra')).to include('Drake')
+    end
+
+    it 'suggests song titles matching query' do
+      expect(Song.suggest(field: 'title', query: 'Hot')).to include('Hotline Bling')
+    end
+
+    it 'suggests album names matching query' do
+      expect(Song.suggest(field: 'album', query: 'Vie')).to include('Views')
+    end
+
+    it 'suggests release years' do
+      expect(Song.suggest(field: 'year')).to include(2016)
+    end
+
+    it 'returns available field names for unknown field' do
+      expect(Song.suggest(field: nil)).to eq(%w[artist title album year_from year_to])
+    end
+  end
+
   describe '#cleanup' do
     context 'if the song has no air plays' do
       let!(:song_no_air_play) { create :song }

--- a/spec/requests/api/v1/artists_spec.rb
+++ b/spec/requests/api/v1/artists_spec.rb
@@ -103,6 +103,121 @@ RSpec.describe 'Artists API', type: :request do
     end
   end
 
+  path '/api/v1/artists/search' do
+    get 'Faceted search for artists' do
+      tags 'Artists'
+      produces 'application/json'
+      description 'Search artists with structured filters. All filters are optional and combinable.'
+      parameter name: :q, in: :query, type: :string, required: false,
+                description: 'Free text search on artist name'
+      parameter name: :name, in: :query, type: :string, required: false,
+                description: 'Filter by artist name (fuzzy match)'
+      parameter name: :genre, in: :query, type: :string, required: false,
+                description: 'Filter by genre'
+      parameter name: :country, in: :query, type: :string, required: false,
+                description: 'Filter by country of origin'
+      parameter name: :limit, in: :query, type: :integer, required: false,
+                description: 'Maximum number of results (default: 10, max: 20)'
+
+      response '200', 'Search results retrieved successfully' do
+        example 'application/json', :with_genre_filter, {
+          data: [
+            {
+              id: '1',
+              type: 'artist',
+              attributes: {
+                id: 1,
+                name: 'Coldplay',
+                genres: %w[rock pop],
+                country_of_origin: ['United Kingdom']
+              }
+            }
+          ]
+        }
+
+        let!(:rock_artist) { create(:artist, name: 'Coldplay', genres: %w[rock pop], spotify_popularity: 90) }
+        let!(:hiphop_artist) { create(:artist, name: 'Drake', genres: %w[hip-hop rap], spotify_popularity: 95) }
+        let(:genre) { 'rock' }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          names = data['data'].map { |d| d['attributes']['name'] }
+          expect(names).to include('Coldplay')
+          expect(names).not_to include('Drake')
+        end
+      end
+
+      context 'with country filter' do
+        response '200', 'Filtered by country' do
+          let!(:dutch_artist) { create(:artist, name: 'Davina Michelle', country_of_origin: ['Netherlands']) }
+          let!(:american_artist) { create(:artist, name: 'Taylor Swift', country_of_origin: ['United States']) }
+          let(:country) { 'Netherlands' }
+
+          run_test! do |response|
+            data = JSON.parse(response.body)
+            names = data['data'].map { |d| d['attributes']['name'] }
+            expect(names).to include('Davina Michelle')
+            expect(names).not_to include('Taylor Swift')
+          end
+        end
+      end
+
+      context 'without any filters' do
+        response '200', 'Returns artists ordered by popularity' do
+          let!(:artist) { create(:artist, spotify_popularity: 80) }
+
+          run_test! do |response|
+            data = JSON.parse(response.body)
+            expect(data['data']).to be_an(Array)
+          end
+        end
+      end
+    end
+  end
+
+  path '/api/v1/artists/search_suggestions' do
+    get 'Get search suggestions for a field' do
+      tags 'Artists'
+      produces 'application/json'
+      description 'Returns autocomplete suggestions for a specific artist search field'
+      parameter name: :field, in: :query, type: :string, required: false,
+                description: 'Field to suggest values for: name, genre, country'
+      parameter name: :q, in: :query, type: :string, required: false,
+                description: 'Partial input to filter suggestions'
+      parameter name: :limit, in: :query, type: :integer, required: false,
+                description: 'Maximum suggestions (default: 5, max: 10)'
+
+      response '200', 'Genre suggestions' do
+        example 'application/json', :genre_suggestions, {
+          suggestions: %w[rock pop hip-hop],
+          field: 'genre'
+        }
+
+        let!(:artist) { create(:artist, genres: %w[rock pop]) }
+        let(:field) { 'genre' }
+        let(:q) { 'ro' }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['suggestions']).to include('rock')
+          expect(data['field']).to eq('genre')
+        end
+      end
+
+      response '200', 'Available fields when no field specified' do
+        example 'application/json', :available_fields, {
+          suggestions: %w[name genre country],
+          field: nil
+        }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['suggestions']).to eq(%w[name genre country])
+        end
+      end
+    end
+  end
+
   path '/api/v1/artists/{id}' do
     get 'Get an artist' do
       tags 'Artists'

--- a/spec/requests/api/v1/songs_spec.rb
+++ b/spec/requests/api/v1/songs_spec.rb
@@ -158,6 +158,144 @@ RSpec.describe 'Songs API', type: :request do
     end
   end
 
+  path '/api/v1/songs/search' do
+    get 'Faceted search for songs' do
+      tags 'Songs'
+      produces 'application/json'
+      description 'Search songs with structured filters. All filters are optional and combinable.'
+      parameter name: :q, in: :query, type: :string, required: false,
+                description: 'Free text search across title and artist'
+      parameter name: :artist, in: :query, type: :string, required: false,
+                description: 'Filter by artist name (fuzzy match)'
+      parameter name: :title, in: :query, type: :string, required: false,
+                description: 'Filter by song title (fuzzy match)'
+      parameter name: :album, in: :query, type: :string, required: false,
+                description: 'Filter by album name'
+      parameter name: :year_from, in: :query, type: :integer, required: false,
+                description: 'Filter songs released in or after this year'
+      parameter name: :year_to, in: :query, type: :integer, required: false,
+                description: 'Filter songs released in or before this year'
+      parameter name: :limit, in: :query, type: :integer, required: false,
+                description: 'Maximum number of results (default: 10, max: 20)'
+
+      response '200', 'Search results retrieved successfully' do
+        example 'application/json', :with_artist_filter, {
+          data: [
+            {
+              id: '1',
+              type: 'song',
+              attributes: {
+                id: 1,
+                title: 'Hotline Bling',
+                spotify_artwork_url: 'https://i.scdn.co/image/abc123',
+                artists: [{ id: 1, name: 'Drake' }]
+              }
+            }
+          ]
+        }
+
+        let!(:drake) { create(:artist, name: 'Drake') }
+        let!(:song) { create(:song, title: 'Hotline Bling', artists: [drake], album_name: 'Views', release_date: Date.new(2016, 4, 29)) }
+        let(:artist) { 'Drake' }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['data']).to be_an(Array)
+        end
+      end
+
+      context 'with combined filters' do
+        response '200', 'Filtered results' do
+          let!(:target_artist) { create(:artist, name: 'Adele') }
+          let!(:target_song) do
+            create(:song, title: 'Rolling in the Deep', artists: [target_artist],
+                          album_name: '21', release_date: Date.new(2011, 1, 24))
+          end
+          let!(:other_song) { create(:song, title: 'Other Song', release_date: Date.new(2022, 1, 1)) }
+          let(:artist) { 'Adele' }
+          let(:year_from) { 2010 }
+          let(:year_to) { 2012 }
+
+          run_test! do |response|
+            data = JSON.parse(response.body)
+            titles = data['data'].map { |d| d['attributes']['title'] }
+            expect(titles).to include('Rolling in the Deep')
+            expect(titles).not_to include('Other Song')
+          end
+        end
+      end
+
+      context 'without any filters' do
+        response '200', 'Returns songs ordered by popularity' do
+          let!(:song) { create(:song, title: 'Some Song', popularity: 80) }
+
+          run_test! do |response|
+            data = JSON.parse(response.body)
+            expect(data['data']).to be_an(Array)
+          end
+        end
+      end
+    end
+  end
+
+  path '/api/v1/songs/search_suggestions' do
+    get 'Get search suggestions for a field' do
+      tags 'Songs'
+      produces 'application/json'
+      description 'Returns autocomplete suggestions for a specific song search field'
+      parameter name: :field, in: :query, type: :string, required: false,
+                description: 'Field to suggest values for: artist, title, album, year'
+      parameter name: :q, in: :query, type: :string, required: false,
+                description: 'Partial input to filter suggestions'
+      parameter name: :limit, in: :query, type: :integer, required: false,
+                description: 'Maximum suggestions (default: 5, max: 10)'
+
+      response '200', 'Artist suggestions' do
+        example 'application/json', :artist_suggestions, {
+          suggestions: ['Drake', 'Dua Lipa'],
+          field: 'artist'
+        }
+
+        let!(:artist) { create(:artist, name: 'Drake', spotify_popularity: 90) }
+        let(:field) { 'artist' }
+        let(:q) { 'Dra' }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['suggestions']).to include('Drake')
+          expect(data['field']).to eq('artist')
+        end
+      end
+
+      response '200', 'Year suggestions' do
+        example 'application/json', :year_suggestions, {
+          suggestions: [2024, 2023, 2022],
+          field: 'year'
+        }
+
+        let!(:song) { create(:song, release_date: Date.new(2023, 6, 1)) }
+        let(:field) { 'year' }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['suggestions']).to include(2023)
+        end
+      end
+
+      response '200', 'Available fields when no field specified' do
+        example 'application/json', :available_fields, {
+          suggestions: %w[artist title album year_from year_to],
+          field: nil
+        }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['suggestions']).to eq(%w[artist title album year_from year_to])
+        end
+      end
+    end
+  end
+
   path '/api/v1/songs/{id}' do
     get 'Get a song' do
       tags 'Songs'

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -400,6 +400,108 @@ paths:
                 empty_results:
                   value:
                     data: []
+  "/api/v1/artists/search":
+    get:
+      summary: Faceted search for artists
+      tags:
+      - Artists
+      description: Search artists with structured filters. All filters are optional
+        and combinable.
+      parameters:
+      - name: q
+        in: query
+        required: false
+        description: Free text search on artist name
+        schema:
+          type: string
+      - name: name
+        in: query
+        required: false
+        description: Filter by artist name (fuzzy match)
+        schema:
+          type: string
+      - name: genre
+        in: query
+        required: false
+        description: Filter by genre
+        schema:
+          type: string
+      - name: country
+        in: query
+        required: false
+        description: Filter by country of origin
+        schema:
+          type: string
+      - name: limit
+        in: query
+        required: false
+        description: 'Maximum number of results (default: 10, max: 20)'
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: Returns artists ordered by popularity
+          content:
+            application/json:
+              examples:
+                with_genre_filter:
+                  value:
+                    data:
+                    - id: '1'
+                      type: artist
+                      attributes:
+                        id: 1
+                        name: Coldplay
+                        genres:
+                        - rock
+                        - pop
+                        country_of_origin:
+                        - United Kingdom
+  "/api/v1/artists/search_suggestions":
+    get:
+      summary: Get search suggestions for a field
+      tags:
+      - Artists
+      description: Returns autocomplete suggestions for a specific artist search field
+      parameters:
+      - name: field
+        in: query
+        required: false
+        description: 'Field to suggest values for: name, genre, country'
+        schema:
+          type: string
+      - name: q
+        in: query
+        required: false
+        description: Partial input to filter suggestions
+        schema:
+          type: string
+      - name: limit
+        in: query
+        required: false
+        description: 'Maximum suggestions (default: 5, max: 10)'
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: Available fields when no field specified
+          content:
+            application/json:
+              examples:
+                genre_suggestions:
+                  value:
+                    suggestions:
+                    - rock
+                    - pop
+                    - hip-hop
+                    field: genre
+                available_fields:
+                  value:
+                    suggestions:
+                    - name
+                    - genre
+                    - country
+                    field:
   "/api/v1/artists/{id}":
     get:
       summary: Get an artist
@@ -2600,6 +2702,127 @@ paths:
                 empty_results:
                   value:
                     data: []
+  "/api/v1/songs/search":
+    get:
+      summary: Faceted search for songs
+      tags:
+      - Songs
+      description: Search songs with structured filters. All filters are optional
+        and combinable.
+      parameters:
+      - name: q
+        in: query
+        required: false
+        description: Free text search across title and artist
+        schema:
+          type: string
+      - name: artist
+        in: query
+        required: false
+        description: Filter by artist name (fuzzy match)
+        schema:
+          type: string
+      - name: title
+        in: query
+        required: false
+        description: Filter by song title (fuzzy match)
+        schema:
+          type: string
+      - name: album
+        in: query
+        required: false
+        description: Filter by album name
+        schema:
+          type: string
+      - name: year_from
+        in: query
+        required: false
+        description: Filter songs released in or after this year
+        schema:
+          type: integer
+      - name: year_to
+        in: query
+        required: false
+        description: Filter songs released in or before this year
+        schema:
+          type: integer
+      - name: limit
+        in: query
+        required: false
+        description: 'Maximum number of results (default: 10, max: 20)'
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: Returns songs ordered by popularity
+          content:
+            application/json:
+              examples:
+                with_artist_filter:
+                  value:
+                    data:
+                    - id: '1'
+                      type: song
+                      attributes:
+                        id: 1
+                        title: Hotline Bling
+                        spotify_artwork_url: https://i.scdn.co/image/abc123
+                        artists:
+                        - id: 1
+                          name: Drake
+  "/api/v1/songs/search_suggestions":
+    get:
+      summary: Get search suggestions for a field
+      tags:
+      - Songs
+      description: Returns autocomplete suggestions for a specific song search field
+      parameters:
+      - name: field
+        in: query
+        required: false
+        description: 'Field to suggest values for: artist, title, album, year'
+        schema:
+          type: string
+      - name: q
+        in: query
+        required: false
+        description: Partial input to filter suggestions
+        schema:
+          type: string
+      - name: limit
+        in: query
+        required: false
+        description: 'Maximum suggestions (default: 5, max: 10)'
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: Available fields when no field specified
+          content:
+            application/json:
+              examples:
+                artist_suggestions:
+                  value:
+                    suggestions:
+                    - Drake
+                    - Dua Lipa
+                    field: artist
+                year_suggestions:
+                  value:
+                    suggestions:
+                    - 2024
+                    - 2023
+                    - 2022
+                    field: year
+                available_fields:
+                  value:
+                    suggestions:
+                    - artist
+                    - title
+                    - album
+                    - year_from
+                    - year_to
+                    field:
   "/api/v1/songs/{id}":
     get:
       summary: Get a song


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/songs/search` with filters: `artist`, `title`, `album`, `year_from`, `year_to`, `q` (free text)
- Adds `GET /api/v1/artists/search` with filters: `name`, `genre`, `country`, `q` (free text)
- Adds `GET /api/v1/songs/search_suggestions` and `GET /api/v1/artists/search_suggestions` for contextual field autocomplete
- Uses Arel query building with PostgreSQL trigram + ILIKE fuzzy matching and `sanitize_sql_like` for input safety
- Year filtering supports ranges via `year_from`/`year_to` (>= / <=)

Closes #2022

## Test plan
- [x] RSpec request specs for all new endpoints (search, suggestions, combined filters, edge cases)
- [x] Rubocop passes with no offenses
- [x] Swagger docs regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)