### PR TITLE
Add SongImportLogRollback service + rake task

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,8 @@ bundle exec rake data_repair:find_mismatched_airplays[limit]   # Dry run: detect
 bundle exec rake data_repair:fix_mismatched_airplays[limit]    # Fix airplays linked to wrong songs
 bundle exec rake data_repair:find_contaminated_isrcs[limit]    # Dry run: find songs with cross-contaminated ISRCs
 bundle exec rake data_repair:fix_contaminated_isrcs[limit]     # Fix songs with cross-contaminated ISRCs
+bundle exec rake data_repair:rollback_import_log[log_id]       # Dry run: preview rollback of a single SongImportLog
+bundle exec rake data_repair:rollback_import_log[log_id,apply] # Apply: destroy airplay, destroy song if orphaned, mark log failed
 bundle exec rake optimization:vacuum                           # PostgreSQL VACUUM FULL ANALYZE
 
 # Hit Potential
@@ -82,6 +84,7 @@ The app uses service objects extensively in `app/services/`:
 - `DuplicateArtistMerger` - Finds and merges duplicate artists via Spotify ID or fuzzy name matching (Jaro-Winkler, threshold: 92)
 - `DuplicateSongMerger` - Finds and merges duplicate songs via Spotify ID or fuzzy title matching (Jaro-Winkler, threshold: 92)
 - `MismatchedAirplayRepair` - Detects and fixes airplays linked to wrong songs via two detectors: (1) title mismatch — import log title vs linked song title (Jaro-Winkler < 70%); (2) spotify_track_id mismatch — the log's Spotify ID points to a different canonical song than the one linked. Reassigns airplays to the canonical song (found by Spotify track ID, exact match, or newly created).
+- `SongImportLogRollback` - Rolls back a single `SongImportLog`: destroys the linked airplay, destroys the linked song if no other airplays reference it, marks the log `failed` with a rollback reason. Guards against orphaning charts (skips song deletion if chart positions exist) and preserves songs played on other stations.
 - `HitPotentialCalculator` - Predicts song hit potential (0-100) using multi-signal scoring: audio features (50%), artist popularity (20%), engagement metrics (15%), release recency (15%)
 - `SoundProfileGenerator` - Generates per-station sound profiles with audio feature averages, top genres/tags, release decade distribution, and bilingual descriptions (EN/NL). Uses song-count-weighted percentiles and peak decade detection (≥15% threshold) for accurate era descriptions instead of naive min/max year ranges
 - `NaturalLanguageSearch` - Translates free-text queries (e.g., "upbeat Dutch songs on Radio 538 last week") into structured filters via `Llm::QueryTranslator`, then applies faceted search. Supports mood-based filtering using Spotify audio feature ranges, result limiting ("top 3 songs", "most popular song" → `.limit()`), and lyrics-based song identification

--- a/app/services/song_import_log_rollback.rb
+++ b/app/services/song_import_log_rollback.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+# Rolls back a single SongImportLog by ID: destroys the linked airplay,
+# destroys the linked song if no other airplays reference it, and marks
+# the log as failed with a rollback reason.
+#
+# Guards:
+#  - Skips song deletion if the song still has airplays from other stations.
+#  - Skips song deletion if the song has chart positions (keeps charts intact).
+class SongImportLogRollback
+  ROLLBACK_REASON = 'rolled_back'
+
+  attr_reader :results
+
+  def initialize(log_id, dry_run: true, reason: ROLLBACK_REASON)
+    @log_id = log_id
+    @dry_run = dry_run
+    @reason = reason
+    @results = initial_results
+  end
+
+  def run
+    log = SongImportLog.find_by(id: @log_id)
+    return error_result('import log not found') if log.blank?
+
+    ActiveRecord::Base.transaction do
+      rollback_airplay(log)
+      rollback_song(log)
+      mark_log_rolled_back(log)
+    end
+
+    @results
+  rescue StandardError => e
+    @results[:errors] << e.message
+    @results
+  end
+
+  private
+
+  def initial_results
+    {
+      log_id: @log_id,
+      air_play_destroyed: false,
+      song_destroyed: false,
+      song_kept_reason: nil,
+      errors: []
+    }
+  end
+
+  def error_result(message)
+    @results[:errors] << message
+    @results
+  end
+
+  def rollback_airplay(log)
+    air_play = log.air_play
+    return if air_play.blank?
+
+    @results[:air_play_destroyed] = true
+    air_play.destroy! unless @dry_run
+  end
+
+  def rollback_song(log)
+    song = log.song
+    return if song.blank?
+
+    reason = song_kept_reason(song, log.air_play_id)
+    if reason.present?
+      @results[:song_kept_reason] = reason
+      return
+    end
+
+    @results[:song_destroyed] = true
+    return if @dry_run
+
+    ArtistsSong.where(song_id: song.id).delete_all
+    song.destroy!
+  end
+
+  def song_kept_reason(song, excluded_air_play_id)
+    return 'other_airplays_exist' if other_airplays_exist?(song, excluded_air_play_id)
+    return 'has_chart_positions' if song.chart_positions.exists?
+
+    nil
+  end
+
+  def other_airplays_exist?(song, excluded_air_play_id)
+    scope = AirPlay.where(song_id: song.id)
+    scope = scope.where.not(id: excluded_air_play_id) if excluded_air_play_id.present?
+    scope.exists?
+  end
+
+  def mark_log_rolled_back(log)
+    return if @dry_run
+
+    log.update!(status: :failed, failure_reason: @reason, song_id: nil, air_play_id: nil)
+  end
+end

