### PR TITLE
Add admins/radio_stations endpoint

### DIFF
--- a/app/controllers/api/v1/admins/radio_stations_controller.rb
+++ b/app/controllers/api/v1/admins/radio_stations_controller.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Api::V1::Admins::RadioStationsController < ApplicationController
+  def index
+    radio_stations = RadioStation.order(:name)
+    render json: RadioStationSerializer.new(radio_stations).serializable_hash, status: :ok
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
       patch 'admins/songs/:id', to: 'admins/songs#update'
       get 'admins/artists', to: 'admins/artists#index'
       patch 'admins/artists/:id', to: 'admins/artists#update'
+      get 'admins/radio_stations', to: 'admins/radio_stations#index'
 
       resources :air_plays, only: %i[index]
       # Redirect old playlists routes to air_plays

--- a/spec/requests/api/v1/admins/radio_stations_spec.rb
+++ b/spec/requests/api/v1/admins/radio_stations_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'swagger_helper'
+
+RSpec.describe 'Admin Radio Stations API', type: :request do
+  let(:admin) { create(:admin) }
+  let(:Authorization) { "Bearer #{jwt_token_for(admin)}" }
+
+  path '/api/v1/admins/radio_stations' do
+    get 'List radio stations for admin' do
+      tags 'Admin Radio Stations'
+      security [{ bearer_auth: [] }]
+      produces 'application/json'
+
+      response '200', 'Radio stations retrieved successfully' do
+        let!(:radio_station) { create(:radio_station) }
+
+        run_test!
+      end
+
+      response '401', 'Not authenticated' do
+        let(:Authorization) { 'Bearer invalid_token' }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -121,6 +121,18 @@ paths:
           description: Current admin retrieved successfully
         '401':
           description: Not authenticated
+  "/api/v1/admins/radio_stations":
+    get:
+      summary: List radio stations for admin
+      tags:
+      - Admin Radio Stations
+      security:
+      - bearer_auth: []
+      responses:
+        '200':
+          description: Radio stations retrieved successfully
+        '401':
+          description: Not authenticated
   "/api/v1/admins/songs":
     get:
       summary: List songs for admin


### PR DESCRIPTION
## Summary
- Expose `GET /api/v1/admins/radio_stations` so the admin panel can list stations with its admin JWT.
- Reuses `RadioStationSerializer`; the existing public endpoint sits behind `authenticate_client!` (frontend JWT) so the admin token cannot use it.

## Test plan
- [x] `bundle exec rspec spec/requests/api/v1/admins/radio_stations_spec.rb`
- [x] `bundle exec rake rswag:specs:swaggerize`
- [ ] Verify the admin panel radio-station dropdown on the song import logs page populates after this is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)