### PR TITLE
Add LLM-powered fallbacks to song import for edge cases

### DIFF
--- a/app/models/song_import_log.rb
+++ b/app/models/song_import_log.rb
@@ -18,6 +18,8 @@
 #  itunes_artist           :string
 #  itunes_raw_response     :jsonb
 #  itunes_title            :string
+#  llm_action              :string
+#  llm_raw_response        :jsonb
 #  recognized_artist       :string
 #  recognized_isrc         :string
 #  recognized_raw_response :jsonb
@@ -70,6 +72,7 @@ class SongImportLog < ApplicationRecord
     spotify_artist spotify_title spotify_track_id spotify_isrc
     deezer_artist deezer_title deezer_track_id
     itunes_artist itunes_title itunes_track_id
+    llm_action
     status failure_reason broadcasted_at created_at updated_at
   ].freeze
 

--- a/app/serializers/song_import_log_serializer.rb
+++ b/app/serializers/song_import_log_serializer.rb
@@ -18,6 +18,8 @@
 #  itunes_artist           :string
 #  itunes_raw_response     :jsonb
 #  itunes_title            :string
+#  llm_action              :string
+#  llm_raw_response        :jsonb
 #  recognized_artist       :string
 #  recognized_isrc         :string
 #  recognized_raw_response :jsonb

--- a/app/services/llm/alternative_search_queries.rb
+++ b/app/services/llm/alternative_search_queries.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Llm
+  class AlternativeSearchQueries < Base
+    MAX_QUERIES = 3
+
+    attr_reader :raw_response
+
+    def initialize(artist_name:, title:)
+      super()
+      @artist_name = artist_name
+      @title = title
+      @raw_response = {}
+    end
+
+    def generate
+      response = chat(system_prompt: system_prompt, user_message: user_message, max_tokens: 256)
+      @raw_response = { request: user_message.strip, response: response }
+      return [] if response.blank?
+
+      parse_queries(response)
+    end
+
+    private
+
+    def system_prompt
+      <<~PROMPT
+        You are a music search expert. A Spotify search for a song returned no results.
+        Generate 2-3 alternative search queries that might find the song.
+
+        Consider:
+        - Removing featured artists from the title or artist field
+        - Fixing common .titleize capitalization errors (e.g., "Dj" → "DJ", "Mc" → "MC")
+        - Restoring special characters (e.g., "Tiesto" → "Tiësto", "Beyonce" → "Beyoncé")
+        - Trying the international/English title if it looks like a Dutch translation
+        - Removing parenthetical suffixes like "(Radio Edit)", "(Official Audio)", "(Live)"
+        - Removing radio station tags or prefixes from the title
+        - Simplifying punctuation
+
+        Return ONLY a JSON array of objects with "artist" and "title" keys. No explanation.
+        Example: [{"artist": "Tiësto", "title": "Red Lights"}, {"artist": "DJ Tiësto", "title": "Red Lights"}]
+      PROMPT
+    end
+
+    def user_message
+      "Artist: #{@artist_name}\nTitle: #{@title}"
+    end
+
+    def parse_queries(response)
+      json = extract_json(response)
+      return [] if json.blank?
+
+      parsed = JSON.parse(json)
+      return [] unless parsed.is_a?(Array)
+
+      parsed.select { |q| q['artist'].present? && q['title'].present? }.first(MAX_QUERIES)
+    rescue JSON::ParserError => e
+      Rails.logger.warn("[LLM::AlternativeSearchQueries] Failed to parse JSON: #{e.message}")
+      []
+    end
+  end
+end

--- a/app/services/llm/base.rb
+++ b/app/services/llm/base.rb
@@ -45,5 +45,12 @@ module Llm
     def extract_text(response)
       response.dig('choices', 0, 'message', 'content')
     end
+
+    def extract_json(text)
+      match = text.match(/```(?:json)?\s*([{\[].*?[}\]])\s*```/m)
+      return match[1] if match
+
+      text.strip
+    end
   end
 end

--- a/app/services/llm/borderline_match_validator.rb
+++ b/app/services/llm/borderline_match_validator.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Llm
+  class BorderlineMatchValidator < Base
+    BORDERLINE_TITLE_RANGE = (60...70)
+
+    attr_reader :raw_response
+
+    def initialize(scraped_title:, scraped_artist:, matched_title:, matched_artist:)
+      super()
+      @scraped_title = scraped_title
+      @scraped_artist = scraped_artist
+      @matched_title = matched_title
+      @matched_artist = matched_artist
+      @raw_response = {}
+    end
+
+    def same_song?
+      response = chat(system_prompt: system_prompt, user_message: user_message, max_tokens: 64)
+      @raw_response = { request: user_message.strip, response: response }
+      return false if response.blank?
+
+      response.strip.downcase.start_with?('yes')
+    end
+
+    private
+
+    def system_prompt
+      <<~PROMPT
+        You are a music metadata expert. Given a scraped radio song and a potential Spotify match,
+        determine if they are the SAME song. Variations like "(Radio Edit)", "(Remastered)", "(Live)",
+        "(Acoustic Version)", or subtitle differences after " - " are still the same song.
+        Different songs by the same artist are NOT the same song.
+
+        Answer ONLY "yes" or "no".
+      PROMPT
+    end
+
+    def user_message
+      <<~MSG
+        Scraped: "#{@scraped_artist} - #{@scraped_title}"
+        Spotify: "#{@matched_artist} - #{@matched_title}"
+      MSG
+    end
+  end
+end

