### PR TITLE
Skip redundant enrichment work in song and artist jobs

### DIFF
--- a/app/jobs/artist_enrichment_job.rb
+++ b/app/jobs/artist_enrichment_job.rb
@@ -7,12 +7,18 @@ class ArtistEnrichmentJob
   WIKIPEDIA_RATE_LIMIT_PER_HOUR = 500
   WIKIPEDIA_REQUESTS_PER_JOB = 2
   THROTTLE_INTERVAL = (3600.0 / (WIKIPEDIA_RATE_LIMIT_PER_HOUR / WIKIPEDIA_REQUESTS_PER_JOB)).ceil
+  RECHECK_AFTER = 90.days
 
   include Sidekiq::Job
   sidekiq_options queue: 'low'
 
   def self.enqueue_all
-    Artist.where(country_of_origin: []).find_each.with_index do |artist, index|
+    stale_threshold = RECHECK_AFTER.ago
+    scope = Artist
+              .where(country_of_origin: [])
+              .where('country_of_origin_checked_at IS NULL OR country_of_origin_checked_at < ?', stale_threshold)
+
+    scope.find_each.with_index do |artist, index|
       perform_in((index * THROTTLE_INTERVAL).seconds, artist.id)
     end
   end
@@ -20,9 +26,12 @@ class ArtistEnrichmentJob
   def perform(artist_id)
     artist = Artist.find_by(id: artist_id)
     return if artist.blank?
+    return if artist.country_of_origin.present?
+    return if artist.country_of_origin_checked_at.present? && artist.country_of_origin_checked_at > RECHECK_AFTER.ago
 
     enrich_country_of_origin(artist)
     enrich_spotify_metrics(artist)
+    artist.update(country_of_origin_checked_at: Time.current)
   end
 
   private

--- a/app/jobs/song_external_ids_enrichment_job.rb
+++ b/app/jobs/song_external_ids_enrichment_job.rb
@@ -21,6 +21,7 @@ class SongExternalIdsEnrichmentJob
   def perform(song_id)
     song = Song.find_by(id: song_id)
     return if song.blank?
+    return unless song.needs_external_ids_enrichment?
 
     song.enrich_with_external_services
   end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -4,25 +4,26 @@
 #
 # Table name: artists
 #
-#  id                      :bigint           not null, primary key
-#  country_of_origin       :string           default([]), is an Array
-#  genres                  :string           default([]), is an Array
-#  id_on_spotify           :string
-#  image                   :string
-#  instagram_url           :string
-#  lastfm_enriched_at      :datetime
-#  lastfm_listeners        :bigint
-#  lastfm_playcount        :bigint
-#  lastfm_tags             :string           default([]), is an Array
-#  name                    :string
-#  slug                    :string
-#  spotify_artist_url      :string
-#  spotify_artwork_url     :string
-#  spotify_followers_count :integer
-#  spotify_popularity      :integer
-#  website_url             :string
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
+#  id                           :bigint           not null, primary key
+#  country_of_origin            :string           default([]), is an Array
+#  country_of_origin_checked_at :datetime
+#  genres                       :string           default([]), is an Array
+#  id_on_spotify                :string
+#  image                        :string
+#  instagram_url                :string
+#  lastfm_enriched_at           :datetime
+#  lastfm_listeners             :bigint
+#  lastfm_playcount             :bigint
+#  lastfm_tags                  :string           default([]), is an Array
+#  name                         :string
+#  slug                         :string
+#  spotify_artist_url           :string
+#  spotify_artwork_url          :string
+#  spotify_followers_count      :integer
+#  spotify_popularity           :integer
+#  website_url                  :string
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
 #
 # Indexes
 #

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -287,6 +287,10 @@ class Song < ApplicationRecord
     enrich_with_music_brainz if should_enrich_with_music_brainz?
   end
 
+  def needs_external_ids_enrichment?
+    should_enrich_with_deezer? || should_enrich_with_itunes? || should_enrich_with_music_brainz?
+  end
+
   private
 
   def update_air_plays_obsolete_songs(songs, most_played_song)

--- a/app/serializers/artist_serializer.rb
+++ b/app/serializers/artist_serializer.rb
@@ -4,25 +4,26 @@
 #
 # Table name: artists
 #
