### PR TITLE
Update README clone URL to airplays

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Airplays is a Ruby on Rails 8.1 API-only application that monitors Dutch radio s
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/samuelvaneck/radio_playlists.git
+   git clone https://github.com/samuelvaneck/airplays.git
    cd airplays
    ```
 2. Install Ruby gems:


### PR DESCRIPTION
## Summary
- Repo was renamed from `radio_playlists` to `airplays`; README clone URL was the only stale reference left in-tree.

## Test plan
- [x] `git clone https://github.com/samuelvaneck/airplays.git` resolves (and the old URL still redirects via GitHub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)