--- a/app/services/llm/query_translator.rb
+++ b/app/services/llm/query_translator.rb
@@ -85,13 +85,6 @@ module Llm
       {}
     end
 
-    def extract_json(text)
-      match = text.match(/```(?:json)?\s*(\{.*?\})\s*```/m)
-      return match[1] if match
-
-      text.strip
-    end
-
     def normalize_filters(parsed)
       filters = extract_string_filters(parsed)
       filters[:search_type] = parsed['search_type'] if SEARCH_TYPES.include?(parsed['search_type'])

--- a/app/services/llm/track_name_cleaner.rb
+++ b/app/services/llm/track_name_cleaner.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Llm
+  class TrackNameCleaner < Base
+    attr_reader :raw_response
+
+    def initialize(artist_name:, title:)
+      super()
+      @artist_name = artist_name
+      @title = title
+      @raw_response = {}
+    end
+
+    def clean
+      response = chat(system_prompt: system_prompt, user_message: user_message, max_tokens: 256)
+      @raw_response = { request: user_message.strip, response: response }
+      return nil if response.blank?
+
+      parse_response(response)
+    end
+
+    private
+
+    def system_prompt
+      <<~PROMPT
+        You are a music metadata expert. You receive raw artist name and song title from a Dutch radio station
+        scraper or audio recognizer. Clean them up so they can be used to search on Spotify.
+
+        Fix these common issues:
+        - .titleize capitalization errors: "Dj Tiesto" → "DJ Tiësto", "Mc Hammer" → "MC Hammer"
+        - Missing diacritics: "Beyonce" → "Beyoncé", "Tiesto" → "Tiësto", "Suze" → "Suzé"
+        - Radio station tags in titles: remove station names, "Radio 538 versie", etc.
+        - Chart position prefixes: "#1: ", "89. ", etc.
+        - Unnecessary suffixes: "(Official Audio)", "(Official Video)", "(Lyric Video)"
+        - Featured artists in the wrong field: move them from title to artist if needed
+        - Combined artist names: keep them but fix spelling/capitalization
+
+        Return ONLY a JSON object with "artist" and "title" keys. No explanation.
+        Example: {"artist": "DJ Tiësto", "title": "Red Lights"}
+      PROMPT
+    end
+
+    def user_message
+      "Artist: #{@artist_name}\nTitle: #{@title}"
+    end
+
+    def parse_response(response)
+      json = extract_json(response)
+      return nil if json.blank?
+
+      parsed = JSON.parse(json)
+      return nil unless parsed.is_a?(Hash) && parsed['artist'].present? && parsed['title'].present?
+      return nil if parsed['artist'] == @artist_name && parsed['title'] == @title
+
+      parsed
+    rescue JSON::ParserError => e
+      Rails.logger.warn("[LLM::TrackNameCleaner] Failed to parse JSON: #{e.message}")
+      nil
+    end
+  end
+end

--- a/app/services/song_import_logger.rb
+++ b/app/services/song_import_logger.rb
@@ -90,6 +90,15 @@ class SongImportLogger
     )
   end
 
+  def log_llm(action:, raw_response:)
+    return unless @log
+
+    @log.update(
+      llm_action: action,
+      llm_raw_response: raw_response || {}
+    )
+  end
+
   def complete_log(song:, air_play:)
     return unless @log
 

--- a/app/services/song_importer/concerns/track_finding.rb
+++ b/app/services/song_importer/concerns/track_finding.rb
@@ -10,9 +10,14 @@ module SongImporter::Concerns
       @track ||= spotify_track_if_valid || itunes_track_if_valid || deezer_track_if_valid || llm_cleaned_track
     end
 
+    def llm_import_enabled?
+      ENV.fetch('LLM_IMPORT_ENABLED', 'true') == 'true'
+    end
+
     def spotify_track_if_valid
       result = spotify_track
       return result if result&.valid_match?
+      return nil unless llm_import_enabled?
 
       # Try alternative search queries when Spotify returned no results at all
       if no_spotify_results?(result)
@@ -111,6 +116,8 @@ module SongImporter::Concerns
 
     # Feature 1: Clean up artist/title via LLM and retry Spotify as last resort
     def llm_cleaned_track
+      return nil unless llm_import_enabled?
+
       service = Llm::TrackNameCleaner.new(artist_name: artist_name, title: title)
       cleaned = service.clean
       @import_logger.log_llm(action: 'track_name_cleanup', raw_response: service.raw_response)

--- a/app/services/song_importer/concerns/track_finding.rb
+++ b/app/services/song_importer/concerns/track_finding.rb
@@ -7,12 +7,23 @@ module SongImporter::Concerns
     private
 
     def track
