### PR TITLE
Fix multi-artist matching when artists are in different order

### DIFF
--- a/app/services/spotify/base.rb
+++ b/app/services/spotify/base.rb
@@ -59,8 +59,20 @@ module Spotify
       Spotify::Token.new.token
     end
 
-    def artist_distance(item_artist_names)
-      (JaroWinkler.similarity(item_artist_names.downcase, args[:artists].to_s.downcase) * 100).to_i
+    def artist_distance(spotify_artist_names)
+      scraped_names = split_artist_string(args[:artists].to_s).sort_by(&:downcase)
+      spotify_names = spotify_artist_names.sort_by(&:downcase)
+
+      (JaroWinkler.similarity(spotify_names.join(' ').downcase, scraped_names.join(' ').downcase) * 100).to_i
+    end
+
+    def split_artist_string(artist_string)
+      regex = Regexp.new(Song::MULTIPLE_ARTIST_REGEX, Regexp::IGNORECASE)
+      if artist_string.match?(regex)
+        artist_string.split(regex).map(&:strip).reject(&:blank?)
+      else
+        [artist_string]
+      end
     end
 
     def title_distance(item_title)
@@ -71,7 +83,7 @@ module Spotify
       items.filter_map do |item|
         next if item.blank?
 
-        item_artist_names = item.dig('album', 'artists').map { |artist| artist['name'] }.join(' ')
+        item_artist_names = item.dig('album', 'artists').map { |artist| artist['name'] }
         item_title = item['name']
 
         artist_dist = artist_distance(item_artist_names)

--- a/app/services/spotify/track_finder/result.rb
+++ b/app/services/spotify/track_finder/result.rb
@@ -224,7 +224,7 @@ module Spotify
       def add_match_scores(track)
         return if track.blank?
 
-        item_artist_names = track.dig('album', 'artists')&.map { |a| a['name'] }&.join(' ') || ''
+        item_artist_names = track.dig('album', 'artists')&.map { |a| a['name'] } || []
         item_title = track['name'] || ''
 
         track['artist_distance'] = artist_distance(item_artist_names)

--- a/spec/services/spotify/base_spec.rb
+++ b/spec/services/spotify/base_spec.rb
@@ -83,19 +83,35 @@ describe Spotify::Base, type: :service do
   describe '#artist_distance' do
     context 'when artist names match exactly' do
       it 'returns 100' do
-        expect(spotify_base.send(:artist_distance, 'Artist Name')).to eq(100)
+        expect(spotify_base.send(:artist_distance, ['Artist Name'])).to eq(100)
       end
     end
 
     context 'when artist names are similar' do
       it 'returns a high score' do
-        expect(spotify_base.send(:artist_distance, 'Artist Names')).to be > 80
+        expect(spotify_base.send(:artist_distance, ['Artist Names'])).to be > 80
       end
     end
 
     context 'when artist names are different' do
       it 'returns a low score' do
-        expect(spotify_base.send(:artist_distance, 'Completely Different')).to be < 60
+        expect(spotify_base.send(:artist_distance, ['Completely Different'])).to be < 60
+      end
+    end
+
+    context 'when multiple artists are in different order' do
+      let(:args) { { artists: 'Snelle & Zoé Livay', title: 'Song Title' } }
+
+      it 'returns a high score' do
+        expect(spotify_base.send(:artist_distance, ['Zoë Livay', 'Snelle'])).to be > 80
+      end
+    end
+
+    context 'when scraped has feat. separator and Spotify has different order' do
+      let(:args) { { artists: 'Artist A feat. Artist B', title: 'Song Title' } }
+
+      it 'returns a high score' do
+        expect(spotify_base.send(:artist_distance, ['Artist B', 'Artist A'])).to be > 80
       end
     end
   end


### PR DESCRIPTION
## Summary
- Spotify artist distance calculation now handles multi-artist strings with different ordering and separators (e.g., scraped `"Snelle & Zoé Livay"` vs Spotify `"Zoë Livay, Snelle"`)
- Splits artist names using `MULTIPLE_ARTIST_REGEX` (strips `&`, `feat.`, `vs.`, `,`, etc.) and sorts alphabetically before comparing with JaroWinkler
- Fixes false rejections where valid Spotify matches scored 46% instead of ~96%, causing new songs to be created without Spotify data

## Test plan
- [x] Existing Spotify base, result, and song importer specs pass (136 tests)
- [x] New test cases for multi-artist reordering (`"Snelle & Zoé Livay"` ↔ `["Zoë Livay", "Snelle"]`)
- [x] New test case for feat. separator with reordering
- [ ] Run `rake data_repair:merge_duplicate_songs_dry_run` on production to clean up existing duplicates
- [x] Rubocop clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)