### PR TITLE
Transliterate non-Latin slugs via babosa

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ bundle exec rake hit_potential:backfill                        # Backfill hit_po
 bundle exec rake slug:backfill_songs                           # Backfill slugs for songs without one
 bundle exec rake slug:backfill_artists                         # Backfill slugs for artists without one
 bundle exec rake slug:backfill_all                             # Backfill slugs for both songs and artists
+bundle exec rake slug:repair_empty                             # Regenerate slugs built from empty parameterize output (non-Latin titles)
 
 # Memory Diagnostics
 bundle exec rake memory:stats                                  # Show RSS, GC stats, top object classes

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 ruby '4.0.2'
 
+gem 'babosa', '~> 2.0'
 gem 'bootsnap', require: false
 gem 'charlock_holmes', '~> 0.7.7'
 gem 'csv', '~> 3.3', '>= 3.3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
       activerecord (>= 6.0.0)
       activesupport (>= 6.0.0)
     ast (2.4.3)
+    babosa (2.0.0)
     base64 (0.3.0)
     bcrypt (3.1.22)
     bigdecimal (4.1.0)
@@ -569,6 +570,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotaterb
+  babosa (~> 2.0)
   bootsnap
   brakeman
   bullet

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -37,6 +37,7 @@ class Artist < ApplicationRecord
   include ChartConcern
   include TimeAnalyticsConcern
   include ArtistSearchConcern
+  include Sluggable
 
   pg_search_scope :search_by_name,
                   against: :name,
@@ -153,25 +154,7 @@ class Artist < ApplicationRecord
 
   private
 
-  def set_slug
-    return if slug.present?
-
-    base_slug = name.parameterize
-    self.slug = unique_slug(base_slug)
-  end
-
-  def update_slug
-    base_slug = name.parameterize
-    update_column(:slug, unique_slug(base_slug)) # rubocop:disable Rails/SkipsModelValidations
-  end
-
-  def unique_slug(base_slug)
-    candidate = base_slug
-    counter = 1
-    while Artist.where(slug: candidate).where.not(id:).exists?
-      counter += 1
-      candidate = "#{base_slug}-#{counter}"
-    end
-    candidate
+  def slug_source
+    name
   end
 end

--- a/app/models/concerns/sluggable.rb
+++ b/app/models/concerns/sluggable.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Sluggable
+  extend ActiveSupport::Concern
+
+  TRANSLITERATION_LOCALES = %i[russian greek].freeze
+
+  def update_slug
+    update!(slug: next_slug)
+  end
+
+  private
+
+  def set_slug
+    return if slug.present?
+
+    self.slug = next_slug
+  end
+
+  def next_slug
+    unique_slug(slug_base)
+  end
+
+  def slug_base
+    base = slug_source.to_s.to_slug.transliterate(*TRANSLITERATION_LOCALES).normalize.to_s
+    base.presence || "#{self.class.model_name.singular}-#{SecureRandom.hex(4)}"
+  end
+
+  def unique_slug(base_slug)
+    candidate = base_slug
+    counter = 1
+    while self.class.where(slug: candidate).where.not(id:).exists?
+      counter += 1
+      candidate = "#{base_slug}-#{counter}"
+    end
+    candidate
+  end
+end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -55,6 +55,7 @@ class Song < ApplicationRecord
   include ChartConcern
   include TimeAnalyticsConcern
   include SongSearchConcern
+  include Sluggable
 
   pg_search_scope :search_by_text,
                   against: :search_text,
@@ -319,24 +320,8 @@ class Song < ApplicationRecord
     update_column(:search_text, "#{artists.pluck(:name).join(' ')} #{title}")
   end
 
-  def set_slug
-    return if slug.present?
-
-    self.slug = unique_slug("#{title} #{artists.first&.name}".parameterize)
-  end
-
-  def update_slug
-    update_column(:slug, unique_slug("#{title} #{artists.first&.name}".parameterize))
-  end
-
-  def unique_slug(base_slug)
-    candidate = base_slug
-    counter = 1
-    while Song.where(slug: candidate).where.not(id:).exists?
-      counter += 1
-      candidate = "#{base_slug}-#{counter}"
-    end
-    candidate
+  def slug_source
+    "#{title} #{artists.first&.name}"
   end
 
   def should_update_youtube?

--- a/lib/tasks/slug_backfill.rake
+++ b/lib/tasks/slug_backfill.rake
@@ -8,8 +8,7 @@ namespace :slug do
 
     processed = 0
     Song.where(slug: nil).find_each do |song|
-      song.send(:set_slug)
-      song.update_column(:slug, song.slug) # rubocop:disable Rails/SkipsModelValidations
+      song.update_slug
       processed += 1
       print "\rProcessed #{processed}/#{total}..." if (processed % 1000).zero?
     end
@@ -24,8 +23,7 @@ namespace :slug do
 
     processed = 0
     Artist.where(slug: nil).find_each do |artist|