-      @track ||= spotify_track_if_valid || itunes_track_if_valid || deezer_track_if_valid
+      @track ||= spotify_track_if_valid || itunes_track_if_valid || deezer_track_if_valid || llm_cleaned_track
     end
 
     def spotify_track_if_valid
       result = spotify_track
-      result&.valid_match? ? result : nil
+      return result if result&.valid_match?
+
+      # Try alternative search queries when Spotify returned no results at all
+      if no_spotify_results?(result)
+        alt_result = spotify_track_with_alternative_queries
+        return alt_result if alt_result&.valid_match?
+      end
+
+      # Ask GPT to validate borderline title matches (60-69% title similarity, artist already passes)
+      return llm_validated_spotify_track(result) if borderline_match?(result)
+
+      nil
     end
 
     def itunes_track_if_valid
@@ -47,6 +58,71 @@ module SongImporter::Concerns
         @import_logger.log_itunes(result) if result&.valid_match?
         result
       end
+    end
+
+    # Feature 5: Generate alternative search queries via LLM when Spotify returned no results
+    def spotify_track_with_alternative_queries
+      service = Llm::AlternativeSearchQueries.new(artist_name: artist_name, title: title)
+      alternatives = service.generate
+      @import_logger.log_llm(action: 'alternative_search_queries', raw_response: service.raw_response)
+      return nil if alternatives.blank?
+
+      alternatives.each do |alt|
+        alt_result = Spotify::TrackFinder::Result.new(artists: alt['artist'], title: alt['title'])
+        alt_result.execute
+        next unless alt_result.valid_match?
+
+        Rails.logger.info("[LLM] Alternative query matched: '#{alt['artist']} - #{alt['title']}'")
+        @import_logger.log_spotify(alt_result)
+        return alt_result
+      end
+      nil
+    end
+
+    def no_spotify_results?(result)
+      return true if result.blank?
+
+      result.track.blank? && result.spotify_query_result&.dig('tracks', 'items').blank?
+    end
+
+    # Feature 4: Validate borderline matches where title similarity is 60-69% but artist passes
+    def borderline_match?(result)
+      return false if result.blank? || result.track.blank?
+
+      result.matched_artist_distance.to_i >= Spotify::Base::ARTIST_SIMILARITY_THRESHOLD &&
+        Llm::BorderlineMatchValidator::BORDERLINE_TITLE_RANGE.cover?(result.matched_title_distance.to_i)
+    end
+
+    def llm_validated_spotify_track(result)
+      matched_artist = result.artists&.filter_map { |a| a&.dig('name') }&.join(', ')
+      validator = Llm::BorderlineMatchValidator.new(
+        scraped_title: title,
+        scraped_artist: artist_name,
+        matched_title: result.title,
+        matched_artist: matched_artist
+      )
+      is_same = validator.same_song?
+      @import_logger.log_llm(action: 'borderline_match_validation', raw_response: validator.raw_response)
+      return nil unless is_same
+
+      Rails.logger.info("[LLM] Borderline match validated: '#{title}' ≈ '#{result.title}'")
+      result
+    end
+
+    # Feature 1: Clean up artist/title via LLM and retry Spotify as last resort
+    def llm_cleaned_track
+      service = Llm::TrackNameCleaner.new(artist_name: artist_name, title: title)
+      cleaned = service.clean
+      @import_logger.log_llm(action: 'track_name_cleanup', raw_response: service.raw_response)
+      return nil if cleaned.blank?
+
+      Rails.logger.info("[LLM] Track name cleaned: '#{artist_name}' → '#{cleaned['artist']}', '#{title}' → '#{cleaned['title']}'")
+      cleaned_result = Spotify::TrackFinder::Result.new(artists: cleaned['artist'], title: cleaned['title'])
+      cleaned_result.execute
+      return nil unless cleaned_result.valid_match?
+
+      @import_logger.log_spotify(cleaned_result)
+      cleaned_result
     end
   end
 end

--- a/db/migrate/20260413081110_add_llm_fields_to_song_import_logs.rb
+++ b/db/migrate/20260413081110_add_llm_fields_to_song_import_logs.rb
@@ -1,0 +1,6 @@
+class AddLlmFieldsToSongImportLogs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :song_import_logs, :llm_action, :string
+    add_column :song_import_logs, :llm_raw_response, :jsonb, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_03_185447) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_13_081110) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -198,6 +198,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_03_185447) do
     t.jsonb "itunes_raw_response", default: {}
     t.string "itunes_title"
     t.string "itunes_track_id"
+    t.string "llm_action"
+    t.jsonb "llm_raw_response", default: {}
     t.bigint "radio_station_id", null: false
     t.string "recognized_artist"
     t.string "recognized_isrc"

--- a/spec/models/song_import_log_spec.rb
+++ b/spec/models/song_import_log_spec.rb
@@ -18,6 +18,8 @@
 #  itunes_artist           :string
 #  itunes_raw_response     :jsonb
 #  itunes_title            :string
+#  llm_action              :string
+#  llm_raw_response        :jsonb
 #  recognized_artist       :string
 #  recognized_isrc         :string
 #  recognized_raw_response :jsonb

