### PR TITLE
Add second-round alternative queries after LLM cleanup

### DIFF
--- a/app/services/llm/alternative_search_queries.rb
+++ b/app/services/llm/alternative_search_queries.rb
@@ -29,11 +29,15 @@ module Llm
         Generate 2-3 alternative search queries that might find the song.
 
         Consider:
+        - Simplifying complex artist names: try just the primary band/group name without collaborators
+          (e.g., "Opwekking Band met Marcel Zimmer" → "Opwekking", "André Rieu & Johann Strauss Orchestra" → "André Rieu")
         - Removing featured artists from the title or artist field
         - Fixing common .titleize capitalization errors (e.g., "Dj" → "DJ", "Mc" → "MC")
         - Restoring special characters (e.g., "Tiesto" → "Tiësto", "Beyonce" → "Beyoncé")
         - Trying the international/English title if it looks like a Dutch translation
         - Removing parenthetical suffixes like "(Radio Edit)", "(Official Audio)", "(Live)"
+        - Handling track/catalog numbers: move to parentheses or remove
+          (e.g., "785 Fundament" → "Fundament" or "Fundament (785)")
         - Removing radio station tags or prefixes from the title
         - Simplifying punctuation
 

--- a/app/services/song_importer/concerns/track_finding.rb
+++ b/app/services/song_importer/concerns/track_finding.rb
@@ -72,8 +72,8 @@ module SongImporter::Concerns
     end
 
     # Feature 5: Generate alternative search queries via LLM when Spotify returned no results
-    def spotify_track_with_alternative_queries
-      service = Llm::AlternativeSearchQueries.new(artist_name: artist_name, title: title)
+    def spotify_track_with_alternative_queries(search_artist: artist_name, search_title: title)
+      service = Llm::AlternativeSearchQueries.new(artist_name: search_artist, title: search_title)
       alternatives = service.generate
       @import_logger.log_llm(action: 'alternative_search_queries', raw_response: service.raw_response)
       return nil if alternatives.blank?
@@ -133,10 +133,16 @@ module SongImporter::Concerns
       Rails.logger.info("[LLM] Track name cleaned: '#{artist_name}' → '#{cleaned['artist']}', '#{title}' → '#{cleaned['title']}'")
       cleaned_result = Spotify::TrackFinder::Result.new(artists: cleaned['artist'], title: cleaned['title'])
       cleaned_result.execute
-      return nil unless cleaned_result.valid_match?
 
-      @import_logger.log_spotify(cleaned_result)
-      cleaned_result
+      if cleaned_result.valid_match?
+        @import_logger.log_spotify(cleaned_result)
+        return cleaned_result
+      end
+
+      # Second round: try alternative queries with cleaned names
+      return nil unless no_spotify_results?(cleaned_result)
+
+      spotify_track_with_alternative_queries(search_artist: cleaned['artist'], search_title: cleaned['title'])
     end
 
     # Skip LLM cleanup when Spotify already found a match — the search terms

--- a/spec/services/song_importer/concerns/track_finding_spec.rb
+++ b/spec/services/song_importer/concerns/track_finding_spec.rb
@@ -235,6 +235,55 @@ RSpec.describe SongImporter::Concerns::TrackFinding do
           expect(song_importer.send(:track)).to be_nil
         end
       end
+
+      context 'when cleaned direct search fails but alternative queries with cleaned names succeed' do
+        let(:title) { '785 Fundament' }
+        let(:artist_name) { 'Opwekking Band met Marcel Zimmer' }
+
+        before do
+          allow(cleaner_double).to receive(:clean).and_return(
+            { 'artist' => 'Opwekking Band met Marcel Zimmer', 'title' => 'Fundament' }
+          )
+
+          # First call: alternative queries for original names (returns nothing)
+          # Second call: alternative queries for cleaned names (returns simplified artist)
+          alt_queries_cleaned = instance_double(Llm::AlternativeSearchQueries, raw_response: {})
+          allow(alt_queries_cleaned).to receive(:generate).and_return(
+            [{ 'artist' => 'Opwekking', 'title' => 'Fundament' }]
+          )
+          allow(Llm::AlternativeSearchQueries).to receive(:new)
+                                                    .with(artist_name: artist_name, title: title).and_return(alt_queries_double)
+          allow(Llm::AlternativeSearchQueries).to receive(:new)
+                                                    .with(artist_name: 'Opwekking Band met Marcel Zimmer', title: 'Fundament')
+                                                    .and_return(alt_queries_cleaned)
+
+          # All searches with the full artist name return empty
+          stub_request(:get, %r{api\.spotify\.com/v1/search\?q=.*opwekking%20band})
+            .to_return(status: 200, body: spotify_empty_response.to_json,
+                       headers: { 'Content-Type' => 'application/json' })
+
+          # Simplified "Opwekking" search returns a result
+          opwekking_response = {
+            'tracks' => {
+              'items' => [
+                build_spotify_track_item(id: 'spotify_opw', name: 'Fundament', artist_name: 'Opwekking')
+              ]
+            }
+          }
+          stub_request(:get, %r{api\.spotify\.com/v1/search\?q=.*artist.opwekking&type=track})
+            .to_return(status: 200, body: opwekking_response.to_json,
+                       headers: { 'Content-Type' => 'application/json' })
+
+          stub_request(:get, %r{api\.spotify\.com/v1/artists/})
+            .to_return(status: 200,
+                       body: { 'id' => 'opw1', 'name' => 'Opwekking', 'images' => [] }.to_json,
+                       headers: { 'Content-Type' => 'application/json' })
+        end
+
+        it 'finds the track via second-round alternative queries' do
+          expect(song_importer.send(:track)).to be_present
+        end
+      end
     end
 
     describe '#worth_llm_cleanup?' do


### PR DESCRIPTION
## Summary
- **Enhanced AlternativeSearchQueries prompt** with instructions to simplify complex artist names (e.g., "Opwekking Band met Marcel Zimmer" → "Opwekking") and handle track/catalog numbers in titles (e.g., "785 Fundament" → "Fundament")
- **Added second round of alternative queries after TrackNameCleaner** — when cleanup fixes the title but the direct Spotify search still returns nothing, AlternativeSearchQueries runs again with the cleaned names to simplify the artist
- Parameterized `spotify_track_with_alternative_queries` with `search_artist:`/`search_title:` kwargs (backwards compatible, defaults to original scraped names)

### Context
Songs like "Opwekking Band met Marcel Zimmer - 785 Fundament" fail all search paths because:
1. Original Spotify search fails (complex artist + numbered title)
2. First-round alternative queries can't fix both issues at once
3. TrackNameCleaner fixes the title ("Fundament") but keeps the full artist name
4. Direct search with cleaned names still fails

The second round lets the LLM simplify the already-cleaned artist name → match found.

## Test plan
- [x] Existing track finding specs pass (19/19)
- [x] New spec covers the Opwekking case: cleaned direct search fails, second-round alternatives succeed
- [x] Rubocop clean
- [x] Monitor import logs after deploy for new `alternative_search_queries` matches on previously-failing stations (GNR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)