### PR TITLE
Fix DuplicateSongMerger crash on nil broadcasted_at

### DIFF
--- a/app/services/duplicate_song_merger.rb
+++ b/app/services/duplicate_song_merger.rb
@@ -197,7 +197,7 @@ class DuplicateSongMerger
       if existing
         air_play.destroy
       else
-        air_play.update!(song_id: target.id)
+        air_play.update_columns(song_id: target.id)
       end
     end
   end

--- a/app/services/duplicate_song_merger.rb
+++ b/app/services/duplicate_song_merger.rb
@@ -197,7 +197,7 @@ class DuplicateSongMerger
       if existing
         air_play.destroy
       else
-        air_play.update_columns(song_id: target.id)
+        air_play.update_columns(song_id: target.id) # rubocop:disable Rails/SkipsModelValidations
       end
     end
   end


### PR DESCRIPTION
## Summary
- `DuplicateSongMerger#merge_air_plays` used `update!` to reassign air plays to the target song, which triggers model validations
- Some air plays have a nil `broadcasted_at`, causing `ActiveRecord::RecordInvalid` during deduplication
- Changed to `update_columns` to write `song_id` directly, bypassing validations — appropriate for a data repair task that only needs to move the foreign key

## Test plan
- [ ] Run `bundle exec rake data_repair:merge_duplicate_isrcs` against production and verify no validation errors
- [ ] Verify merged air plays have correct `song_id` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)