--- a/spec/services/llm/alternative_search_queries_spec.rb
+++ b/spec/services/llm/alternative_search_queries_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Llm::AlternativeSearchQueries, type: :service do
+  let(:service) { described_class.new(artist_name: artist_name, title: title) }
+  let(:artist_name) { 'Dj Tiesto' }
+  let(:title) { 'Red Lights (Radio 538 Versie)' }
+
+  describe '#generate' do
+    subject(:generate) { service.generate }
+
+    context 'when the LLM returns valid alternative queries' do
+      let(:llm_response) do
+        [
+          { artist: 'Tiësto', title: 'Red Lights' },
+          { artist: 'DJ Tiësto', title: 'Red Lights' }
+        ].to_json
+      end
+
+      before do
+        allow(service).to receive(:chat).and_return(llm_response)
+      end
+
+      it 'returns parsed query alternatives', :aggregate_failures do
+        expect(generate.length).to eq(2)
+        expect(generate.first['artist']).to eq('Tiësto')
+        expect(generate.first['title']).to eq('Red Lights')
+      end
+    end
+
+    context 'when the LLM returns JSON wrapped in markdown code blocks' do
+      let(:llm_response) do
+        "```json\n[{\"artist\": \"Tiësto\", \"title\": \"Red Lights\"}]\n```"
+      end
+
+      before do
+        allow(service).to receive(:chat).and_return(llm_response)
+      end
+
+      it 'extracts and parses the JSON' do
+        expect(generate.length).to eq(1)
+      end
+    end
+
+    context 'when the LLM returns more than MAX_QUERIES results' do
+      let(:llm_response) do
+        [
+          { artist: 'A', title: 'T1' },
+          { artist: 'B', title: 'T2' },
+          { artist: 'C', title: 'T3' },
+          { artist: 'D', title: 'T4' }
+        ].to_json
+      end
+
+      before do
+        allow(service).to receive(:chat).and_return(llm_response)
+      end
+
+      it 'limits results to MAX_QUERIES' do
+        expect(generate.length).to eq(3)
+      end
+    end
+
+    context 'when the LLM returns entries with blank fields' do
+      let(:llm_response) do
+        [
+          { artist: '', title: 'Red Lights' },
+          { artist: 'Tiësto', title: '' },
+          { artist: 'Tiësto', title: 'Red Lights' }
+        ].to_json
+      end
+
+      before do
+        allow(service).to receive(:chat).and_return(llm_response)
+      end
+
+      it 'filters out entries with blank artist or title', :aggregate_failures do
+        expect(generate.length).to eq(1)
+        expect(generate.first['artist']).to eq('Tiësto')
+      end
+    end
+
+    context 'when the LLM returns nil' do
+      before do
+        allow(service).to receive(:chat).and_return(nil)
+      end
+
+      it 'returns an empty array' do
+        expect(generate).to eq([])
+      end
+    end
+
+    context 'when the LLM returns invalid JSON' do
+      before do
+        allow(service).to receive(:chat).and_return('not valid json')
+      end
+
+      it 'returns an empty array' do
+        expect(generate).to eq([])
+      end
+    end
+
+    context 'when the LLM returns a hash instead of an array' do
+      before do
+        allow(service).to receive(:chat).and_return('{"artist": "Tiësto", "title": "Red Lights"}')
+      end
+
+      it 'returns an empty array' do
+        expect(generate).to eq([])
+      end
+    end
+  end
+end

--- a/spec/services/llm/borderline_match_validator_spec.rb
+++ b/spec/services/llm/borderline_match_validator_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Llm::BorderlineMatchValidator, type: :service do
+  let(:validator) do
+    described_class.new(
+      scraped_title: scraped_title,
+      scraped_artist: scraped_artist,
+      matched_title: matched_title,
+      matched_artist: matched_artist
+    )
+  end
+
+  let(:scraped_artist) { 'The Weeknd' }
+  let(:scraped_title) { 'Blinding Lights' }
+  let(:matched_artist) { 'The Weeknd' }
+  let(:matched_title) { 'Blinding Lights (Radio Edit)' }
+
+  describe '#same_song?' do
+    subject(:same_song) { validator.same_song? }
+
+    context 'when the LLM confirms the songs match' do
+      before do
+        allow(validator).to receive(:chat).and_return('yes')
+      end
+
+      it 'returns true' do
+        expect(same_song).to be true
+      end
+    end
+
+    context 'when the LLM confirms with additional text' do
+      before do
+        allow(validator).to receive(:chat).and_return('Yes, these are the same song.')
+      end
+
+      it 'returns true' do
+        expect(same_song).to be true
+      end
+    end
+
+    context 'when the LLM says the songs do not match' do
+      before do
+        allow(validator).to receive(:chat).and_return('no')
+      end
+
+      it 'returns false' do
+        expect(same_song).to be false
+      end
+    end
+
+    context 'when the LLM returns nil' do
+      before do
+        allow(validator).to receive(:chat).and_return(nil)
+      end
+
+      it 'returns false' do
+        expect(same_song).to be false
+      end
+    end
+
+    context 'when the LLM returns an empty string' do
+      before do
+        allow(validator).to receive(:chat).and_return('')
+      end
+
+      it 'returns false' do
+        expect(same_song).to be false
+      end
+    end
+
+    context 'when the LLM returns unexpected text' do
+      before do
+        allow(validator).to receive(:chat).and_return('I am not sure about this match')
+      end
+
+      it 'returns false' do
+        expect(same_song).to be false
+      end
+    end
+  end
+
+  describe 'BORDERLINE_TITLE_RANGE' do
+    it 'covers 60 through 69', :aggregate_failures do
+      expect(described_class::BORDERLINE_TITLE_RANGE).to cover(60)
+      expect(described_class::BORDERLINE_TITLE_RANGE).to cover(69)
+      expect(described_class::BORDERLINE_TITLE_RANGE).not_to cover(70)
+      expect(described_class::BORDERLINE_TITLE_RANGE).not_to cover(59)
+    end
+  end
+end

