### PR TITLE
Add slug-based duplicate detection to DuplicateSongMerger

### DIFF
--- a/app/services/duplicate_song_merger.rb
+++ b/app/services/duplicate_song_merger.rb
@@ -13,6 +13,7 @@ class DuplicateSongMerger
     @groups = []
     find_spotify_id_duplicates
     find_fuzzy_title_duplicates
+    find_slug_duplicates
     @groups
   end
 
@@ -84,6 +85,44 @@ class DuplicateSongMerger
         @groups << { keeper:, duplicates:, reason: 'fuzzy title match' }
       end
     end
+  end
+
+  def find_slug_duplicates
+    seen_ids = @groups.flat_map { |g| [g[:keeper].id] + g[:duplicates].map(&:id) }.to_set
+    base_groups = build_slug_groups(seen_ids)
+    return if base_groups.empty?
+
+    base_groups.each_value do |ids|
+      next if ids.size < 2
+
+      songs = Song.includes(:artists).where(id: ids.to_a).to_a
+      filtered = filter_conflicting_spotify_ids(songs)
+      next if filtered.size < 2
+
+      keeper, duplicates = select_keeper_and_duplicates(filtered)
+      @groups << { keeper:, duplicates:, reason: 'slug duplicate' }
+      seen_ids.merge(filtered.map(&:id))
+    end
+  end
+
+  def build_slug_groups(seen_ids)
+    base_groups = Hash.new { |h, k| h[k] = Set.new }
+
+    # Find songs with numbered slug suffixes (the -2, -3, etc. added by unique_slug)
+    Song.where("slug ~ '-\\d+$'").pluck(:id, :slug).each do |id, slug|
+      next if seen_ids.include?(id)
+
+      base_groups[slug.sub(/-\d+$/, '')] << id
+    end
+
+    # Add original songs (the ones with the unsuffixed base slug)
+    Song.where(slug: base_groups.keys).pluck(:id, :slug).each do |id, slug|
+      next if seen_ids.include?(id)
+
+      base_groups[slug] << id
+    end
+
+    base_groups
   end
 
   def build_artist_groups(seen_ids)

--- a/spec/services/duplicate_song_merger_spec.rb
+++ b/spec/services/duplicate_song_merger_spec.rb
@@ -90,6 +90,59 @@ describe DuplicateSongMerger do
         expect(merger.find_duplicates).to be_empty
       end
     end
+
+    context 'when songs have numbered slug suffixes (slug duplicates)' do
+      let(:other_artist) { create(:artist, name: 'Snelle') }
+      let!(:song_a) do
+        create(:song, title: 'Ik Zing', id_on_spotify: 'spotify_1', artists: [artist], slug: 'ik-zing-taylor-swift')
+      end
+      let!(:song_b) do
+        create(:song, title: 'Ik Zing', id_on_spotify: nil, artists: [artist, other_artist],
+                      slug: 'ik-zing-taylor-swift-2')
+      end
+
+      before { create(:air_play, song: song_a) }
+
+      it 'groups them as slug duplicates', :aggregate_failures do
+        groups = merger.find_duplicates
+
+        slug_group = groups.find { |g| g[:reason] == 'slug duplicate' }
+        expect(slug_group).to be_present
+        expect(slug_group[:keeper]).to eq(song_a)
+        expect(slug_group[:duplicates]).to eq([song_b])
+      end
+    end
+
+    context 'when slug duplicates have conflicting Spotify IDs' do
+      before do
+        create(:song, title: 'Ik Zing', id_on_spotify: 'spotify_1', artists: [artist], slug: 'ik-zing-taylor-swift')
+        create(:song, title: 'Ik Zing', id_on_spotify: 'spotify_2', artists: [artist],
+                      slug: 'ik-zing-taylor-swift-2')
+      end
+
+      it 'does not group them' do
+        groups = merger.find_duplicates
+        slug_group = groups.find { |g| g[:reason] == 'slug duplicate' }
+
+        expect(slug_group).to be_nil
+      end
+    end
+
+    context 'when slug duplicates are already caught by another strategy' do
+      before do
+        create(:song, title: 'Love Story', id_on_spotify: 'spotify_1', artists: [artist],
+                      slug: 'love-story-taylor-swift')
+        create(:song, title: 'Love Story', id_on_spotify: 'spotify_1', artists: [artist],
+                      slug: 'love-story-taylor-swift-2')
+      end
+
+      it 'does not create a duplicate group for slugs', :aggregate_failures do
+        groups = merger.find_duplicates
+
+        expect(groups.size).to eq(1)
+        expect(groups.first[:reason]).to include('Spotify ID')
+      end
+    end
   end
 
   describe '#merge_all' do


### PR DESCRIPTION
## Summary
- Adds a third duplicate detection strategy to `DuplicateSongMerger` that uses numbered slug suffixes (e.g. `ik-zing-snelle-zoe-livay-6`) as a signal for duplicate songs
- Catches duplicates missed by Spotify ID and fuzzy title matching — particularly songs with different artist sets but the same first artist (feat. variants)
- Runs after existing strategies and skips songs already identified as duplicates; reuses existing `filter_conflicting_spotify_ids` safety check

## Test plan
- [x] Spec: slug duplicates with different artist sets are grouped
- [x] Spec: slug duplicates with conflicting Spotify IDs are excluded
- [x] Spec: songs already caught by Spotify ID strategy are not double-grouped
- [ ] Run `rake data_repair:merge_duplicate_songs_dry_run` against production dump to verify matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)