### PR TITLE
Add CI security, swagger drift, JUnit reporting, deploy tag check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,16 @@ jobs:
         run: bundle exec rails db:seed
 
       - name: Run RSpec
-        run: bundle exec rspec
+        run: bundle exec rspec --format progress --format RspecJunitFormatter --out tmp/rspec_results.xml
+
+      - name: Publish RSpec test report
+        if: always()
+        uses: mikepenz/action-junit-report@v5
+        with:
+          report_paths: tmp/rspec_results.xml
+          check_name: RSpec results
+          require_tests: true
+          fail_on_failure: true
 
       - name: Upload coverage artifacts
         if: always()
@@ -98,6 +107,73 @@ jobs:
           path: log
           if-no-files-found: ignore
 
+  swagger:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:18.3
+        env:
+          POSTGRES_USER: airplays
+          POSTGRES_DB: airplays_test
+          POSTGRES_PASSWORD: "Super-C0mpl3X"
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      POSTGRES_HOST: localhost
+      POSTGRES_USER: airplays
+      POSTGRES_PASSWORD: "Super-C0mpl3X"
+      RAILS_ENV: test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Setup environment
+        run: cp .env.ci .env
+
+      - name: Prepare test database
+        run: bundle exec rails db:test:prepare
+
+      - name: Regenerate Swagger
+        run: bundle exec rake rswag:specs:swaggerize
+
+      - name: Verify Swagger is up to date
+        run: |
+          if ! git diff --exit-code -- swagger/; then
+            echo "::error::swagger/v1/swagger.yaml is out of date. Run 'bundle exec rake rswag:specs:swaggerize' locally and commit the result."
+            exit 1
+          fi
+
+  security:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Run Brakeman
+        run: bundle exec brakeman --quiet --no-progress --no-summary -i config/brakeman.ignore --exit-on-warn --exit-on-error
+
+      - name: Run bundler-audit
+        run: bundle exec bundle-audit check --update
+
   rubocop:
     runs-on: ubuntu-latest
 
@@ -114,7 +190,7 @@ jobs:
         run: bundle exec rubocop
 
   build-and-push:
-    needs: [actionlint, test, rubocop]
+    needs: [actionlint, test, rubocop, security, swagger]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,12 +11,30 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     concurrency:
       group: deploy-prod
       cancel-in-progress: false
     env:
       DEPLOY_TAG: ${{ inputs.tag }}
     steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify image tag exists in GHCR
