### PR TITLE
Slim SongImporter and decouple importer subclasses

### DIFF
--- a/app/services/song_importer.rb
+++ b/app/services/song_importer.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class SongImporter
+  CLEARED_IVARS = %i[
+    @played_song @artists @song @track @spotify_track @deezer_track @itunes_track @scraper_import
+  ].freeze
+
   include SongImporter::Concerns::AudioRecognition
   include SongImporter::Concerns::TrackFinding
   include SongImporter::Concerns::AirPlayCreation
@@ -34,25 +38,7 @@ class SongImporter
 
   private
 
-  def title
-    @title ||= @played_song.title
-  end
-
-  def artist_name
-    @artist_name ||= @played_song.artist_name
-  end
-
-  def spotify_url
-    @spotify_url ||= @played_song.spotify_url
-  end
-
-  def isrc_code
-    @isrc_code ||= @played_song.isrc_code
-  end
-
-  def broadcasted_at
-    @broadcasted_at ||= @played_song.broadcasted_at
-  end
+  delegate :title, :artist_name, :spotify_url, :isrc_code, :broadcasted_at, to: :@played_song, allow_nil: true
 
   def artists
     @artists ||= TrackExtractor::ArtistsExtractor.new(played_song: @played_song, track:).extract
@@ -146,15 +132,6 @@ class SongImporter
     Array.wrap(artists).map(&:name).join(', ')
   end
 
-  def artists_ids_to_s
-    Array.wrap(artists).map(&:id).join(' ')
-  end
-
-  ### check if any song played last hour matches the song we are importing
-  def any_song_matches?
-    @matching = SongImporter::Matcher.new(radio_station: @radio_station, song: @song).matches_any_played_last_hour?
-  end
-
   def safe_start_log
     @import_logger.start_log
   rescue StandardError => e
@@ -162,20 +139,8 @@ class SongImporter
   end
 
   def clear_instance_variables
-    @played_song = nil
-    @title = nil
-    @artist_name = nil
-    @spotify_url = nil
-    @isrc_code = nil
-    @broadcasted_at = nil
-    @artists = nil
-    @song = nil
-    @track = nil
-    @spotify_track = nil
-    @deezer_track = nil
-    @itunes_track = nil
-    @scraper_import = nil
-    @importer = nil
-    @matching = nil
+    CLEARED_IVARS.each do |ivar|
+      remove_instance_variable(ivar) if instance_variable_defined?(ivar)
+    end
   end
 end

--- a/app/services/song_importer/concerns/air_play_creation.rb
+++ b/app/services/song_importer/concerns/air_play_creation.rb
@@ -7,15 +7,15 @@ module SongImporter::Concerns
     private
 
     def create_air_play
-      @importer = if scraper_import
-                    SongImporter::ScraperImporter.new(radio_station: @radio_station, artists:, song:)
-                  else
-                    SongImporter::RecognizerImporter.new(radio_station: @radio_station, artists:, song:)
-                  end
-      if @importer.may_import_song?
+      importer = if scraper_import
+                   SongImporter::ScraperImporter.new(radio_station: @radio_station, artists:, song:)
+                 else
+                   SongImporter::RecognizerImporter.new(radio_station: @radio_station, artists:, song:)
+                 end
+      if importer.may_import_song?
         add_song
       else
-        @importer.broadcast_error_message
+        importer.broadcast_error_message
         @import_logger.skip_log(reason: 'Song already imported recently or matches last played song')
       end
     end

--- a/app/services/song_importer/concerns/importable.rb
+++ b/app/services/song_importer/concerns/importable.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module SongImporter::Concerns
+  module Importable
+    extend ActiveSupport::Concern
+
+    def may_import_song?
+      not_last_added_song && !any_song_matches?
+    end
+
+    def broadcast_error_message
+      Broadcaster.last_song(title: @song.title, artists_names:, radio_station_name: @radio_station.name)
+    end
+
+    private
+
+    def any_song_matches?
+      SongImporter::Matcher.new(radio_station: @radio_station, song: @song).matches_any_played_last_hour?
+    end
+
+    def artists_names
+      Array.wrap(@artists).map(&:name).join(', ')
+    end
+  end
+end

--- a/app/services/song_importer/matcher.rb
+++ b/app/services/song_importer/matcher.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class SongImporter::Matcher < SongImporter
+class SongImporter::Matcher
   ARTIST_SIMILARITY_THRESHOLD = 80
   TITLE_SIMILARITY_THRESHOLD = 70
 
@@ -12,8 +12,6 @@ class SongImporter::Matcher < SongImporter
   end
 
   def matches_any_played_last_hour?
-    # Use any? with early exit for better performance
-    # Check artist similarity first, then title similarity
     @radio_station.songs_played_last_hour.any? do |played_song|
       artist_match(played_song) >= ARTIST_SIMILARITY_THRESHOLD &&
         title_match(played_song) >= TITLE_SIMILARITY_THRESHOLD
@@ -21,8 +19,6 @@ class SongImporter::Matcher < SongImporter
   end
 
   def song_matches
