### PR TITLE
Skip imports cleanly when no persistent segment is available

### DIFF
--- a/app/services/song_importer/concerns/audio_recognition.rb
+++ b/app/services/song_importer/concerns/audio_recognition.rb
@@ -20,6 +20,9 @@ module SongImporter::Concerns
       @import_logger.log_acoustid(acoustid)
 
       songrec_result ? songrec : nil
+    rescue PersistentStream::SegmentReader::NoSegmentError,
+           PersistentStream::SegmentReader::StaleSegmentError
+      nil
     ensure
       audio_stream&.delete_file
     end

--- a/spec/services/song_importer_spec.rb
+++ b/spec/services/song_importer_spec.rb
@@ -74,6 +74,34 @@ describe SongImporter do
         expect(Broadcaster).to have_received(:no_importing_song)
       end
     end
+
+    context 'when scraper returns nil and no persistent segment is available' do
+      let(:import_logger) do
+        instance_double(SongImportLogger, start_log: nil, log_scraping: nil, skip_log: nil,
+                                          complete_log: nil, log_recognition: nil, log_acoustid: nil,
+                                          fail_log: nil, log_spotify: nil, log_deezer: nil, log_itunes: nil)
+      end
+
+      before do
+        allow(SongImportLogger).to receive(:new).and_return(import_logger)
+        allow(TrackScraper::NpoApiProcessor).to receive(:new).and_return(
+          instance_double(TrackScraper::NpoApiProcessor, last_played_song: nil)
+        )
+        allow(AudioStream::PersistentSegment).to receive(:new).and_return(
+          instance_double(AudioStream::PersistentSegment, delete_file: nil).tap do |stream|
+            allow(stream).to receive(:capture)
+              .and_raise(PersistentStream::SegmentReader::NoSegmentError, 'no segment')
+          end
+        )
+        allow(Broadcaster).to receive(:no_importing_song)
+      end
+
+      it 'marks the log as skipped instead of failed', :aggregate_failures do
+        importer.import
+        expect(import_logger).to have_received(:skip_log).with(reason: 'No song scraped or recognized')
+        expect(import_logger).not_to have_received(:fail_log)
+      end
+    end
   end
 
   describe '#should_update_artists?' do


### PR DESCRIPTION
## Summary
- Rescue `PersistentStream::SegmentReader::NoSegmentError` / `StaleSegmentError` inside `recognize_song` so it returns `nil` instead of raising.
- `skip_import?` now correctly marks the log as `skipped` (reason: `"No song scraped or recognized"`) in this case, instead of leaving it stranded in `pending`.

## Why
On Yoursafe Radio (video-only HLS), there is no persistent audio segment. Every time the OCR can't parse an `Artist - Title` line (brief between-song moments where the overlay shows only "JE LUISTERT NAAR / Yoursafe Radio"), the scraper returns nil and the code falls through to `recognize_song`. That then raised `NoSegmentError`, propagating to the broad `rescue StandardError` in `SongImporter#import` — where something in the rescue chain (`ExceptionNotifier.notify` / `Broadcaster.error_during_import`) was failing silently, so `fail_log` never ran. Result: ~10 import logs for station 16 stuck in `pending` with empty `scraped_raw_response`.

Treating a missing/stale segment as an expected condition (not an exception) also makes audio stations more resilient while the persistent stream manager is restarting.

## Test plan
- [x] `bundle exec rspec spec/services/song_importer_spec.rb spec/services/song_importer_edge_cases_spec.rb spec/services/song_importer_track_fallback_spec.rb spec/services/song_importer/` — 183 examples, 0 failures
- [x] `bundle exec rubocop app/services/song_importer/concerns/audio_recognition.rb spec/services/song_importer_spec.rb` — no offenses
- [x] New spec covers: scraper nil + `PersistentSegment#capture` raising `NoSegmentError` → `skip_log` called, `fail_log` not called
- [ ] After merge, verify new pending logs for Yoursafe Radio stop appearing and instead land as `skipped` with reason "No song scraped or recognized"

🤖 Generated with [Claude Code](https://claude.com/claude-code)