+        run: |
+          if ! docker manifest inspect "ghcr.io/samuelvaneck/airplays:${DEPLOY_TAG}" > /dev/null 2>&1; then
+            echo "::error::Image ghcr.io/samuelvaneck/airplays:${DEPLOY_TAG} not found in registry. Aborting deploy."
+            exit 1
+          fi
+          echo "Image tag '${DEPLOY_TAG}' found."
+
       - name: Configure SSH
         env:
           SSH_KEY:     ${{ secrets.DEPLOY_SSH_KEY }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,8 @@ bundle exec rspec spec/path/to/file_spec.rb:42 # Run specific test line
 
 # Code Quality
 bundle exec rubocop                         # Lint (auto-fixes enabled)
-bundle exec brakeman                        # Security scan
+bundle exec brakeman -i config/brakeman.ignore  # Security scan (suppresses triaged findings)
+bundle exec bundle-audit check --update     # Check Gemfile.lock for known CVEs
 
 # API Documentation
 bundle exec rake rswag:specs:swaggerize     # Regenerate swagger/v1/swagger.yaml
@@ -363,7 +364,7 @@ bundle exec rake rswag:specs:swaggerize     # Regenerates swagger/v1/swagger.yam
 
 Schema definitions are configured in `spec/swagger_helper.rb`. The generated `swagger/v1/swagger.yaml` should be committed to version control.
 
-**Important:** Always run `bundle exec rake rswag:specs:swaggerize` and commit the updated `swagger/v1/swagger.yaml` after adding or modifying request specs in `spec/requests/api/v1/`.
+**Important:** Always run `bundle exec rake rswag:specs:swaggerize` and commit the updated `swagger/v1/swagger.yaml` after adding or modifying request specs in `spec/requests/api/v1/`. The CI `swagger` job regenerates the file and fails if the working tree is dirty, so a missed swaggerize run will block the PR.
 
 ### Security
 
@@ -401,6 +402,39 @@ echo 'deb http://ppa.launchpad.net/marin-m/songrec/ubuntu jammy main' > /etc/apt
 ### Important: LD_PRELOAD and Bundle Install
 
 `LD_PRELOAD` must be set **after** `bundle install` — setting it before causes gem native extension compilation to fail with "cannot be preloaded" errors. In multi-stage builds, only set it in the runtime stage.
+
+## CI/CD
+
+GitHub Actions workflows live in `.github/workflows/`.
+
+### `ci.yml`
+
+Runs on every PR and on `push` to `main`. Concurrency is keyed on `workflow+ref` and cancels in-progress runs on PR branches but never on `main` (so post-merge build/deploy isn't aborted by a follow-up commit).
+
+Jobs:
+- **`actionlint`** — lints workflow YAML via `reviewdog/action-actionlint`. Catches expression errors and deprecated inputs before they break a real run.
+- **`test`** — RSpec with `RspecJunitFormatter`; `mikepenz/action-junit-report` surfaces failing examples inline on the PR diff. Coverage and `log/` are uploaded as artifacts on success/failure respectively.
+- **`rubocop`** — style/lint gate.
+- **`security`** — Brakeman + bundler-audit. Brakeman is gated by `config/brakeman.ignore` (each suppression has a justification note); new findings fail the job. bundler-audit checks `Gemfile.lock` against the ruby-advisory-db.
+- **`swagger`** — regenerates `swagger/v1/swagger.yaml` via `rake rswag:specs:swaggerize` and fails if the working tree is dirty. Enforces the rule that swagger be committed alongside spec changes.
+- **`build-and-push`** — Docker buildx build, push to `ghcr.io/samuelvaneck/airplays`. `needs: [actionlint, test, rubocop, security, swagger]` and gated to `push` on `main`, so the image only ships when every other job is green.
+
+### `rubocop-analysis.yml`
+
+Uploads RuboCop findings as SARIF for GitHub code scanning. Runs alongside `ci.yml` but doesn't gate the build (`code-scanning-rubocop` formatter is informational).
+
+### `deploy.yml`
+
+Manual `workflow_dispatch` only. Logs in to GHCR and runs `docker manifest inspect ghcr.io/samuelvaneck/airplays:$TAG` before SSHing — a typo'd or non-existent tag fails fast at the manifest step instead of redeploying the previous release.
+
+### `dependabot.yml`
+
+Weekly grouped updates for the `github-actions` ecosystem. Keeps action versions current without per-action PR noise.
+
+### Adding/changing CI
+
+- Workflow YAML changes will trigger the `actionlint` job — run `actionlint .github/workflows/*.yml` locally if available, or rely on the CI gate.
+- New action versions: prefer Node 24 majors (e.g. `actions/checkout@v6`, `docker/build-push-action@v7`). Older Node 20 majors emit a deprecation warning on the runner and will stop working in late 2026.
 
 ## External Dependencies
 

--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,9 @@ end
 
 group :test do
   gem 'brakeman'
+  gem 'bundler-audit'
   gem 'database_cleaner'
+  gem 'rspec_junit_formatter'
   gem 'shoulda-matchers'
   # Sinatra is used to mock requests
   gem 'sinatra'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,9 @@ GEM
     bullet (8.1.1)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
+    bundler-audit (0.9.3)
+      bundler (>= 1.2.0)
+      thor (~> 1.0)
     byebug (13.0.0)
       reline (>= 0.6.0)
     charlock_holmes (0.7.9)
@@ -418,6 +421,8 @@ GEM
       rspec-mocks (>= 3.13.0, < 5.0.0)
       rspec-support (>= 3.13.0, < 5.0.0)
     rspec-support (3.13.7)
+    rspec_junit_formatter (0.6.0)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rswag-api (2.17.0)
       activesupport (>= 5.2, < 8.2)
       railties (>= 5.2, < 8.2)
@@ -574,6 +579,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   bullet
+  bundler-audit
   charlock_holmes (~> 0.7.7)
   circuitbox (~> 2.0)
   concurrent-ruby
@@ -613,6 +619,7 @@ DEPENDENCIES
   rails-controller-testing
   redis
   rspec-rails
+  rspec_junit_formatter
   rswag-api
   rswag-specs
   rswag-ui

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Airplays is a Ruby on Rails 8.1 API-only application that monitors Dutch radio s
 - **OCR**: Tesseract (via rtesseract gem)
 - **Song Enrichment**: Spotify, Deezer, iTunes, Last.fm, YouTube, MusicBrainz APIs
 - **Testing**: RSpec, VCR, WebMock
-- **Code Quality**: RuboCop, Brakeman
+- **Code Quality**: RuboCop, Brakeman, bundler-audit
+- **CI/CD**: GitHub Actions (test, rubocop, security, swagger drift, build, deploy)
 - **API Documentation**: rswag (Swagger/OpenAPI)
 - **Monitoring**: Sentry
 - **Containerization**: Docker with multi-stage builds
@@ -84,11 +85,27 @@ bundle exec rspec spec/path/to/file_spec.rb # Run single test file
 
 # Code Quality
 bundle exec rubocop                         # Lint
-bundle exec brakeman                        # Security scan
+bundle exec brakeman -i config/brakeman.ignore  # Security scan (suppresses triaged findings)
+bundle exec bundle-audit check --update     # Check Gemfile for known CVEs
 
 # API Documentation
 bundle exec rake rswag:specs:swaggerize     # Regenerate Swagger docs
 ```
+
+## CI/CD
+
+GitHub Actions pipelines (`.github/workflows/`):
+
+- **`ci.yml`** — runs on every push to `main` and every PR. Jobs:
+  - `actionlint` — lints workflow YAML
+  - `test` — RSpec with JUnit reporting (failures surface inline on PRs)
+  - `rubocop` — style/lint
+  - `security` — Brakeman (gated by `config/brakeman.ignore`) + bundler-audit (CVE check)
+  - `swagger` — regenerates `swagger/v1/swagger.yaml` and fails if it's out of date
+  - `build-and-push` — builds and pushes the Docker image to GHCR. Only runs on `main` after every other job passes.
+- **`rubocop-analysis.yml`** — uploads RuboCop findings as SARIF for GitHub code scanning.
+- **`deploy.yml`** — manual `workflow_dispatch` deploy. Verifies the image tag exists in GHCR via `docker manifest inspect` before SSHing to production.
+- **`dependabot.yml`** — keeps action versions up to date weekly.
 
 ## API Documentation
 

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,17 @@
+{
+  "ignored_warnings": [
+    {
+      "fingerprint": "21795f8c69a6eed323950d5322ecf972fa8e66b6aa38bd8810bb374791713cff",
+      "note": "False positive: interpolated values come from `sanitized_sql_array`, which returns Rails-sanitized SQL fragments. Inputs (`genres`, `lastfm_tags`) are validated array attributes on Artist."
+    },
+    {
+      "fingerprint": "6042218481a64580afe6976f652913474ac85cdfa778354777014e099048aa7b",
+      "note": "Intentional: `direct_stream_url` only validates the `https://` prefix. `\\z` anchor is not appropriate — we don't want to require the URL to be exactly `https://`."
+    },
+    {
+      "fingerprint": "c2a0c7101fbb88c416cd13e26458718b5d72f546f1a86cae2a23a6514be600e7",
+      "note": "Safe: ffmpeg is invoked via `Open3.capture3` with array args (no shell interpolation). `direct_stream_url` is validated to start with `https://`. See CLAUDE.md security section."
+    }
+  ],
+  "updated": "2026-04-29"
+}


