### PR TITLE
Upgrade Bundler to 4.0.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@
         - run: sudo apt-get update -qq && sudo apt-get install -y tesseract-ocr tesseract-ocr-eng
 
         # install bundler
-        - run: gem install bundler:2.4.10
+        - run: gem install bundler:4.0.10
 
         # Bundle install dependencies
         - run: bundle config set path 'vendor/bundle'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -640,7 +640,7 @@ DEPENDENCIES
   will_paginate
 
 RUBY VERSION
-   ruby 4.0.1
+  ruby 4.0.1
 
 BUNDLED WITH
-   2.6.2
+  4.0.10


### PR DESCRIPTION
## Summary
- Bump `BUNDLED WITH` in `Gemfile.lock` from `2.6.2` to `4.0.10`
- Update the CircleCI pre-install pin from `bundler:2.4.10` to `bundler:4.0.10` so CI doesn't fall back to an older version before Bundler re-execs

## Why
Bundler 2.6.2 polyfilled `Gem::Platform::JAVA`, `MSWIN`, `MINGW`, `X64_LINUX`, `WINDOWS`, etc. — constants that RubyGems 4.0.3 (shipped with Ruby 4.0.1) already defines. Every `bundle` invocation emitted `warning: already initialized constant` noise. Bundler 4.0.10 guards the assignments so the warnings disappear.

## Test plan
- [x] `bundle --version` — prints `4.0.10`, no warnings
- [x] `bundle check` — `The Gemfile's dependencies are satisfied`, no warnings
- [x] `bundle exec rspec spec/services/mismatched_airplay_repair_spec.rb` — passes
- [ ] CircleCI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)