--- a/lib/tasks/data_repair.rake
+++ b/lib/tasks/data_repair.rake
@@ -1338,4 +1338,28 @@ namespace :data_repair do
     puts "Errors: #{results[:errors].count}" if results[:errors].any?
     results[:errors].each { |e| puts "  Song ##{e[:song_id]}: #{e[:error]}" }
   end
+
+  desc 'Roll back a single SongImportLog: destroy airplay, destroy song if orphaned, mark log failed. ' \
+       'Dry run by default. Usage: rake data_repair:rollback_import_log[2765957] or [2765957,apply]'
+  task :rollback_import_log, %i[log_id mode] => :environment do |_t, args|
+    log_id = args[:log_id].to_i
+    if log_id.zero?
+      puts 'Usage: rake data_repair:rollback_import_log[LOG_ID] or rake data_repair:rollback_import_log[LOG_ID,apply]'
+      next
+    end
+
+    dry_run = args[:mode] != 'apply'
+    puts "Rolling back SongImportLog ##{log_id} (#{dry_run ? 'DRY RUN' : 'APPLY'})"
+    puts '=' * 80
+
+    results = SongImportLogRollback.new(log_id, dry_run:).run
+
+    puts "AirPlay destroyed: #{results[:air_play_destroyed]}"
+    puts "Song destroyed:    #{results[:song_destroyed]}"
+    puts "Song kept reason:  #{results[:song_kept_reason]}" if results[:song_kept_reason]
+    if results[:errors].any?
+      puts "Errors: #{results[:errors].count}"
+      results[:errors].each { |e| puts "  #{e}" }
+    end
+  end
 end