### PR DESCRIPTION
Follow-up to #2078 — adds the remaining CI improvements with actual quality gates and reporting.

## Summary
- **`security` job** — runs `brakeman` and `bundler-audit`. Brakeman is gated by `config/brakeman.ignore` which suppresses three pre-existing findings (each annotated with a justification). New findings fail the job.
- **`swagger` job** — regenerates `swagger/v1/swagger.yaml` via `rake rswag:specs:swaggerize` and fails if the working tree is dirty. Enforces the CLAUDE.md rule that swagger be committed alongside spec changes.
- **JUnit reporting** — RSpec writes JUnit XML, and `mikepenz/action-junit-report` surfaces failing examples inline on the PR diff.
- **Deploy tag verification** — `deploy.yml` logs in to GHCR and runs `docker manifest inspect` before SSHing, so a typo'd tag fails fast instead of redeploying the previous release.
- Adds `bundler-audit` and `rspec_junit_formatter` to the test group.

## Test plan
- [ ] `security` job passes on this PR.
- [ ] `swagger` job passes (no drift).
- [ ] Test failures show up as inline annotations on the diff.
- [ ] Deploy workflow with a bogus tag fails at the manifest-inspect step.

## Brakeman findings to triage (separate)
Three pre-existing findings are suppressed in `config/brakeman.ignore` with reasoning:
1. Artist#similar_artists SQL — uses `sanitized_sql_array`, safe but flagged.
2. `direct_stream_url` regex — prefix-only is intentional.
3. ffmpeg `Open3.capture3` — array args, no shell interpolation. Safe per CLAUDE.md.

If any of these warrant a real fix vs. suppression, that's a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)