### PR TITLE
Add Tesseract language packs for multilingual OCR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@
           key: airplays-{{ checksum "Gemfile.lock" }}
 
         # Install system dependencies
-        - run: sudo apt-get update -qq && sudo apt-get install -y tesseract-ocr tesseract-ocr-eng
+        - run: sudo apt-get update -qq && sudo apt-get install -y tesseract-ocr tesseract-ocr-eng tesseract-ocr-nld tesseract-ocr-deu tesseract-ocr-fra tesseract-ocr-spa tesseract-ocr-ita tesseract-ocr-por tesseract-ocr-rus tesseract-ocr-tur
 
         # install bundler
         - run: gem install bundler:4.0.10

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -376,7 +376,7 @@ Schema definitions are configured in `spec/swagger_helper.rb`. The generated `sw
 The `Dockerfile` uses a two-stage build with `ruby:4.0.2-slim-bookworm`:
 
 1. **Builder stage** — installs build deps (`build-essential`, `libpq-dev`, `libyaml-dev`, `libicu-dev`, `zlib1g-dev`, `pkg-config`), SongRec from PPA, and runs `bundle install`
-2. **Runtime stage** — installs only runtime deps (`libpq5`, `libyaml-0-2`, `libicu72`, `ffmpeg`, `libchromaprint-tools`, `tesseract-ocr`, `libjemalloc2`, `songrec`), copies built app and gems from builder
+2. **Runtime stage** — installs only runtime deps (`libpq5`, `libyaml-0-2`, `libicu72`, `ffmpeg`, `libchromaprint-tools`, `tesseract-ocr` + language packs, `libjemalloc2`, `songrec`), copies built app and gems from builder
 
 ### Memory Optimization
 
@@ -460,7 +460,7 @@ Yoursafe Radio streams via Amazon IVS HLS with a video overlay displaying "JE LU
 3. Parser finds the last line containing ` - ` separator (skipping header lines like "JE LUISTERT NAAR")
 4. Splits into artist name and title
 
-**Dependencies:** `tesseract-ocr` + `tesseract-ocr-eng` system packages, `rtesseract` gem.
+**Dependencies:** `tesseract-ocr` + language packs (`eng`, `nld`, `deu`, `fra`, `spa`, `ita`, `por`, `rus`, `tur`) system packages, `rtesseract` gem. The full language set is configured in `YoursafeVideoProcessor::OCR_LANGUAGES` so Tesseract can read Cyrillic and other non-Latin scripts that appear on the overlay (e.g., Russian tracks).
 
 ### Planned: Populate AcoustID Database
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,13 @@ RUN apt-get update -qq && \
       tesseract-ocr \
       tesseract-ocr-eng \
       tesseract-ocr-nld \
+      tesseract-ocr-deu \
+      tesseract-ocr-fra \
+      tesseract-ocr-spa \
+      tesseract-ocr-ita \
+      tesseract-ocr-por \
+      tesseract-ocr-rus \
+      tesseract-ocr-tur \
       libjemalloc2 \
       curl \
       wget \

--- a/app/services/track_scraper/yoursafe_video_processor.rb
+++ b/app/services/track_scraper/yoursafe_video_processor.rb
@@ -2,6 +2,7 @@
 
 class TrackScraper::YoursafeVideoProcessor < TrackScraper
   ARTIST_TITLE_SEPARATOR = ' - '
+  OCR_LANGUAGES = 'eng+nld+deu+fra+spa+ita+por+rus+tur'
 
   def last_played_song
     frame_file = extract_video_frame
@@ -43,7 +44,7 @@ class TrackScraper::YoursafeVideoProcessor < TrackScraper
   end
 
   def ocr_frame(frame_file)
-    image = RTesseract.new(frame_file, lang: 'eng')
+    image = RTesseract.new(frame_file, lang: OCR_LANGUAGES)
     image.to_s.strip
   end
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -13,6 +13,13 @@ RUN apt-get update -qq && \
       tesseract-ocr \
       tesseract-ocr-eng \
       tesseract-ocr-nld \
+      tesseract-ocr-deu \
+      tesseract-ocr-fra \
+      tesseract-ocr-spa \
+      tesseract-ocr-ita \
+      tesseract-ocr-por \
+      tesseract-ocr-rus \
+      tesseract-ocr-tur \
       libjemalloc2 \
       curl \
       wget \

--- a/spec/services/track_scraper/yoursafe_video_processor_spec.rb
+++ b/spec/services/track_scraper/yoursafe_video_processor_spec.rb
@@ -26,7 +26,7 @@ describe TrackScraper::YoursafeVideoProcessor, type: :service do
       before do
         allow(File).to receive(:exist?).with(frame_file).and_return(true)
         rtesseract_instance = instance_double(RTesseract, to_s: ocr_text)
-        allow(RTesseract).to receive(:new).with(frame_file, lang: 'eng').and_return(rtesseract_instance)
+        allow(RTesseract).to receive(:new).with(frame_file, lang: described_class::OCR_LANGUAGES).and_return(rtesseract_instance)
       end
 
       it 'sets the artist name' do
@@ -61,7 +61,7 @@ describe TrackScraper::YoursafeVideoProcessor, type: :service do
       before do
         allow(File).to receive(:exist?).with(frame_file).and_return(true)
         rtesseract_instance = instance_double(RTesseract, to_s: ocr_text)
-        allow(RTesseract).to receive(:new).with(frame_file, lang: 'eng').and_return(rtesseract_instance)
+        allow(RTesseract).to receive(:new).with(frame_file, lang: described_class::OCR_LANGUAGES).and_return(rtesseract_instance)
       end
 
       it 'sets the full artist string' do
@@ -89,7 +89,7 @@ describe TrackScraper::YoursafeVideoProcessor, type: :service do
       before do
         allow(File).to receive(:exist?).with(frame_file).and_return(true)
         rtesseract_instance = instance_double(RTesseract, to_s: '')
-        allow(RTesseract).to receive(:new).with(frame_file, lang: 'eng').and_return(rtesseract_instance)
+        allow(RTesseract).to receive(:new).with(frame_file, lang: described_class::OCR_LANGUAGES).and_return(rtesseract_instance)
       end
 
       it 'returns false' do
@@ -104,7 +104,7 @@ describe TrackScraper::YoursafeVideoProcessor, type: :service do
       before do
         allow(File).to receive(:exist?).with(frame_file).and_return(true)
         rtesseract_instance = instance_double(RTesseract, to_s: ocr_text)
-        allow(RTesseract).to receive(:new).with(frame_file, lang: 'eng').and_return(rtesseract_instance)
+        allow(RTesseract).to receive(:new).with(frame_file, lang: described_class::OCR_LANGUAGES).and_return(rtesseract_instance)
       end
 
       it 'returns false' do
@@ -117,7 +117,7 @@ describe TrackScraper::YoursafeVideoProcessor, type: :service do
 
       before do
         allow(File).to receive(:exist?).with(frame_file).and_return(true)
-        allow(RTesseract).to receive(:new).with(frame_file, lang: 'eng').and_raise(StandardError, 'OCR failed')
+        allow(RTesseract).to receive(:new).with(frame_file, lang: described_class::OCR_LANGUAGES).and_raise(StandardError, 'OCR failed')
         allow(Rails.logger).to receive(:warn).and_call_original
         allow(ExceptionNotifier).to receive(:notify).and_call_original
       end


### PR DESCRIPTION
## Summary
- Installs `tesseract-ocr-{deu,fra,spa,ita,por,rus,tur}` alongside the existing `eng`/`nld` packs in `Dockerfile`, `dev.Dockerfile`, and `.circleci/config.yml`.
- `YoursafeVideoProcessor` now runs Tesseract with `eng+nld+deu+fra+spa+ita+por+rus+tur` (exposed via `OCR_LANGUAGES` constant) so non-Latin scripts on the overlay are recognized correctly.

## Context
Triggered by import log 2765957 (song 204291): Yoursafe Radio played a Russian track whose overlay was Cyrillic. With only `eng` available, Tesseract force-mapped the glyphs to Latin characters, producing garbage like `Bana [mutpvenko & Ans Mepecunag - Cunyat (u3 K/cp «Anuca B CtpaHe Yyfec»)`. Because `SongExtractor#find_or_create_by_title` creates a song from scraped data when all external services miss, a junk artist/song pair landed in the DB. Fixing the OCR language set prevents the garbled input in the first place.

Languages chosen for Dutch-radio relevance: German (border/Schlager), French (chansons, Belgian FR artists), Spanish (Latin pop/reggaeton), Italian (Italo/classics), Portuguese (Brazilian pop), Russian (this bug), Turkish (large NL community).

## Test plan
- [x] `bundle exec rubocop` on `app/services/track_scraper/yoursafe_video_processor.rb` and its spec — no offenses
- [x] `bundle exec rspec spec/services/track_scraper/yoursafe_video_processor_spec.rb` — 13 examples, 0 failures
- [ ] CI build passes (Docker images build with new packs)
- [ ] Post-deploy: verify a Russian/non-Latin Yoursafe track produces clean `ocr_text` in `SongImportLog`

🤖 Generated with [Claude Code](https://claude.com/claude-code)