### PR TITLE
Skip unnecessary LLM track name cleanup calls

### DIFF
--- a/app/services/song_importer/concerns/track_finding.rb
+++ b/app/services/song_importer/concerns/track_finding.rb
@@ -4,6 +4,12 @@ module SongImporter::Concerns
   module TrackFinding
     extend ActiveSupport::Concern
 
+    # Patterns in scraped names that LLM cleanup can realistically fix
+    TITLEIZE_ARTIFACTS = /\b(?:Dj|Mc)\b/
+    NOISE_SUFFIXES = /\((?:Official|Radio|Live|Lyric|Video|Audio|Remix|Edit|feat)\b/i
+    CHART_PREFIX = /\A\s*#?\d+[.)\s:-]+\S/
+    STATION_TAGS = /\b(?:538|Qmusic|NPO|SLAM|Sky\s?Radio|3FM|Radio\s*\d)\b/i
+
     private
 
     def track
@@ -117,6 +123,7 @@ module SongImporter::Concerns
     # Feature 1: Clean up artist/title via LLM and retry Spotify as last resort
     def llm_cleaned_track
       return nil unless llm_import_enabled?
+      return nil unless worth_llm_cleanup?
 
       service = Llm::TrackNameCleaner.new(artist_name: artist_name, title: title)
       cleaned = service.clean
@@ -130,6 +137,23 @@ module SongImporter::Concerns
 
       @import_logger.log_spotify(cleaned_result)
       cleaned_result
+    end
+
+    # Skip LLM cleanup when Spotify already found a match — the search terms
+    # were adequate and cleanup can't bridge match-threshold gaps. Only proceed
+    # when Spotify returned nothing or the names have concrete fixable patterns.
+    def worth_llm_cleanup?
+      return true if no_spotify_results?(@spotify_track)
+
+      cleanup_patterns?(artist_name, title)
+    end
+
+    def cleanup_patterns?(artist, title)
+      text = "#{artist} #{title}"
+      TITLEIZE_ARTIFACTS.match?(text) ||
+        NOISE_SUFFIXES.match?(title) ||
+        CHART_PREFIX.match?(title) ||
+        STATION_TAGS.match?(title)
     end
   end
 end

--- a/spec/services/song_importer/concerns/track_finding_spec.rb
+++ b/spec/services/song_importer/concerns/track_finding_spec.rb
@@ -236,6 +236,84 @@ RSpec.describe SongImporter::Concerns::TrackFinding do
         end
       end
     end
+
+    describe '#worth_llm_cleanup?' do
+      context 'when Spotify found results with reasonable similarity' do
+        let(:title) { 'Slapeloze Nachten' }
+        let(:artist_name) { 'Opposites' }
+        let(:spotify_result_double) do
+          instance_double(
+            Spotify::TrackFinder::Result,
+            valid_match?: false,
+            track: { 'id' => 'test' },
+            matched_title_distance: 100,
+            matched_artist_distance: 78,
+            artists: [{ 'name' => 'The Opposites' }],
+            title: 'Slapeloze Nachten',
+            spotify_query_result: { 'tracks' => { 'items' => [{ 'id' => 'test' }] } }
+          )
+        end
+        let(:spotify_finder_double) do
+          instance_double(TrackExtractor::SpotifyTrackFinder, find: spotify_result_double)
+        end
+        let(:cleaner_double) { instance_double(Llm::TrackNameCleaner, clean: nil, raw_response: {}) }
+
+        before do
+          allow(TrackExtractor::SpotifyTrackFinder).to receive(:new).and_return(spotify_finder_double)
+          allow(Llm::TrackNameCleaner).to receive(:new).and_return(cleaner_double)
+          stub_request(:get, /api\.deezer\.com/).to_return(
+            status: 200, body: { 'data' => [] }.to_json, headers: { 'Content-Type' => 'application/json' }
+          )
+          stub_request(:get, /itunes\.apple\.com/).to_return(
+            status: 200, body: { 'resultCount' => 0, 'results' => [] }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+        end
+
+        it 'skips LLM cleanup' do
+          song_importer.send(:track)
+          expect(Llm::TrackNameCleaner).not_to have_received(:new)
+        end
+      end
+
+      context 'when Spotify found results but names have cleanup patterns' do
+        let(:title) { 'Red Lights (Radio 538 Versie)' }
+        let(:artist_name) { 'Dj Tiesto' }
+        let(:spotify_result_double) do
+          instance_double(
+            Spotify::TrackFinder::Result,
+            valid_match?: false,
+            track: { 'id' => 'test' },
+            matched_title_distance: 55,
+            matched_artist_distance: 75,
+            artists: [{ 'name' => 'Tiësto' }],
+            title: 'Red Lights',
+            spotify_query_result: { 'tracks' => { 'items' => [{ 'id' => 'test' }] } }
+          )
+        end
+        let(:spotify_finder_double) do
+          instance_double(TrackExtractor::SpotifyTrackFinder, find: spotify_result_double)
+        end
+        let(:cleaner_double) { instance_double(Llm::TrackNameCleaner, clean: nil, raw_response: {}) }
+
+        before do
+          allow(TrackExtractor::SpotifyTrackFinder).to receive(:new).and_return(spotify_finder_double)
+          allow(Llm::TrackNameCleaner).to receive(:new).and_return(cleaner_double)
+          stub_request(:get, /api\.deezer\.com/).to_return(
+            status: 200, body: { 'data' => [] }.to_json, headers: { 'Content-Type' => 'application/json' }
+          )
+          stub_request(:get, /itunes\.apple\.com/).to_return(
+            status: 200, body: { 'resultCount' => 0, 'results' => [] }.to_json,
+            headers: { 'Content-Type' => 'application/json' }
+          )
+        end
+
+        it 'proceeds with LLM cleanup' do
+          song_importer.send(:track)
+          expect(Llm::TrackNameCleaner).to have_received(:new)
+        end
+      end
+    end
   end
 
   private


### PR DESCRIPTION
## Summary
- Skip `llm_cleaned_track` when Spotify already found search results (even with low match scores), since the search terms were adequate and the LLM can't bridge match-threshold gaps
- Only proceed with LLM cleanup when Spotify returned zero results OR the scraped names contain concrete fixable patterns (titleize artifacts like `Dj`/`Mc`, noise suffixes, chart prefixes, station tags)
- Reduces unnecessary OpenAI API calls and import latency for the common case where names are clean but just slightly different from Spotify's canonical form (e.g., "Opposites" vs "The Opposites")

## Test plan
- [x] Existing `#llm_cleaned_track` tests pass (no Spotify results → cleanup still fires)
- [x] New test: Spotify found results with clean names → LLM cleanup skipped
- [x] New test: Spotify found results but names have cleanup patterns → LLM cleanup proceeds
- [x] RuboCop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)