### PR TITLE
Add filters to song import logs API

### DIFF
--- a/app/controllers/api/v1/song_import_logs_controller.rb
+++ b/app/controllers/api/v1/song_import_logs_controller.rb
@@ -15,29 +15,17 @@ module Api
       def song_import_logs
         @song_import_logs ||= SongImportLog.includes(:radio_station, :song, :air_play)
                                 .by_radio_station(params[:radio_station_id])
-                                .then { |scope| filter_by_song(scope) }
-                                .then { |scope| filter_by_status(scope) }
-                                .then { |scope| filter_by_import_source(scope) }
+                                .by_song(params[:song_id])
+                                .by_status(params[:status])
+                                .by_import_source(params[:import_source])
+                                .by_llm_action(params[:llm_action])
+                                .created_from(params[:created_at_from])
+                                .created_until(params[:created_at_to])
+                                .broadcasted_from(params[:broadcasted_at_from])
+                                .broadcasted_until(params[:broadcasted_at_to])
+                                .linked(params[:linked])
                                 .order(created_at: :desc)
                                 .paginate(page: params[:page], per_page: params[:per_page] || 25)
-      end
-
-      def filter_by_song(scope)
-        return scope if params[:song_id].blank?
-
-        scope.where(song_id: params[:song_id])
-      end
-
-      def filter_by_status(scope)
-        return scope if params[:status].blank?
-
-        scope.where(status: params[:status])
-      end
-
-      def filter_by_import_source(scope)
-        return scope if params[:import_source].blank?
-
-        scope.where(import_source: params[:import_source])
       end
 
       def pagination_data(items)

--- a/app/models/song_import_log.rb
+++ b/app/models/song_import_log.rb
@@ -88,6 +88,19 @@ class SongImportLog < ApplicationRecord
   scope :older_than, ->(time) { where(created_at: ...time) }
   scope :recent, -> { where(created_at: 24.hours.ago..) }
   scope :by_radio_station, ->(radio_station_id) { where(radio_station_id:) if radio_station_id.present? }
+  scope :by_song, ->(song_id) { where(song_id:) if song_id.present? }
+  scope :by_status, ->(status) { where(status:) if status.present? }
+  scope :by_import_source, ->(import_source) { where(import_source:) if import_source.present? }
+  scope :by_llm_action, ->(llm_action) { where(llm_action:) if llm_action.present? }
+  scope :created_from, ->(time) { where(created_at: time..) if time.present? }
+  scope :created_until, ->(time) { where(created_at: ..time) if time.present? }
+  scope :broadcasted_from, ->(time) { where(broadcasted_at: time..) if time.present? }
+  scope :broadcasted_until, ->(time) { where(broadcasted_at: ..time) if time.present? }
+  scope :linked, lambda { |value|
+    next if value.nil? || value.to_s.empty?
+
+    ActiveModel::Type::Boolean.new.cast(value) ? where.not(song_id: nil) : where(song_id: nil)
+  }
 
   def self.to_csv(logs)
     require 'csv'

--- a/spec/models/song_import_log_spec.rb
+++ b/spec/models/song_import_log_spec.rb
@@ -131,6 +131,172 @@ describe SongImportLog do
         expect(described_class.by_radio_station(nil)).to include(old_log, recent_log, station_log)
       end
     end
