### PR TITLE
Sanitize LLM responses and prevent database info leakage

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -9,8 +9,18 @@ module Api
                  with: -> { render json: { error: 'Rate limit exceeded' }, status: :too_many_requests }
 
       rescue_from DateConcern::ConflictingTimeParametersError, with: :render_conflicting_params_error
+      rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
+      rescue_from ActiveRecord::StatementInvalid, ActionController::BadRequest, with: :render_bad_request
 
       private
+
+      def render_not_found
+        render json: { error: 'Not found' }, status: :not_found
+      end
+
+      def render_bad_request
+        render json: { error: 'Bad request' }, status: :bad_request
+      end
 
       def authenticate_client!
         secret = ENV['FRONTEND_JWT_SECRET']

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -8,6 +8,7 @@ module Api
       rate_limit to: 300, within: 1.minute, by: -> { request.remote_ip }, name: 'general',
                  with: -> { render json: { error: 'Rate limit exceeded' }, status: :too_many_requests }
 
+      rescue_from StandardError, with: :render_internal_error
       rescue_from DateConcern::ConflictingTimeParametersError, with: :render_conflicting_params_error
       rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
       rescue_from ActiveRecord::StatementInvalid, ActionController::BadRequest, with: :render_bad_request
@@ -20,6 +21,12 @@ module Api
 
       def render_bad_request
         render json: { error: 'Bad request' }, status: :bad_request
+      end
+
+      def render_internal_error(exception)
+        Rails.logger.error("[API Error] #{exception.class}: #{exception.message}")
+        ExceptionNotifier.notify(exception) if defined?(ExceptionNotifier)
+        render json: { error: 'Internal server error' }, status: :internal_server_error
       end
 
       def authenticate_client!