--- a/spec/services/song_import_log_rollback_spec.rb
+++ b/spec/services/song_import_log_rollback_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SongImportLogRollback do
+  describe '#run' do
+    let(:radio_station) { create(:radio_station) }
+    let(:artist) { create(:artist, name: 'OCR Garbage Artist') }
+    let(:song) { create(:song, title: 'OCR Garbage Title', artists: [artist]) }
+    let(:air_play) { create(:air_play, song: song, radio_station: radio_station) }
+    let(:import_log) do
+      create(:song_import_log,
+             radio_station: radio_station,
+             song: song,
+             air_play: air_play,
+             status: :success,
+             scraped_artist: 'OCR Garbage Artist',
+             scraped_title: 'OCR Garbage Title',
+             import_source: :scraping)
+    end
+
+    context 'with dry_run: true' do
+      subject(:results) { described_class.new(import_log.id, dry_run: true).run }
+
+      it 'reports what would happen without mutating', :aggregate_failures do
+        expect(results[:air_play_destroyed]).to be true
+        expect(results[:song_destroyed]).to be true
+        expect(results[:errors]).to be_empty
+        expect(AirPlay.exists?(air_play.id)).to be true
+        expect(Song.exists?(song.id)).to be true
+        expect(import_log.reload.status).to eq('success')
+      end
+    end
+
+    context 'with dry_run: false and no other airplays' do
+      subject(:results) { described_class.new(import_log.id, dry_run: false).run }
+
+      before { results }
+
+      it 'destroys the airplay and the song', :aggregate_failures do
+        expect(AirPlay.exists?(air_play.id)).to be false
+        expect(Song.exists?(song.id)).to be false
+        expect(results[:air_play_destroyed]).to be true
+        expect(results[:song_destroyed]).to be true
+      end
+
+      it 'marks the log as failed with rolled_back reason', :aggregate_failures do
+        import_log.reload
+        expect(import_log.status).to eq('failed')
+        expect(import_log.failure_reason).to eq('rolled_back')
+        expect(import_log.song_id).to be_nil
+        expect(import_log.air_play_id).to be_nil
+      end
+    end
+
+    context 'when the song has airplays from other stations' do
+      subject(:results) { described_class.new(import_log.id, dry_run: false).run }
+
+      let(:other_station) { create(:radio_station, name: 'Other Station') }
+      let!(:other_air_play) { create(:air_play, song: song, radio_station: other_station) }
+
+      it 'destroys only the targeted airplay and keeps the song', :aggregate_failures do
+        expect(results[:air_play_destroyed]).to be true
+        expect(results[:song_destroyed]).to be false
+        expect(results[:song_kept_reason]).to eq('other_airplays_exist')
+        expect(AirPlay.exists?(air_play.id)).to be false
+        expect(AirPlay.exists?(other_air_play.id)).to be true
+        expect(Song.exists?(song.id)).to be true
+      end
+    end
+
+    context 'when the song has chart positions' do
+      subject(:results) { described_class.new(import_log.id, dry_run: false).run }
+
+      let!(:chart_position) { create(:chart_position, positianable: song) }
+
+      it 'destroys airplay but keeps the song', :aggregate_failures do
+        expect(results[:air_play_destroyed]).to be true
+        expect(results[:song_destroyed]).to be false
+        expect(results[:song_kept_reason]).to eq('has_chart_positions')
+        expect(Song.exists?(song.id)).to be true
+        expect(chart_position.reload).to be_present
+      end
+    end
+
+    context 'when the log does not exist' do
+      subject(:results) { described_class.new(999_999_999, dry_run: false).run }
+
+      it 'returns an error result', :aggregate_failures do
+        expect(results[:errors]).to include('import log not found')
+        expect(results[:air_play_destroyed]).to be false
+        expect(results[:song_destroyed]).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- New \`SongImportLogRollback\` service rolls back a single \`SongImportLog\`: destroys the airplay, destroys the song if it has no airplays from other stations, and marks the log \`failed\` with a \`rolled_back\` failure reason.
- Rake task \`data_repair:rollback_import_log[LOG_ID]\` (dry-run by default; append \`,apply\` to execute).
- Guards against collateral damage: skips song deletion if airplays from other stations or chart positions exist.

## Context
Needed to clean up the garbage row introduced on Yoursafe Radio before the Tesseract language-pack fix (#2054) was deployed:

- \`SongImportLog\` 2765957 — OCR'd Cyrillic text mapped to Latin characters
- \`Song\` 204291 — created from the OCR garbage (no external IDs)
- \`AirPlay\` 6573479 — linked to the garbage song

Once #2054 is deployed, run on production:

\`\`\`
bundle exec rake data_repair:rollback_import_log[2765957]         # dry run
bundle exec rake data_repair:rollback_import_log[2765957,apply]   # apply
\`\`\`

## Implementation notes
- Wrapped in a transaction so partial failures don't leave half-deleted state.
- \`ArtistsSong.where(song_id: ...).delete_all\` is used explicitly — the \`has_many :artists_songs\` association defaults to a nullify delete strategy, which collides with the \`NOT NULL\` constraints on the join table.

## Test plan
- [x] \`bundle exec rubocop\` on all touched files — no offenses
- [x] \`bundle exec rspec spec/services/song_import_log_rollback_spec.rb\` — 6 examples, 0 failures
- [ ] CI green
- [ ] After #2054 is deployed, run the rake task against production and verify the target rows are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)