+
+    describe '.by_song' do
+      let(:song) { create(:song) }
+      let!(:linked_log) { create(:song_import_log, song:) }
+
+      it 'filters by song_id', :aggregate_failures do
+        result = described_class.by_song(song.id)
+        expect(result).to include(linked_log)
+        expect(result).not_to include(old_log, recent_log)
+      end
+
+      it 'returns all logs when blank' do
+        expect(described_class.by_song(nil)).to include(old_log, recent_log, linked_log)
+      end
+    end
+
+    describe '.by_status' do
+      let!(:success_log) { create(:song_import_log, status: :success) }
+
+      it 'filters by status', :aggregate_failures do
+        result = described_class.by_status('success')
+        expect(result).to include(success_log)
+        expect(result).not_to include(old_log, recent_log)
+      end
+
+      it 'returns all logs when blank' do
+        expect(described_class.by_status(nil)).to include(old_log, recent_log, success_log)
+      end
+    end
+
+    describe '.by_import_source' do
+      let!(:recognition_log) { create(:song_import_log, :with_recognition) }
+      let!(:scraping_log) { create(:song_import_log, :with_scraping) }
+
+      it 'filters by import_source', :aggregate_failures do
+        result = described_class.by_import_source('recognition')
+        expect(result).to include(recognition_log)
+        expect(result).not_to include(scraping_log)
+      end
+
+      it 'returns all logs when blank' do
+        expect(described_class.by_import_source(nil)).to include(recognition_log, scraping_log)
+      end
+    end
+
+    describe '.by_llm_action' do
+      let!(:cleanup_log) { create(:song_import_log, llm_action: 'track_name_cleanup') }
+
+      it 'filters by llm_action', :aggregate_failures do
+        result = described_class.by_llm_action('track_name_cleanup')
+        expect(result).to include(cleanup_log)
+        expect(result).not_to include(old_log, recent_log)
+      end
+
+      it 'returns all logs when blank' do
+        expect(described_class.by_llm_action(nil)).to include(old_log, recent_log, cleanup_log)
+      end
+    end
+
+    describe '.created_from' do
+      it 'includes logs created at or after the given time', :aggregate_failures do
+        result = described_class.created_from(1.day.ago)
+        expect(result).to include(recent_log)
+        expect(result).not_to include(old_log)
+      end
+
+      it 'accepts ISO8601 string input', :aggregate_failures do
+        result = described_class.created_from(1.day.ago.iso8601)
+        expect(result).to include(recent_log)
+        expect(result).not_to include(old_log)
+      end
+
+      it 'is inclusive on the lower bound' do
+        boundary_time = 1.day.ago
+        boundary = create(:song_import_log, created_at: boundary_time)
+        expect(described_class.created_from(boundary_time)).to include(boundary)
+      end
+
+      it 'returns all logs when blank' do
+        expect(described_class.created_from(nil)).to include(old_log, recent_log)
+      end
+    end
+
+    describe '.created_until' do
+      it 'includes logs created at or before the given time', :aggregate_failures do
+        result = described_class.created_until(1.day.ago)
+        expect(result).to include(old_log)
+        expect(result).not_to include(recent_log)
+      end
+
+      it 'is inclusive on the upper bound' do
+        boundary_time = 1.day.ago
+        boundary = create(:song_import_log, created_at: boundary_time)
+        expect(described_class.created_until(boundary_time)).to include(boundary)
+      end
+
+      it 'returns all logs when blank' do
+        expect(described_class.created_until(nil)).to include(old_log, recent_log)
+      end
+    end
+
+    describe '.broadcasted_from and .broadcasted_until' do
+      let!(:old_broadcast) { create(:song_import_log, broadcasted_at: 3.days.ago) }
+      let!(:recent_broadcast) { create(:song_import_log, broadcasted_at: 1.hour.ago) }
+
+      it 'broadcasted_from filters by lower bound', :aggregate_failures do
+        result = described_class.broadcasted_from(2.days.ago)
+        expect(result).to include(recent_broadcast)
+        expect(result).not_to include(old_broadcast)
+      end
+
+      it 'broadcasted_until filters by upper bound', :aggregate_failures do
+        result = described_class.broadcasted_until(2.days.ago)
+        expect(result).to include(old_broadcast)
+        expect(result).not_to include(recent_broadcast)
+      end
+
+      it 'combined they produce a range', :aggregate_failures do
+        result = described_class.broadcasted_from(2.days.ago).broadcasted_until(30.minutes.ago)
+        expect(result).to include(recent_broadcast)
+        expect(result).not_to include(old_broadcast)
+      end
+
+      it 'both return all logs when blank' do
+        scope = described_class.broadcasted_from(nil).broadcasted_until(nil)
+        expect(scope).to include(old_broadcast, recent_broadcast)
+      end
+    end
+
+    describe '.linked' do
+      let(:song) { create(:song) }
+      let!(:linked_log) { create(:song_import_log, song:) }
+      let!(:unlinked_log) { create(:song_import_log, song: nil) }
+
+      context 'when true' do
+        it 'includes only logs with a song', :aggregate_failures do
+          result = described_class.linked(true)
+          expect(result).to include(linked_log)
+          expect(result).not_to include(unlinked_log)
+        end
+
+        it 'coerces string "true"', :aggregate_failures do
+          result = described_class.linked('true')
+          expect(result).to include(linked_log)
+          expect(result).not_to include(unlinked_log)
+        end
+      end
+
+      context 'when false' do
+        it 'includes only logs without a song', :aggregate_failures do
+          result = described_class.linked(false)
+          expect(result).to include(unlinked_log)
+          expect(result).not_to include(linked_log)
+        end
+
+        it 'coerces string "false"', :aggregate_failures do
+          result = described_class.linked('false')
+          expect(result).to include(unlinked_log)
+          expect(result).not_to include(linked_log)
+        end
+      end
+
+      it 'returns all logs when blank' do
+        expect(described_class.linked(nil)).to include(linked_log, unlinked_log)
+      end
+    end
   end
 
   describe '.to_csv' do