--- a/spec/services/llm/track_name_cleaner_spec.rb
+++ b/spec/services/llm/track_name_cleaner_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Llm::TrackNameCleaner, type: :service do
+  let(:service) { described_class.new(artist_name: artist_name, title: title) }
+  let(:artist_name) { 'Dj Tiesto' }
+  let(:title) { 'Red Lights - Radio 538 Versie' }
+
+  describe '#clean' do
+    subject(:clean) { service.clean }
+
+    context 'when the LLM returns cleaned data' do
+      let(:llm_response) { '{"artist": "DJ Tiësto", "title": "Red Lights"}' }
+
+      before do
+        allow(service).to receive(:chat).and_return(llm_response)
+      end
+
+      it 'returns the cleaned artist and title', :aggregate_failures do
+        expect(clean['artist']).to eq('DJ Tiësto')
+        expect(clean['title']).to eq('Red Lights')
+      end
+    end
+
+    context 'when the LLM returns JSON wrapped in markdown code blocks' do
+      let(:llm_response) { "```json\n{\"artist\": \"DJ Tiësto\", \"title\": \"Red Lights\"}\n```" }
+
+      before do
+        allow(service).to receive(:chat).and_return(llm_response)
+      end
+
+      it 'extracts and parses the JSON', :aggregate_failures do
+        expect(clean['artist']).to eq('DJ Tiësto')
+        expect(clean['title']).to eq('Red Lights')
+      end
+    end
+
+    context 'when the LLM returns the same artist and title as input' do
+      let(:llm_response) { { artist: artist_name, title: title }.to_json }
+
+      before do
+        allow(service).to receive(:chat).and_return(llm_response)
+      end
+
+      it 'returns nil to avoid duplicate searches' do
+        expect(clean).to be_nil
+      end
+    end
+
+    context 'when the LLM returns a response with blank artist' do
+      let(:llm_response) { '{"artist": "", "title": "Red Lights"}' }
+
+      before do
+        allow(service).to receive(:chat).and_return(llm_response)
+      end
+
+      it 'returns nil' do
+        expect(clean).to be_nil
+      end
+    end
+
+    context 'when the LLM returns nil' do
+      before do
+        allow(service).to receive(:chat).and_return(nil)
+      end
+
+      it 'returns nil' do
+        expect(clean).to be_nil
+      end
+    end
+
+    context 'when the LLM returns invalid JSON' do
+      before do
+        allow(service).to receive(:chat).and_return('not valid json at all')
+      end
+
+      it 'returns nil' do
+        expect(clean).to be_nil
+      end
+    end
+
+    context 'when the LLM returns an array instead of a hash' do
+      before do
+        allow(service).to receive(:chat).and_return('[{"artist": "DJ Tiësto", "title": "Red Lights"}]')
+      end
+
+      it 'returns nil' do
+        expect(clean).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/song_import_logger_spec.rb
+++ b/spec/services/song_import_logger_spec.rb
@@ -295,6 +295,25 @@ describe SongImportLogger do
     end
   end
 
+  describe '#log_llm' do
+    before { logger.start_log }
+
+    it 'updates llm_action' do
+      logger.log_llm(action: 'borderline_match_validation', raw_response: { request: 'test', response: 'yes' })
+      expect(logger.log.llm_action).to eq('borderline_match_validation')
+    end
+
+    it 'stores the raw LLM response' do
+      logger.log_llm(action: 'track_name_cleanup', raw_response: { request: 'Artist: Dj Tiesto', response: '{"artist":"Tiësto"}' })
+      expect(logger.log.llm_raw_response).to eq({ 'request' => 'Artist: Dj Tiesto', 'response' => '{"artist":"Tiësto"}' })
+    end
+
+    it 'does nothing if log is nil' do
+      new_logger = described_class.new(radio_station:)
+      expect { new_logger.log_llm(action: 'test', raw_response: {}) }.not_to raise_error
+    end
+  end
+
   describe '#complete_log' do
     let(:song) { create(:song) }
     let(:air_play) { create(:air_play, song:) }

--- a/spec/services/song_importer/concerns/track_finding_spec.rb
+++ b/spec/services/song_importer/concerns/track_finding_spec.rb
@@ -44,6 +44,27 @@ RSpec.describe SongImporter::Concerns::TrackFinding do
       )
     end
 
