### PR TITLE
Skip ambiguous-punctuation title check when Spotify matched

### DIFF
--- a/app/services/song_importer.rb
+++ b/app/services/song_importer.rb
@@ -5,6 +5,11 @@ class SongImporter
     @played_song @artists @song @track @spotify_track @deezer_track @itunes_track @scraper_import
   ].freeze
 
+  AD_MARKERS = /(reklame|reclame|nieuws|pingel)/i
+  # Punctuation patterns that appear in legit titles (e.g. "...Baby One More Time") but also in noisy scraped data.
+  # Only reject when Spotify can't match the track either.
+  AMBIGUOUS_PUNCTUATION = /'{2,}|\.{2,}/
+
   include SongImporter::Concerns::AudioRecognition
   include SongImporter::Concerns::TrackFinding
   include SongImporter::Concerns::AirPlayCreation
@@ -87,8 +92,9 @@ class SongImporter
   end
 
   def illegal_word_in_title
-    # 2 single quotes, reklame/reclame/nieuws/pingel and 2 dots
-    title.match?(/'{2,}|(reklame|reclame|nieuws|pingel)|\.{2,}/i)
+    return true if title.match?(AD_MARKERS)
+
+    title.match?(AMBIGUOUS_PUNCTUATION) && track.blank?
   end
 
   def recently_imported?

--- a/spec/services/song_importer_edge_cases_spec.rb
+++ b/spec/services/song_importer_edge_cases_spec.rb
@@ -396,27 +396,76 @@ describe SongImporter do
       allow(importer).to receive(:title).and_return(title_text)
     end
 
-    {
-      'title with reklame' => true,
-      'REKLAME block' => true,
-      'Reclame' => true,
-      'nieuws update' => true,
-      'NIEUWS' => true,
-      'pingel sound' => true,
-      "title with ''" => true,
-      "title with '''" => true,
-      'title with ..' => true,
-      'title with ...' => true,
-      'Normal Song Title' => false,
-      "It's a normal title" => false,
-      '3.14 is pi' => false,
-      "Song with 'quotes'" => false
-    }.each do |title_text, expected|
-      context "with title '#{title_text}'" do
-        let(:title_text) { title_text }
+    context 'with ad-marker titles' do
+      {
+        'title with reklame' => true,
+        'REKLAME block' => true,
+        'Reclame' => true,
+        'nieuws update' => true,
+        'NIEUWS' => true,
+        'pingel sound' => true
+      }.each do |title_text, expected|
+        context "with title '#{title_text}'" do
+          let(:title_text) { title_text }
 
-        it "returns #{expected}" do
-          expect(importer.send(:illegal_word_in_title)).to eq(expected)
+          it "returns #{expected} without consulting Spotify" do
+            expect(importer.send(:illegal_word_in_title)).to eq(expected)
+          end
+        end
+      end
+    end
+
+    context 'with ambiguous punctuation and no Spotify match' do
+      before { allow(importer).to receive(:track).and_return(nil) }
+
+      {
+        "title with ''" => true,
+        "title with '''" => true,
+        'title with ..' => true,
+        'title with ...' => true
+      }.each do |title_text, expected|
+        context "with title '#{title_text}'" do
+          let(:title_text) { title_text }
+
+          it "returns #{expected}" do
+            expect(importer.send(:illegal_word_in_title)).to eq(expected)
+          end
+        end
+      end
+    end
+
+    context 'with ambiguous punctuation but Spotify matched the track' do
+      before { allow(importer).to receive(:track).and_return(Object.new) }
+
+      [
+        "title with ''",
+        "title with '''",
+        'title with ..',
+        '...Baby One More Time'
+      ].each do |title_text|
+        context "with title '#{title_text}'" do
+          let(:title_text) { title_text }
+
+          it 'returns false' do
+            expect(importer.send(:illegal_word_in_title)).to be false
+          end
+        end
+      end
+    end
+
+    context 'with a clean title' do
+      {
+        'Normal Song Title' => false,
+        "It's a normal title" => false,
+        '3.14 is pi' => false,
+        "Song with 'quotes'" => false
+      }.each do |title_text, expected|
+        context "with title '#{title_text}'" do
+          let(:title_text) { title_text }
+
+          it "returns #{expected} without consulting Spotify" do
+            expect(importer.send(:illegal_word_in_title)).to eq(expected)
+          end
         end
       end
     end


### PR DESCRIPTION
## Summary
- Split `SongImporter#illegal_word_in_title` into two tiers: ad markers (reklame/reclame/nieuws/pingel) still hard-fail, ambiguous punctuation (`''`, `..`) only rejects when `track` is blank.
- Fixes false positives on legitimate titles like Britney Spears' "...Baby One More Time" where Spotify matched cleanly but the title was dropped due to the leading ellipsis.
- Extracted the two patterns into named constants (`AD_MARKERS`, `AMBIGUOUS_PUNCTUATION`) and restructured the spec around the new behavior.

## Test plan
- [x] `bundle exec rspec spec/services/song_importer_edge_cases_spec.rb` — 18 examples, 0 failures
- [x] `bundle exec rubocop app/services/song_importer.rb spec/services/song_importer_edge_cases_spec.rb` — no offenses
- [ ] Monitor Jumbo Radio import logs after deploy to confirm the previously skipped tracks now import

🤖 Generated with [Claude Code](https://claude.com/claude-code)