--- a/spec/requests/api/v1/song_import_logs_spec.rb
+++ b/spec/requests/api/v1/song_import_logs_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe 'SongImportLogs API', type: :request do
                 description: 'Filter by import source: recognition, scraping'
       parameter name: :song_id, in: :query, type: :integer, required: false,
                 description: 'Filter by song ID'
+      parameter name: :llm_action, in: :query, type: :string, required: false,
+                description: 'Filter by LLM action: track_name_cleanup, alternative_search_queries, borderline_match_validation'
+      parameter name: :created_at_from, in: :query, type: :string, required: false,
+                description: 'Filter logs created at or after this timestamp (ISO8601 or YYYY-MM-DD)'
+      parameter name: :created_at_to, in: :query, type: :string, required: false,
+                description: 'Filter logs created at or before this timestamp (ISO8601 or YYYY-MM-DD)'
+      parameter name: :broadcasted_at_from, in: :query, type: :string, required: false,
+                description: 'Filter logs broadcasted at or after this timestamp (ISO8601 or YYYY-MM-DD)'
+      parameter name: :broadcasted_at_to, in: :query, type: :string, required: false,
+                description: 'Filter logs broadcasted at or before this timestamp (ISO8601 or YYYY-MM-DD)'
+      parameter name: :linked, in: :query, type: :boolean, required: false,
+                description: 'Filter by whether the log is linked to a song (true = has song_id, false = null)'
 
       let(:admin) { create(:admin) }
       let(:Authorization) { "Bearer #{jwt_token_for(admin)}" }
@@ -65,6 +77,54 @@ RSpec.describe 'SongImportLogs API', type: :request do
           json = JSON.parse(response.body)
           expect(json['data'].length).to eq(1)
           expect(json['data'].first['attributes']['radio_station']['id']).to eq(radio_station.id)