+    describe '#llm_import_enabled?' do
+      context 'when LLM_IMPORT_ENABLED is set to false' do
+        before do
+          allow(ENV).to receive(:fetch).and_call_original
+          allow(ENV).to receive(:fetch).with('LLM_IMPORT_ENABLED', 'true').and_return('false')
+          allow(Llm::AlternativeSearchQueries).to receive(:new)
+          allow(Llm::TrackNameCleaner).to receive(:new)
+
+          stub_request(:get, %r{api\.spotify\.com/v1/search})
+            .to_return(status: 200, body: spotify_empty_response.to_json,
+                       headers: { 'Content-Type' => 'application/json' })
+        end
+
+        it 'skips all LLM features and returns nil', :aggregate_failures do
+          song_importer.send(:track)
+          expect(Llm::AlternativeSearchQueries).not_to have_received(:new)
+          expect(Llm::TrackNameCleaner).not_to have_received(:new)
+        end
+      end
+    end
+
     describe '#spotify_track_with_alternative_queries (Feature 5)' do
       let(:valid_spotify_response) do
         {

--- a/spec/services/song_importer/concerns/track_finding_spec.rb
+++ b/spec/services/song_importer/concerns/track_finding_spec.rb
@@ -1,0 +1,243 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe SongImporter::Concerns::TrackFinding do
+  let(:radio_station) { create(:radio_station) }
+  let(:song_importer) { SongImporter.new(radio_station:) }
+  let(:played_song) do
+    instance_double(
+      SongRecognizer,
+      title: title,
+      artist_name: artist_name,
+      spotify_url: nil,
+      isrc_code: nil,
+      broadcasted_at: Time.current
+    )
+  end
+  let(:import_logger) { instance_double(SongImportLogger, log_spotify: nil, log_deezer: nil, log_itunes: nil, log_llm: nil) }
+
+  before do
+    song_importer.instance_variable_set(:@played_song, played_song)
+    song_importer.instance_variable_set(:@import_logger, import_logger)
+  end
+
+  describe 'LLM-enhanced track finding' do
+    let(:title) { 'Red Lights - Radio 538 Versie' }
+    let(:artist_name) { 'Dj Tiesto' }
+    let(:spotify_empty_response) { { 'tracks' => { 'items' => [] } } }
+
+    before do
+      stub_request(:post, 'https://accounts.spotify.com/api/token')
+        .to_return(
+          status: 200,
+          body: { access_token: 'test_token', token_type: 'Bearer', expires_in: 3600 }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+
+      stub_request(:get, /api\.deezer\.com/).to_return(
+        status: 200, body: { 'data' => [] }.to_json, headers: { 'Content-Type' => 'application/json' }
+      )
+      stub_request(:get, /itunes\.apple\.com/).to_return(
+        status: 200, body: { 'resultCount' => 0, 'results' => [] }.to_json,
+        headers: { 'Content-Type' => 'application/json' }
+      )
+    end
+
+    describe '#spotify_track_with_alternative_queries (Feature 5)' do
+      let(:valid_spotify_response) do
+        {
+          'tracks' => {
+            'items' => [
+              build_spotify_track_item(id: 'spotify_alt', name: 'Red Lights', artist_name: 'Tiësto')
+            ]
+          }
+        }
+      end
+      let(:alt_queries_double) { instance_double(Llm::AlternativeSearchQueries, raw_response: {}) }
+      let(:cleaner_double) { instance_double(Llm::TrackNameCleaner, clean: nil, raw_response: {}) }
+
+      before do
+        stub_request(:get, %r{api\.spotify\.com/v1/search\?q=.*tiesto})
+          .to_return(status: 200, body: spotify_empty_response.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        stub_request(:get, %r{api\.spotify\.com/v1/search\?q=.*ti%C3%ABsto})
+          .to_return(status: 200, body: valid_spotify_response.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        stub_request(:get, %r{api\.spotify\.com/v1/artists/})
+          .to_return(status: 200,
+                     body: { 'id' => 'tiesto1', 'name' => 'Tiësto', 'images' => [] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        allow(Llm::AlternativeSearchQueries).to receive(:new).and_return(alt_queries_double)
+        allow(Llm::TrackNameCleaner).to receive(:new).and_return(cleaner_double)
+      end
+
+      context 'when LLM generates alternative queries that find a match' do
+        before do
+          allow(alt_queries_double).to receive(:generate).and_return(
+            [{ 'artist' => 'Tiësto', 'title' => 'Red Lights' }]
+          )
+        end
+
+        it 'returns the alternative match' do
+          expect(song_importer.send(:track)).to be_present
+        end
+
+        it 'logs the spotify result' do
+          song_importer.send(:track)
+          expect(import_logger).to have_received(:log_spotify).at_least(:once)
+        end
+      end
+
+      context 'when LLM returns no alternatives' do
+        before do
+          allow(alt_queries_double).to receive(:generate).and_return([])
+        end
+
+        it 'returns nil for the track' do
+          expect(song_importer.send(:track)).to be_nil
+        end
+      end
+    end
+
+    describe '#llm_validated_spotify_track (Feature 4)' do
+      let(:spotify_result_double) do
+        instance_double(
+          Spotify::TrackFinder::Result,
+          valid_match?: false,
+          track: { 'id' => 'test' },
+          matched_title_distance: 65,
+          matched_artist_distance: 85,
+          artists: [{ 'name' => 'Tiësto' }],
+          title: 'Red Lights (Deluxe Edition Remaster)',
+          spotify_query_result: { 'tracks' => { 'items' => [{ 'id' => 'test' }] } }
+        )
+      end
+      let(:spotify_finder_double) do
+        instance_double(TrackExtractor::SpotifyTrackFinder, find: spotify_result_double)
+      end
+      let(:validator_double) { instance_double(Llm::BorderlineMatchValidator, raw_response: {}) }
+      let(:cleaner_double) { instance_double(Llm::TrackNameCleaner, clean: nil, raw_response: {}) }
+
+      before do
+        allow(TrackExtractor::SpotifyTrackFinder).to receive(:new).and_return(spotify_finder_double)
+        allow(Llm::BorderlineMatchValidator).to receive(:new).and_return(validator_double)
+        allow(Llm::TrackNameCleaner).to receive(:new).and_return(cleaner_double)
+
+        stub_request(:get, /api\.deezer\.com/).to_return(
+          status: 200, body: { 'data' => [] }.to_json, headers: { 'Content-Type' => 'application/json' }
+        )
+        stub_request(:get, /itunes\.apple\.com/).to_return(
+          status: 200, body: { 'resultCount' => 0, 'results' => [] }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+
+      context 'when the match has borderline title similarity and LLM confirms' do
+        before do
+          allow(validator_double).to receive(:same_song?).and_return(true)
+        end
+
+        it 'returns the borderline match' do
+          expect(song_importer.send(:spotify_track_if_valid)).to eq(spotify_result_double)
+        end
+      end
+
+      context 'when the match has borderline title similarity and LLM rejects' do
+        before do
+          allow(validator_double).to receive(:same_song?).and_return(false)
+        end
+
+        it 'returns nil' do
+          expect(song_importer.send(:spotify_track_if_valid)).to be_nil
+        end
+      end
+    end
+
+    describe '#llm_cleaned_track (Feature 1)' do
+      let(:cleaned_spotify_response) do
+        {
+          'tracks' => {
+            'items' => [
+              build_spotify_track_item(id: 'spotify_cleaned', name: 'Red Lights', artist_name: 'Tiësto')
+            ]
+          }
+        }
+      end
+      let(:alt_queries_double) { instance_double(Llm::AlternativeSearchQueries, generate: [], raw_response: {}) }
+      let(:cleaner_double) { instance_double(Llm::TrackNameCleaner, raw_response: {}) }
+
+      before do
+        stub_request(:get, %r{api\.spotify\.com/v1/search\?q=.*tiesto})
+          .to_return(status: 200, body: spotify_empty_response.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        stub_request(:get, %r{api\.spotify\.com/v1/search\?q=.*ti%C3%ABsto})
+          .to_return(status: 200, body: cleaned_spotify_response.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        stub_request(:get, %r{api\.spotify\.com/v1/artists/})
+          .to_return(status: 200,
+                     body: { 'id' => 'tiesto1', 'name' => 'Tiësto', 'images' => [] }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+
+        allow(Llm::AlternativeSearchQueries).to receive(:new).and_return(alt_queries_double)
+        allow(Llm::TrackNameCleaner).to receive(:new).and_return(cleaner_double)
+      end
+
+      context 'when LLM cleans the track name and retry succeeds' do
+        before do
+          allow(cleaner_double).to receive(:clean).and_return(
+            { 'artist' => 'Tiësto', 'title' => 'Red Lights' }
+          )
+        end
+
+        it 'returns the cleaned match' do
+          expect(song_importer.send(:track)).to be_present
+        end
+
+        it 'logs the spotify result' do
+          song_importer.send(:track)
+          expect(import_logger).to have_received(:log_spotify).at_least(:once)
+        end
+      end
+
+      context 'when LLM cleanup returns nil' do
+        before do
+          allow(cleaner_double).to receive(:clean).and_return(nil)
+        end
+
+        it 'returns nil' do
+          expect(song_importer.send(:track)).to be_nil
+        end
+      end
+    end
+  end
+
+  private
+
+  def build_spotify_track_item(id:, name:, artist_name:, popularity: 70)
+    {
+      'id' => id,
+      'name' => name,
+      'popularity' => popularity,
+      'duration_ms' => 210_000,
+      'explicit' => false,
+      'album' => {
+        'artists' => [{ 'id' => "#{id}_artist", 'name' => artist_name }],
+        'album_type' => 'single',
+        'images' => [{ 'url' => 'https://example.com/image.jpg' }],
+        'release_date' => '2014-01-01',
+        'release_date_precision' => 'day',
+        'name' => name
+      },
+      'artists' => [{ 'id' => "#{id}_artist", 'name' => artist_name }],
+      'external_ids' => { 'isrc' => 'NL1234' },
+      'external_urls' => { 'spotify' => "https://open.spotify.com/track/#{id}" },
+      'preview_url' => nil
+    }
+  end
+end

--- a/spec/services/song_importer_edge_cases_spec.rb
+++ b/spec/services/song_importer_edge_cases_spec.rb
@@ -7,7 +7,8 @@ describe SongImporter do
   let(:import_logger) do
     instance_double(SongImportLogger, start_log: nil, log_scraping: nil, skip_log: nil,
                                       complete_log: nil, log_recognition: nil, log_acoustid: nil,
-                                      fail_log: nil, log_spotify: nil, log_deezer: nil, log_itunes: nil)
+                                      fail_log: nil, log_spotify: nil, log_deezer: nil, log_itunes: nil,
+                                      log_llm: nil)
   end
 
   before do
@@ -584,17 +585,23 @@ describe SongImporter do
     end
 
     describe 'when all track finders return invalid matches' do
-      let(:invalid_spotify) { instance_double(Spotify::TrackFinder::Result, valid_match?: false) }
+      let(:invalid_spotify) do
+        instance_double(Spotify::TrackFinder::Result, valid_match?: false, track: { 'id' => 'x' },
+                                                      matched_title_distance: 50, matched_artist_distance: 50,
+                                                      spotify_query_result: { 'tracks' => { 'items' => [{}] } })
+      end
       let(:invalid_itunes) { instance_double(Itunes::TrackFinder::Result, valid_match?: false) }
       let(:invalid_deezer) { instance_double(Deezer::TrackFinder::Result, valid_match?: false) }
       let(:spotify_finder) { instance_double(TrackExtractor::SpotifyTrackFinder, find: invalid_spotify) }
       let(:itunes_finder) { instance_double(TrackExtractor::ItunesTrackFinder, find: invalid_itunes) }
       let(:deezer_finder) { instance_double(TrackExtractor::DeezerTrackFinder, find: invalid_deezer) }
+      let(:cleaner_double) { instance_double(Llm::TrackNameCleaner, clean: nil, raw_response: {}) }
 
       before do
         allow(TrackExtractor::SpotifyTrackFinder).to receive(:new).and_return(spotify_finder)
         allow(TrackExtractor::ItunesTrackFinder).to receive(:new).and_return(itunes_finder)
         allow(TrackExtractor::DeezerTrackFinder).to receive(:new).and_return(deezer_finder)
+        allow(Llm::TrackNameCleaner).to receive(:new).and_return(cleaner_double)
       end
 
       it 'returns nil when no track has a valid match' do
@@ -618,7 +625,11 @@ describe SongImporter do
     end
 
     describe 'when Spotify invalid, iTunes invalid, Deezer valid' do
-      let(:invalid_spotify) { instance_double(Spotify::TrackFinder::Result, valid_match?: false) }
+      let(:invalid_spotify) do
+        instance_double(Spotify::TrackFinder::Result, valid_match?: false, track: { 'id' => 'x' },
+                                                      matched_title_distance: 50, matched_artist_distance: 50,
+                                                      spotify_query_result: { 'tracks' => { 'items' => [{}] } })
+      end
       let(:invalid_itunes) { instance_double(Itunes::TrackFinder::Result, valid_match?: false) }
       let(:valid_deezer) { instance_double(Deezer::TrackFinder::Result, valid_match?: true) }
       let(:spotify_finder) { instance_double(TrackExtractor::SpotifyTrackFinder, find: invalid_spotify) }


### PR DESCRIPTION
## Summary

- **Alternative Search Queries** — When Spotify search returns no results, GPT generates 2-3 alternative queries (fixes diacritics like Tiesto → Tiësto, strips station tags, tries spelling variants) and retries
- **Borderline Match Validation** — When Spotify returns a match with 60-69% title similarity (just below the 70% threshold), GPT validates whether it's actually the same song (handles remasters, radio edits, acoustic versions)
- **Track Name Cleanup** — Last resort when all three services (Spotify/iTunes/Deezer) fail: GPT cleans up raw scraper data (`.titleize` mangling, missing diacritics, station prefixes) and retries Spotify

All three use existing `Llm::Base` with 1-hour response caching, circuit breaker, and exponential backoff. Only fire on failures — estimated ~$2-5/month.

Also adds `llm_action` and `llm_raw_response` columns to `song_import_logs` for observability.

### Feature flag

Set `LLM_IMPORT_ENABLED=false` to disable all three LLM features without redeploying. Defaults to `true`.

## Test plan

- [x] Unit specs for all three LLM services (21 examples)
- [x] Integration specs for TrackFinding concern (9 examples incl. feature flag)
- [x] Logger spec for new `log_llm` method (3 examples)
- [x] Existing specs updated and passing (240+ total, 0 failures)
- [x] Rubocop clean on all changed files
- [ ] Deploy and monitor `song_import_logs.llm_action` to verify edge cases are being recovered
- [ ] Check OpenAI usage dashboard after a few days to confirm costs stay low

🤖 Generated with [Claude Code](https://claude.com/claude-code)