-      artist.send(:set_slug)
-      artist.update_column(:slug, artist.slug) # rubocop:disable Rails/SkipsModelValidations
+      artist.update_slug
       processed += 1
       print "\rProcessed #{processed}/#{total}..." if (processed % 1000).zero?
     end
@@ -35,4 +33,28 @@ namespace :slug do
 
   desc 'Backfill slugs for all songs and artists without a slug'
   task backfill_all: %i[backfill_songs backfill_artists]
+
+  desc 'Regenerate slugs that were built from empty parameterize output (non-Latin titles)'
+  task repair_empty: :environment do
+    song_scope = Song.where("slug = '' OR slug ~ '^-[0-9]+$'")
+    artist_scope = Artist.where("slug = '' OR slug ~ '^-[0-9]+$'")
+
+    song_total = song_scope.count
+    artist_total = artist_scope.count
+    puts "Repairing #{song_total} songs and #{artist_total} artists with broken slugs..."
+
+    repair_records(song_scope, 'songs')
+    repair_records(artist_scope, 'artists')
+  end
+
+  def repair_records(scope, label)
+    processed = 0
+    total = scope.count
+    scope.find_each do |record|
+      record.update_slug
+      processed += 1
+      print "\rRepaired #{processed}/#{total} #{label}..." if (processed % 100).zero?
+    end
+    puts "\nDone! Repaired #{processed} #{label}."
+  end
 end

--- a/spec/models/concerns/sluggable_spec.rb
+++ b/spec/models/concerns/sluggable_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Sluggable do
+  describe '#set_slug' do
+    context 'with Latin characters' do
+      let(:artist) { create :artist, name: 'The Weeknd' }
+
+      it 'parameterizes the name' do
+        expect(artist.slug).to eq('the-weeknd')
+      end
+    end
+
+    context 'with Latin diacritics' do
+      let(:artist) { create :artist, name: 'Jürgen Müller' }
+
+      it 'transliterates diacritics to ASCII' do
+        expect(artist.slug).to eq('jurgen-muller')
+      end
+    end
+
+    context 'with Cyrillic characters' do
+      let(:artist) { create :artist, name: 'Ваня Дмитриенко' }
+
+      it 'transliterates Cyrillic to ASCII' do
+        expect(artist.slug).to eq('vanya-dmitrienko')
+      end
+    end
+
+    context 'with Greek characters' do
+      let(:artist) { create :artist, name: 'Ελλάδα' }
+
+      it 'transliterates Greek to ASCII' do
+        expect(artist.slug).to eq('ellada')
+      end
+    end
+
+    context 'when transliteration produces an empty base' do
+      let(:artist) { create :artist, name: '!!!' }
+
+      it 'falls back to a model-prefixed random slug' do
+        expect(artist.slug).to match(/\Aartist-[0-9a-f]{8}\z/)
+      end
+    end
+
+    context 'with a duplicate slug source' do
+      before { create :artist, name: 'The Weeknd' }
+
+      let(:duplicate) { create :artist, name: 'The Weeknd' }
+
+      it 'appends an incrementing counter' do
+        expect(duplicate.slug).to eq('the-weeknd-2')
+      end
+    end
+  end
+
+  describe 'slug updates on name change' do
+    let(:artist) { create :artist, name: 'Old Name' }
+
+    before { artist.update(name: 'New Name') }
+
+    it 'regenerates the slug' do
+      expect(artist.reload.slug).to eq('new-name')
+    end
+  end
+
+  describe 'Song slug source' do
+    let(:artist) { create :artist, name: 'Ваня Дмитриенко' }
+    let(:song) { create :song, title: 'Силуэт', artists: [artist] }
+
+    it 'combines title and first artist name with transliteration' do
+      expect(song.slug).to eq('siluet-vanya-dmitrienko')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds \`babosa\` gem and a \`Sluggable\` concern that transliterates Cyrillic and Greek characters before parameterizing, so non-Latin titles no longer collapse to an empty base and collide into \`-2\`/\`-3\`/... (e.g. song id 203115, \`Силуэт\`, currently has slug \`-66\`)
- Extracts \`set_slug\`/\`update_slug\`/\`unique_slug\` out of \`Song\` and \`Artist\` into the shared concern, with a model-prefixed random fallback for the rare all-punctuation case
- Adds \`rake slug:repair_empty\` to regenerate the existing broken slugs after the deploy

## Test plan
- [x] \`bundle exec rspec spec/models/concerns/sluggable_spec.rb spec/models/song_spec.rb spec/models/artist_spec.rb\`
- [x] \`bundle exec rubocop\` on changed files
- [ ] After merge: run \`rake slug:repair_empty\` in production to fix existing \`-N\` slugs (song 203115 will become \`siluet-iz-kf-alisa-v-strane-chudes-vanya-dmitrienko\`)