+        end
+      end
+
+      response '200', 'Filtered by created_at range' do
+        let!(:old_log) { create(:song_import_log, :with_recognition, created_at: 3.days.ago) }
+        let!(:recent_log) { create(:song_import_log, :with_recognition, created_at: 1.hour.ago) }
+        let(:created_at_from) { 2.days.ago.iso8601 }
+
+        run_test! do |response|
+          json = JSON.parse(response.body)
+          ids = json['data'].map { |d| d['id'].to_i }
+          expect(ids).to contain_exactly(recent_log.id)
+        end
+      end
+
+      response '200', 'Filtered by broadcasted_at range' do
+        let!(:old_log) { create(:song_import_log, :with_recognition, broadcasted_at: 3.days.ago) }
+        let!(:recent_log) { create(:song_import_log, :with_recognition, broadcasted_at: 1.hour.ago) }
+        let(:broadcasted_at_to) { 2.days.ago.iso8601 }
+
+        run_test! do |response|
+          json = JSON.parse(response.body)
+          ids = json['data'].map { |d| d['id'].to_i }
+          expect(ids).to contain_exactly(old_log.id)
+        end
+      end
+
+      response '200', 'Filtered by llm_action' do
+        let!(:log1) { create(:song_import_log, :with_recognition, llm_action: 'track_name_cleanup') }
+        let!(:log2) { create(:song_import_log, :with_recognition, llm_action: 'borderline_match_validation') }
+        let(:llm_action) { 'track_name_cleanup' }
+
+        run_test! do |response|
+          json = JSON.parse(response.body)
+          ids = json['data'].map { |d| d['id'].to_i }
+          expect(ids).to contain_exactly(log1.id)
+        end
+      end
+
+      response '200', 'Filtered by linked=false (unlinked logs)' do
+        let!(:log1) { create(:song_import_log, :with_recognition, :success) }
+        let!(:log2) { create(:song_import_log, :failed) }
+        let(:linked) { false }
+
+        run_test! do |response|
+          json = JSON.parse(response.body)
+          ids = json['data'].map { |d| d['id'].to_i }
+          expect(ids).to contain_exactly(log2.id)
         end
       end
     end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -2501,9 +2501,49 @@ paths:
         description: Filter by song ID
         schema:
           type: integer
+      - name: llm_action
+        in: query
+        required: false
+        description: 'Filter by LLM action: track_name_cleanup, alternative_search_queries,
+          borderline_match_validation'
+        schema:
+          type: string
+      - name: created_at_from
+        in: query
+        required: false
+        description: Filter logs created at or after this timestamp (ISO8601 or YYYY-MM-DD)
+        schema:
+          type: string
+      - name: created_at_to
+        in: query
+        required: false
+        description: Filter logs created at or before this timestamp (ISO8601 or YYYY-MM-DD)
+        schema:
+          type: string
+      - name: broadcasted_at_from
+        in: query
+        required: false
+        description: Filter logs broadcasted at or after this timestamp (ISO8601 or
+          YYYY-MM-DD)
+        schema:
+          type: string
+      - name: broadcasted_at_to
+        in: query
+        required: false
+        description: Filter logs broadcasted at or before this timestamp (ISO8601
+          or YYYY-MM-DD)
+        schema:
+          type: string
+      - name: linked
+        in: query
+        required: false
+        description: Filter by whether the log is linked to a song (true = has song_id,
+          false = null)
+        schema:
+          type: boolean
       responses:
         '200':
-          description: Filtered by radio station
+          description: Filtered by linked=false (unlinked logs)
   "/api/v1/songs":
     get:
       summary: List songs


### PR DESCRIPTION
## Summary
- Adds six new query params to `GET /api/v1/admins/song_import_logs`: `created_at_from`, `created_at_to`, `broadcasted_at_from`, `broadcasted_at_to`, `llm_action`, and `linked` (boolean — log is/isn't tied to a song)
- Existing filter logic moved out of controller into model scopes (`by_song`, `by_status`, `by_import_source`, `by_llm_action`, `created_from/until`, `broadcasted_from/until`, `linked`) for the thin-controller pattern
- Swagger regenerated

## Test plan
- [x] Model spec covers every scope: match + exclusion + blank no-op, plus ISO8601 string input and boundary inclusivity for time ranges, and boolean/string coercion for `linked`
- [x] Request spec covers each new filter end-to-end
- [x] `bundle exec rspec spec/models/song_import_log_spec.rb spec/requests/api/v1/song_import_logs_spec.rb` — 50 examples, 0 failures
- [x] `bundle exec rubocop` on all changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)