-#  id                      :bigint           not null, primary key
-#  country_of_origin       :string           default([]), is an Array
-#  genres                  :string           default([]), is an Array
-#  id_on_spotify           :string
-#  image                   :string
-#  instagram_url           :string
-#  lastfm_enriched_at      :datetime
-#  lastfm_listeners        :bigint
-#  lastfm_playcount        :bigint
-#  lastfm_tags             :string           default([]), is an Array
-#  name                    :string
-#  slug                    :string
-#  spotify_artist_url      :string
-#  spotify_artwork_url     :string
-#  spotify_followers_count :integer
-#  spotify_popularity      :integer
-#  website_url             :string
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
+#  id                           :bigint           not null, primary key
+#  country_of_origin            :string           default([]), is an Array
+#  country_of_origin_checked_at :datetime
+#  genres                       :string           default([]), is an Array
+#  id_on_spotify                :string
+#  image                        :string
+#  instagram_url                :string
+#  lastfm_enriched_at           :datetime
+#  lastfm_listeners             :bigint
+#  lastfm_playcount             :bigint
+#  lastfm_tags                  :string           default([]), is an Array
+#  name                         :string
+#  slug                         :string
+#  spotify_artist_url           :string
+#  spotify_artwork_url          :string
+#  spotify_followers_count      :integer
+#  spotify_popularity           :integer
+#  website_url                  :string
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
 #
 # Indexes
 #

--- a/db/migrate/20260427183525_add_country_of_origin_checked_at_to_artists.rb
+++ b/db/migrate/20260427183525_add_country_of_origin_checked_at_to_artists.rb
@@ -1,0 +1,5 @@
+class AddCountryOfOriginCheckedAtToArtists < ActiveRecord::Migration[8.1]
+  def change
+    add_column :artists, :country_of_origin_checked_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_13_081110) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_27_183525) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -86,6 +86,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_13_081110) do
 
   create_table "artists", force: :cascade do |t|
     t.string "country_of_origin", default: [], array: true
+    t.datetime "country_of_origin_checked_at"
     t.datetime "created_at", precision: nil, null: false
     t.string "genres", default: [], array: true
     t.string "id_on_spotify"

--- a/spec/jobs/artist_enrichment_job_spec.rb
+++ b/spec/jobs/artist_enrichment_job_spec.rb
@@ -49,6 +49,11 @@ RSpec.describe ArtistEnrichmentJob do
         job.perform(artist.id)
         expect(artist.reload.country_of_origin).to eq(['Netherlands'])
       end
+
+      it 'does not call Spotify' do
+        job.perform(artist.id)
+        expect(Spotify::ArtistFinder).not_to have_received(:new)
+      end
     end
 
     context 'when Wikipedia returns no data' do
@@ -59,6 +64,16 @@ RSpec.describe ArtistEnrichmentJob do
       it 'does not update country_of_origin' do
         job.perform(artist.id)
         expect(artist.reload.country_of_origin).to eq([])
+      end
+
+      it 'still records the check timestamp', :aggregate_failures do
+        freeze_time = Time.current
+        allow(Time).to receive(:current).and_return(freeze_time)
+
+        job.perform(artist.id)
+
+        expect(artist.reload.country_of_origin).to eq([])
+        expect(artist.country_of_origin_checked_at).to be_within(1.second).of(freeze_time)
       end
     end
 
@@ -76,11 +91,44 @@ RSpec.describe ArtistEnrichmentJob do
         expect { job.perform(999_999) }.not_to raise_error
       end
     end
+
+    context 'when artist was checked recently and Wikipedia had no nationality' do
+      let(:artist) do
+        create(:artist, id_on_spotify: 'spotify_123', country_of_origin: [], country_of_origin_checked_at: 2.days.ago)
+      end
+
+      it 'does not call Wikipedia again' do
+        wikipedia_finder = instance_double(Wikipedia::ArtistFinder)
+        allow(Wikipedia::ArtistFinder).to receive(:new).and_return(wikipedia_finder)
+
+        job.perform(artist.id)
+
+        expect(Wikipedia::ArtistFinder).not_to have_received(:new)
+      end
+    end
+
+    context 'when artist was checked long ago and country is still empty' do
+      let(:artist) do
+        create(:artist, id_on_spotify: 'spotify_123', country_of_origin: [],
+                        country_of_origin_checked_at: (described_class::RECHECK_AFTER + 1.day).ago)
+      end
+
+      it 'rechecks Wikipedia' do
+        job.perform(artist.id)
+        expect(artist.reload.country_of_origin).to eq(['United Kingdom'])
+      end
+    end
   end
 
   describe '.enqueue_all' do
     let!(:artist_without_country) { create(:artist, country_of_origin: []) }
     let!(:artist_with_country) { create(:artist, country_of_origin: ['Netherlands']) }
