### PR TITLE
Harden CI: Node 24 action bumps, concurrency, actionlint, Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,26 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@v1
+        with:
+          reporter: github-pr-check
+          fail_level: error
+
   test:
     runs-on: ubuntu-latest
 
@@ -67,7 +84,7 @@ jobs:
 
       - name: Upload coverage artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage
           path: coverage
@@ -75,7 +92,7 @@ jobs:
 
       - name: Upload log artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: logs
           path: log
@@ -97,7 +114,7 @@ jobs:
         run: bundle exec rubocop
 
   build-and-push:
-    needs: [test, rubocop]
+    needs: [actionlint, test, rubocop]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
@@ -108,10 +125,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -119,7 +136,7 @@ jobs:
 
       - name: Extract image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/samuelvaneck/airplays
           tags: |
@@ -127,7 +144,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install system dependencies
         run: |
@@ -86,7 +86,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -105,7 +105,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/rubocop-analysis.yml
+++ b/.github/workflows/rubocop-analysis.yml
@@ -2,7 +2,12 @@ name: Rubocop
 
 on:
   push:
+    branches: [main]
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   rubocop:
@@ -33,6 +38,6 @@ jobs:
           "
 
       - name: Upload Sarif output
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: rubocop.sarif

--- a/.github/workflows/rubocop-analysis.yml
+++ b/.github/workflows/rubocop-analysis.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## Summary
CI hygiene pass — all zero-risk config:

- **Bump Node 20 actions to Node 24 majors** (silences GH runner deprecation):
  - `actions/checkout` v4 → v6
  - `actions/upload-artifact` v4 → v6
  - `docker/setup-buildx-action` v3 → v4
  - `docker/login-action` v3 → v4
  - `docker/metadata-action` v5 → v6
  - `docker/build-push-action` v5 → v7
  - `github/codeql-action/upload-sarif` v3 → v4
- **Scope `push` triggers to `main`** so PR branches stop running CI twice (once per `push`, once per `pull_request`).
- **Concurrency groups** keyed on workflow+ref. PR branches cancel in-progress runs on new pushes; `main` never cancels (so post-merge build/deploy pipelines run to completion).
- **`actionlint` job** (reviewdog) gating `build-and-push` — catches workflow YAML errors before they break a real run.
- **Dependabot** config for the `github-actions` ecosystem (weekly, grouped).

## Test plan
- [ ] CI passes on this PR.
- [ ] No Node.js 20 deprecation warning on any action step.
- [ ] Pushing twice quickly to this branch cancels the first run.
- [ ] After merge to `main`, build-and-push runs and pushes a new image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)