-    # Use map directly instead of find_each.map (find_each is for batch processing large datasets)
-    # Returns array of hashes with artist and title similarity scores
     @radio_station.songs_played_last_hour.map do |played_song|
       {
         artist_similarity: artist_match(played_song),
@@ -32,8 +28,6 @@ class SongImporter::Matcher < SongImporter
   end
 
   def song_match(played_song)
-    # Returns the minimum of artist and title similarity
-    # Both must be high for an overall high match score
     [artist_match(played_song), title_match(played_song)].min
   end
 

--- a/app/services/song_importer/recognizer_importer.rb
+++ b/app/services/song_importer/recognizer_importer.rb
@@ -1,18 +1,14 @@
 # frozen_string_literal: true
 
-class SongImporter::RecognizerImporter < SongImporter
+class SongImporter::RecognizerImporter
+  include SongImporter::Concerns::Importable
+
+  attr_reader :radio_station, :artists, :song
+
   def initialize(radio_station:, artists:, song:)
     @radio_station = radio_station
     @artists = artists
     @song = song
-  end
-
-  def may_import_song?
-    not_last_added_song && !any_song_matches?
-  end
-
-  def broadcast_error_message
-    Broadcaster.last_song(title: song.title, artists_names:, radio_station_name: @radio_station.name)
   end
 
   private

--- a/app/services/song_importer/scraper_importer.rb
+++ b/app/services/song_importer/scraper_importer.rb
@@ -1,20 +1,14 @@
 # frozen_string_literal: true
 
-class SongImporter::ScraperImporter < SongImporter
-  attr_reader :artists, :song
+class SongImporter::ScraperImporter
+  include SongImporter::Concerns::Importable
+
+  attr_reader :radio_station, :artists, :song
 
   def initialize(radio_station:, artists:, song:)
     @radio_station = radio_station
     @artists = artists
     @song = song
-  end
-
-  def may_import_song?
-    not_last_added_song && !any_song_matches?
-  end
-
-  def broadcast_error_message
-    Broadcaster.last_song(title: song.title, artists_names:, radio_station_name: @radio_station.name)
   end
 
   private

--- a/spec/services/song_importer_edge_cases_spec.rb
+++ b/spec/services/song_importer_edge_cases_spec.rb
@@ -428,8 +428,7 @@ describe SongImporter do
     before do
       importer.instance_variable_set(:@song, song)
       importer.instance_variable_set(:@artists, [artist])
-      importer.instance_variable_set(:@played_song, instance_double(SongRecognizer, is_a?: false))
-      importer.instance_variable_set(:@broadcasted_at, Time.current)
+      importer.instance_variable_set(:@played_song, instance_double(SongRecognizer, is_a?: false, broadcasted_at: Time.current))
     end
 
     describe 'when song was already imported recently' do
@@ -457,7 +456,7 @@ describe SongImporter do
       end
 
       before do
-        importer.instance_variable_set(:@broadcasted_at, broadcasted_at)
+        allow(importer.instance_variable_get(:@played_song)).to receive(:broadcasted_at).and_return(broadcasted_at)
         allow(SongImporter::RecognizerImporter).to receive(:new).and_return(
           instance_double(SongImporter::RecognizerImporter, may_import_song?: true)
         )
@@ -496,9 +495,8 @@ describe SongImporter do
         allow(SongImportLogger).to receive(:new).and_return(import_logger)
         rec_importer.instance_variable_set(:@song, song)
         rec_importer.instance_variable_set(:@artists, [artist])
-        rec_importer.instance_variable_set(:@played_song, instance_double(SongRecognizer, is_a?: false))
+        rec_importer.instance_variable_set(:@played_song, instance_double(SongRecognizer, is_a?: false, broadcasted_at: Time.current))
         rec_importer.instance_variable_set(:@scraper_import, false)
-        rec_importer.instance_variable_set(:@broadcasted_at, Time.current)
         allow(SongImporter::RecognizerImporter).to receive(:new).and_return(
           instance_double(SongImporter::RecognizerImporter, may_import_song?: true)
         )


### PR DESCRIPTION
## Summary
- Drop inheritance coupling: `Matcher`, `ScraperImporter`, `RecognizerImporter` are now plain POROs instead of subclasses of `SongImporter`. They were inheriting the entire import workflow only to reuse a few helpers.
- Extract `may_import_song?` / `broadcast_error_message` / `any_song_matches?` / `artists_names` into a new `SongImporter::Concerns::Importable` module shared by both importer POROs.
- Replace the five memoized `@played_song` accessor methods (`title`, `artist_name`, `spotify_url`, `isrc_code`, `broadcasted_at`) with a single `delegate` line.
- Shrink `clear_instance_variables` from 15 manual `= nil` assignments to a `CLEARED_IVARS` constant loop using `remove_instance_variable`. Drop dead `artists_ids_to_s` helper, dead `@matching` ivar, and the `@importer` ivar (now a local).
- Update three `create_air_play` edge-case specs to stub `broadcasted_at` on the `played_song` double instead of injecting the `@broadcasted_at` ivar (memoization is gone).

Net: -28 lines (-81 / +53). No behavior change.

## Test plan
- [x] `bundle exec rspec spec/services/song_importer_spec.rb spec/services/song_importer_edge_cases_spec.rb spec/services/song_importer/` — 171/171 pass
- [x] `bundle exec rubocop` on all changed files — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)