--- a/app/models/concerns/artist_search_concern.rb
+++ b/app/models/concerns/artist_search_concern.rb
@@ -16,12 +16,12 @@ module ArtistSearchConcern
     scope :filter_by_genre, lambda { |genre|
       return all if genre.blank?
 
-      where(Arel::Nodes::InfixOperation.new('@>', arel_table[:genres], Arel::Nodes.build_quoted("{#{genre}}")))
+      where('genres @> ARRAY[?]::varchar[]', genre)
     }
     scope :filter_by_country, lambda { |country|
       return all if country.blank?
 
-      where(Arel::Nodes::InfixOperation.new('@>', arel_table[:country_of_origin], Arel::Nodes.build_quoted("{#{country}}")))
+      where('country_of_origin @> ARRAY[?]::varchar[]', country)
     }
     scope :sorted_by_air_plays, lambda {
       joins(:air_plays)

--- a/app/services/llm/query_translator.rb
+++ b/app/services/llm/query_translator.rb
@@ -19,6 +19,8 @@ module Llm
     SORT_OPTIONS = %w[most_played newest popularity].freeze
     SEARCH_TYPES = %w[songs artists].freeze
     STRING_FILTERS = %w[text_search artist title album genre radio_station period lyrics].freeze
+    MAX_STRING_LENGTH = 200
+    COUNTRY_CODE_PATTERN = /\A[A-Z]{2,3}\z/
 
     def initialize(query)
       super()
@@ -90,7 +92,7 @@ module Llm
     def normalize_filters(parsed)
       filters = extract_string_filters(parsed)
       filters[:search_type] = parsed['search_type'] if SEARCH_TYPES.include?(parsed['search_type'])
-      filters[:country] = parsed['country'].upcase if parsed['country'].present?
+      filters[:country] = parsed['country'].upcase if parsed['country'].present? && parsed['country'].upcase.match?(COUNTRY_CODE_PATTERN)
       filters.merge!(extract_numeric_filters(parsed))
       filters.merge!(extract_enum_filters(parsed))
       filters
@@ -98,8 +100,17 @@ module Llm
 
     def extract_string_filters(parsed)
       STRING_FILTERS.each_with_object({}) do |key, hash|
-        hash[key.to_sym] = parsed[key] if parsed[key].present?
+        hash[key.to_sym] = sanitize_string(parsed[key]) if parsed[key].present?
       end
+    end
+
+    def sanitize_string(value)
+      return nil unless value.is_a?(String)
+
+      value
+        .gsub(/[[:cntrl:]]/, '')
+        .strip
+        .truncate(MAX_STRING_LENGTH, omission: '')
     end
 
     def extract_numeric_filters(parsed)

--- a/app/services/natural_language_search.rb
+++ b/app/services/natural_language_search.rb
@@ -83,23 +83,11 @@ class NaturalLanguageSearch
   end
 
   def apply_genre_filter(scope)
-    scope.joins(:artists).where(
-      Arel::Nodes::InfixOperation.new(
-        '&&',
-        Artist.arel_table[:genres],
-        Arel::Nodes.build_quoted("{#{ActiveRecord::Base.sanitize_sql_like(filters[:genre])}}")
-      )
-    )
+    scope.joins(:artists).where('artists.genres @> ARRAY[?]::varchar[]', filters[:genre])
   end
 
   def apply_country_filter(scope)
-    scope.joins(:artists).where(
-      Arel::Nodes::InfixOperation.new(
-        '@>',
-        Artist.arel_table[:country_of_origin],
-        Arel::Nodes.build_quoted("{#{ActiveRecord::Base.sanitize_sql_like(filters[:country])}}")
-      )
-    )
+    scope.joins(:artists).where('artists.country_of_origin @> ARRAY[?]::varchar[]', filters[:country])
   end
 
   def apply_sorting(scope)

--- a/spec/controllers/api/v1/songs_controller_spec.rb
+++ b/spec/controllers/api/v1/songs_controller_spec.rb
@@ -82,6 +82,21 @@ describe Api::V1::SongsController do
         expect(response.body).not_to include('column')
       end
     end
+
+    context 'when an unexpected error occurs' do
+      before do
+        allow(Song).to receive(:find).and_raise(RuntimeError, 'songs table has columns id, title, secret_key')
+      end
+
+      it 'returns a generic internal server error without leaking details', :aggregate_failures do
+        get :show, params: { id: 1, format: :json }
+        body = JSON.parse(response.body)
+        expect(response).to have_http_status(:internal_server_error)
+        expect(body['error']).to eq('Internal server error')
+        expect(response.body).not_to include('songs table')
+        expect(response.body).not_to include('secret_key')
+      end
+    end
   end
 
   describe 'GET #time_analytics' do

--- a/spec/controllers/api/v1/songs_controller_spec.rb
+++ b/spec/controllers/api/v1/songs_controller_spec.rb
@@ -58,6 +58,32 @@ describe Api::V1::SongsController do
     end
   end
 
+  describe 'error handling' do
+    context 'when the record is not found' do
+      it 'returns a generic not found error', :aggregate_failures do
+        get :show, params: { id: 0, format: :json }
+        body = JSON.parse(response.body)
+        expect(response).to have_http_status(:not_found)
+        expect(body['error']).to eq('Not found')
+      end
+    end
+
+    context 'when a statement is invalid' do
+      before do
+        allow(Song).to receive(:find).and_raise(ActiveRecord::StatementInvalid, 'PG::Error: column "secret" does not exist')
+      end
+
+      it 'returns a generic bad request error without database details', :aggregate_failures do
+        get :show, params: { id: 1, format: :json }
+        body = JSON.parse(response.body)
+        expect(response).to have_http_status(:bad_request)
+        expect(body['error']).to eq('Bad request')
+        expect(response.body).not_to include('PG::Error')
+        expect(response.body).not_to include('column')
+      end
+    end
+  end
+
   describe 'GET #time_analytics' do
     subject(:get_time_analytics) { get :time_analytics, params: { id: song.id, format: :json } }
 

--- a/spec/services/llm/query_translator_spec.rb
+++ b/spec/services/llm/query_translator_spec.rb
@@ -107,6 +107,70 @@ RSpec.describe Llm::QueryTranslator, type: :service do
       end
     end
 
+    context 'when sanitizing string filters' do
+      let(:llm_response) do
+        {
+          artist: "Artist\x00Name\x01With\x1FControl",
+          title: 'a' * 300
+        }.to_json
+      end
+
+      before do
+        allow(translator).to receive(:chat).and_return(llm_response)
+      end
+
+      it 'strips control characters from strings' do
+        expect(translate[:artist]).to eq('ArtistNameWithControl')
+      end
+
+      it 'truncates strings exceeding max length' do
+        expect(translate[:title].length).to eq(described_class::MAX_STRING_LENGTH)
+      end
+    end
+
+    context 'when the LLM returns non-string filter values' do
+      let(:llm_response) do
+        { artist: 12_345, title: ['array'] }.to_json
+      end
+
+      before do
+        allow(translator).to receive(:chat).and_return(llm_response)
+      end
+
+      it 'rejects non-string values', :aggregate_failures do
+        expect(translate[:artist]).to be_nil
+        expect(translate[:title]).to be_nil
+      end
+    end
+
+    context 'when the LLM returns an invalid country code' do
+      let(:llm_response) do
+        { country: 'Netherlands' }.to_json
+      end
+
+      before do
+        allow(translator).to receive(:chat).and_return(llm_response)
+      end
+
+      it 'rejects country values that are not ISO codes' do
+        expect(translate[:country]).to be_nil
+      end
+    end
+
+    context 'when the LLM returns a 3-letter country code' do
+      let(:llm_response) do
+        { country: 'nld' }.to_json
+      end
+
+      before do
+        allow(translator).to receive(:chat).and_return(llm_response)
+      end
+
+      it 'accepts 3-letter ISO codes' do
+        expect(translate[:country]).to eq('NLD')
+      end
+    end
+
     context 'when the query contains lyrics' do
       let(:llm_response) do
         {

--- a/spec/services/natural_language_search_spec.rb
+++ b/spec/services/natural_language_search_spec.rb
@@ -151,6 +151,66 @@ RSpec.describe NaturalLanguageSearch, type: :service do
       end
     end
 
+    context 'when filtering songs by genre via artist' do
+      let(:pop_artist) { create(:artist, name: 'Pop Star', genres: ['pop']) }
+      let(:rock_artist) { create(:artist, name: 'Rock Star', genres: ['rock']) }
+      let(:pop_song) { create(:song, title: 'Pop Hit', artists: [pop_artist]) }
+      let(:rock_song) { create(:song, title: 'Rock Hit', artists: [rock_artist]) }
+
+      before do
+        create(:air_play, song: pop_song, radio_station: radio_station, broadcasted_at: 1.day.ago, status: :confirmed)
+        create(:air_play, song: rock_song, radio_station: radio_station, broadcasted_at: 1.day.ago, status: :confirmed)
+        allow(translator).to receive(:translate).and_return(genre: 'pop', period: 'all')
+      end
+
+      it 'returns only songs by artists with matching genre', :aggregate_failures do
+        result_ids = search.map(&:id)
+        expect(result_ids).to include(pop_song.id)
+        expect(result_ids).not_to include(rock_song.id)
+      end
+    end
+
+    context 'when filtering songs by country via artist' do
+      let(:nl_artist) { create(:artist, name: 'Dutch Singer', country_of_origin: ['NL']) }
+      let(:us_artist) { create(:artist, name: 'American Singer', country_of_origin: ['US']) }
+      let(:nl_song) { create(:song, title: 'Dutch Song', artists: [nl_artist]) }
+      let(:us_song) { create(:song, title: 'American Song', artists: [us_artist]) }
+
+      before do
+        create(:air_play, song: nl_song, radio_station: radio_station, broadcasted_at: 1.day.ago, status: :confirmed)
+        create(:air_play, song: us_song, radio_station: radio_station, broadcasted_at: 1.day.ago, status: :confirmed)
+        allow(translator).to receive(:translate).and_return(country: 'NL', period: 'all')
+      end
+
+      it 'returns only songs by artists from the matching country', :aggregate_failures do
+        result_ids = search.map(&:id)
+        expect(result_ids).to include(nl_song.id)
+        expect(result_ids).not_to include(us_song.id)
+      end
+    end
+
+    context 'when filtering artists by genre' do
+      let(:artist_service) { described_class.new('pop artists') }
+      let(:pop_artist) { create(:artist, name: 'Pop Star', genres: ['pop']) }
+      let(:rock_artist) { create(:artist, name: 'Rock Star', genres: ['rock']) }
+
+      before do
+        pop_song = create(:song, title: 'Pop Hit', artists: [pop_artist])
+        rock_song = create(:song, title: 'Rock Hit', artists: [rock_artist])
+        create(:air_play, song: pop_song, radio_station: radio_station, broadcasted_at: 1.day.ago, status: :confirmed)
+        create(:air_play, song: rock_song, radio_station: radio_station, broadcasted_at: 1.day.ago, status: :confirmed)
+        allow(translator).to receive(:translate).and_return(
+          search_type: 'artists', genre: 'pop', period: 'all'
+        )
+      end
+
+      it 'returns only artists with matching genre', :aggregate_failures do
+        result_ids = artist_service.search.map(&:id)
+        expect(result_ids).to include(pop_artist.id)
+        expect(result_ids).not_to include(rock_artist.id)
+      end
+    end
+
     context 'when the query specifies a limit' do
       let(:songs) { create_list(:song, 5) }
 


### PR DESCRIPTION
## Summary
- Sanitize all GPT string filter values in `QueryTranslator` (strip control characters, truncate to 200 chars, validate types) before they're used in SQL queries or returned in API responses
- Replace PostgreSQL array literal string interpolation (`"{#{value}}"`) with fully parameterized `ARRAY[?]::varchar[]` queries in `ArtistSearchConcern` and `NaturalLanguageSearch`
- Validate `country` filter against ISO code pattern (`/\A[A-Z]{2,3}\z/`) instead of accepting arbitrary strings
- Add global `rescue_from` handlers for `ActiveRecord::RecordNotFound` and `ActiveRecord::StatementInvalid` to return generic error messages instead of leaking table/column names

## Test plan
- [x] All 30 LLM/NaturalLanguageSearch specs pass
- [x] All 194 model + request specs pass
- [x] Rubocop clean on all changed files
- [ ] Verify genre/country filters still work correctly on production data
- [ ] Verify NL search returns expected results for mood, genre, and country queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)