### PR TITLE
Strip leading "The" from artist name comparison

### DIFF
--- a/app/services/deezer/base.rb
+++ b/app/services/deezer/base.rb
@@ -49,8 +49,8 @@ module Deezer
     end
 
     def artist_distance(item_artist_name)
-      scraped_names = split_artist_string(args[:artists].to_s).sort_by(&:downcase)
-      api_names = split_artist_string(item_artist_name.to_s).sort_by(&:downcase)
+      scraped_names = split_artist_string(args[:artists].to_s).map { |name| without_leading_the(name) }.sort_by(&:downcase)
+      api_names = split_artist_string(item_artist_name.to_s).map { |name| without_leading_the(name) }.sort_by(&:downcase)
 
       (JaroWinkler.similarity(api_names.join(' ').downcase, scraped_names.join(' ').downcase) * 100).to_i
     end
@@ -62,6 +62,10 @@ module Deezer
       else
         [artist_string]
       end
+    end
+
+    def without_leading_the(name)
+      name.sub(/\Athe\s+/i, '')
     end
 
     def title_distance(item_title)

--- a/app/services/itunes/base.rb
+++ b/app/services/itunes/base.rb
@@ -51,8 +51,8 @@ module Itunes
     end
 
     def artist_distance(item_artist_name)
-      scraped_names = split_artist_string(args[:artists].to_s).sort_by(&:downcase)
-      api_names = split_artist_string(item_artist_name.to_s).sort_by(&:downcase)
+      scraped_names = split_artist_string(args[:artists].to_s).map { |name| without_leading_the(name) }.sort_by(&:downcase)
+      api_names = split_artist_string(item_artist_name.to_s).map { |name| without_leading_the(name) }.sort_by(&:downcase)
 
       (JaroWinkler.similarity(api_names.join(' ').downcase, scraped_names.join(' ').downcase) * 100).to_i
     end
@@ -64,6 +64,10 @@ module Itunes
       else
         [artist_string]
       end
+    end
+
+    def without_leading_the(name)
+      name.sub(/\Athe\s+/i, '')
     end
 
     def title_distance(item_title)

--- a/app/services/spotify/base.rb
+++ b/app/services/spotify/base.rb
@@ -60,8 +60,8 @@ module Spotify
     end
 
     def artist_distance(spotify_artist_names)
-      scraped_names = split_artist_string(args[:artists].to_s).sort_by(&:downcase)
-      spotify_names = spotify_artist_names.sort_by(&:downcase)
+      scraped_names = split_artist_string(args[:artists].to_s).map { |name| without_leading_the(name) }.sort_by(&:downcase)
+      spotify_names = spotify_artist_names.map { |name| without_leading_the(name) }.sort_by(&:downcase)
 
       (JaroWinkler.similarity(spotify_names.join(' ').downcase, scraped_names.join(' ').downcase) * 100).to_i
     end
@@ -73,6 +73,10 @@ module Spotify
       else
         [artist_string]
       end
+    end
+
+    def without_leading_the(name)
+      name.sub(/\Athe\s+/i, '')
     end
 
     def title_distance(item_title)

--- a/spec/services/spotify/track_finder/result_spec.rb
+++ b/spec/services/spotify/track_finder/result_spec.rb
@@ -164,17 +164,15 @@ describe Spotify::TrackFinder::Result, :use_vcr do
       end
     end
 
-    context 'when artist name has a small prefix difference' do
+    context 'when artist name has a leading "The" prefix difference' do
       let(:artists) { 'Doobie Brothers' }
+      let(:title) { 'China Grove' }
       let(:response_artist) { 'The Doobie Brothers' }
       let(:response_title) { 'China Grove' }
 
-      it 'computes non-zero artist distance' do
-        expect(finder.matched_artist_distance).to be > 0
-      end
-
-      it 'falls below threshold for "The" prefix' do
-        expect(finder.matched_artist_distance).to be < Spotify::Base::ARTIST_SIMILARITY_THRESHOLD
+      it 'matches above threshold after stripping leading "The"', :aggregate_failures do
+        expect(finder.valid_match?).to be true
+        expect(finder.matched_artist_distance).to eq(100)
       end
     end
 


### PR DESCRIPTION
## Summary
- Strips leading "The" (case-insensitive) from artist names before JaroWinkler distance comparison in Spotify, Deezer, and iTunes base classes
- Artists like The Police, The Doors, The Doobie Brothers, and The Killers now match correctly regardless of whether the scraper or API includes the "The" prefix
- Updated spec to verify "Doobie Brothers" vs "The Doobie Brothers" now produces a 100% artist match

## Test plan
- [x] All 95 existing specs for Spotify/Deezer/iTunes base and track finder result pass
- [x] Rubocop clean on all changed files
- [ ] Verify in production that artists with "The" prefix are matched correctly during imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)