+    let!(:artist_recently_checked) do
+      create(:artist, country_of_origin: [], country_of_origin_checked_at: 1.day.ago)
+    end
+    let!(:artist_stale_check) do
+      create(:artist, country_of_origin: [], country_of_origin_checked_at: (described_class::RECHECK_AFTER + 1.day).ago)
+    end
 
     before do
       allow(described_class).to receive(:perform_in)
@@ -89,13 +137,23 @@ RSpec.describe ArtistEnrichmentJob do
     it 'enqueues jobs for artists without country_of_origin' do
       described_class.enqueue_all
       expect(described_class).to have_received(:perform_in).with(
-        0.seconds, artist_without_country.id
+        anything, artist_without_country.id
       )
     end
 
     it 'does not enqueue jobs for artists with country_of_origin' do
       described_class.enqueue_all
       expect(described_class).not_to have_received(:perform_in).with(anything, artist_with_country.id)
+    end
+
+    it 'does not enqueue jobs for artists checked within the recheck window' do
+      described_class.enqueue_all
+      expect(described_class).not_to have_received(:perform_in).with(anything, artist_recently_checked.id)
+    end
+
+    it 'enqueues jobs for artists whose check is older than the recheck window' do
+      described_class.enqueue_all
+      expect(described_class).to have_received(:perform_in).with(anything, artist_stale_check.id)
     end
   end
 end

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -2,25 +2,26 @@
 #
 # Table name: artists
 #
-#  id                      :bigint           not null, primary key
-#  country_of_origin       :string           default([]), is an Array
-#  genres                  :string           default([]), is an Array
-#  id_on_spotify           :string
-#  image                   :string
-#  instagram_url           :string
-#  lastfm_enriched_at      :datetime
-#  lastfm_listeners        :bigint
-#  lastfm_playcount        :bigint
-#  lastfm_tags             :string           default([]), is an Array
-#  name                    :string
-#  slug                    :string
-#  spotify_artist_url      :string
-#  spotify_artwork_url     :string
-#  spotify_followers_count :integer
-#  spotify_popularity      :integer
-#  website_url             :string
-#  created_at              :datetime         not null
-#  updated_at              :datetime         not null
+#  id                           :bigint           not null, primary key
+#  country_of_origin            :string           default([]), is an Array
+#  country_of_origin_checked_at :datetime
+#  genres                       :string           default([]), is an Array
+#  id_on_spotify                :string
+#  image                        :string
+#  instagram_url                :string
+#  lastfm_enriched_at           :datetime
+#  lastfm_listeners             :bigint
+#  lastfm_playcount             :bigint
+#  lastfm_tags                  :string           default([]), is an Array
+#  name                         :string
+#  slug                         :string
+#  spotify_artist_url           :string
+#  spotify_artwork_url          :string
+#  spotify_followers_count      :integer
+#  spotify_popularity           :integer
+#  website_url                  :string
+#  created_at                   :datetime         not null
+#  updated_at                   :datetime         not null
 #
 # Indexes
 #


### PR DESCRIPTION
## Summary
- `SongExternalIdsEnrichmentJob` now exits when the song already has all external IDs (`Song#needs_external_ids_enrichment?` combines the existing `should_enrich_*?` predicates).
- `ArtistEnrichmentJob` now records `country_of_origin_checked_at` on every attempt (new column) so artists Wikipedia has no nationality data for are skipped for 90 days instead of being retried every Sunday forever. Both `enqueue_all` and the in-job guard honor the recheck window.

## Context
After yesterday's Postgres 18.3 upgrade in production, Sidekiq throughput dropped (planner stats wiped by `pg_upgrade`, since restored via `ANALYZE`). During that window the default queue grew to ~4k `SongExternalIdsEnrichmentJob`s — most for songs already fully enriched. The low queue was filled with `ArtistEnrichmentJob` retries for artists like *Peter Jacques Band* and *Jessie Buckley & Bernard Butler* — Wikipedia simply has no entry under those names, so the job ran, found nothing, and the next Sunday batch re-queued them again. The guards keep the queues clean even when DB throughput is lower than usual.

## Test plan
- [x] `bundle exec rspec spec/jobs/song_external_ids_enrichment_job_spec.rb spec/jobs/artist_enrichment_job_spec.rb` (16 + 15 examples passing)
- [x] `bundle exec rubocop` clean on all changed files
- [ ] After merge & deploy: confirm default queue depth drops; confirm next Sunday's `ArtistEnrichmentBatchJob` enqueues a much smaller set than this Sunday's run

🤖 Generated with [Claude Code](https://claude.com/claude-code)