### PR TITLE
Fix Simone FM playlist gaps by draining API backlog

### DIFF
--- a/app/services/track_scraper/simone_api_processor.rb
+++ b/app/services/track_scraper/simone_api_processor.rb
@@ -6,7 +6,7 @@ class TrackScraper::SimoneApiProcessor < TrackScraper
     return false if response.blank?
 
     @raw_response = response
-    track = response.first
+    track = pick_track(response)
     return false if track.blank?
 
     @artist_name = track['artist'].titleize
@@ -20,6 +20,31 @@ class TrackScraper::SimoneApiProcessor < TrackScraper
   end
 
   private
+
+  # The Simone API returns the most-recent ~16 tracks. Pick the oldest one we
+  # haven't logged yet so a backlog (long DJ shows, missed scrapes) drains over
+  # successive ticks. Falls back to the newest track when every entry is already
+  # in SongImportLog — SongImporter#recently_imported? dedupes that case.
+  def pick_track(response)
+    sorted = response.sort_by { |t| Time.zone.parse(t['timestamp']) }
+    keys = recent_log_keys
+    sorted.find { |t| keys.exclude?(log_key_for(t)) } || sorted.last
+  end
+
+  def log_key_for(track)
+    [
+      track['artist'].titleize,
+      TitleSanitizer.sanitize(track['title']).titleize,
+      Time.zone.parse(track['timestamp'])
+    ]
+  end
+
+  def recent_log_keys
+    SongImportLog
+      .where(radio_station: @radio_station, created_at: 1.hour.ago..)
+      .pluck(:scraped_artist, :scraped_title, :broadcasted_at)
+      .to_set
+  end
 
   def fetch_playlist
     response = connection.get(@radio_station.url)

--- a/db/fixtures/001_radio_stations.rb
+++ b/db/fixtures/001_radio_stations.rb
@@ -163,7 +163,7 @@ RadioStation.seed(
   },
   {
     name: 'Simone FM',
-    url: 'https://api01.simone.nl/playlist?station=SIMONEFM&limit=1',
+    url: 'https://api01.simone.nl/playlist?station=SIMONEFM',
     processor: 'simone_api_processor',
     direct_stream_url: 'https://stream.simone.nl/simone',
     slug: 'simone-fm',

--- a/spec/factories/radio_station.rb
+++ b/spec/factories/radio_station.rb
@@ -167,7 +167,7 @@ FactoryBot.define do
 
   factory :simone_fm, parent: :radio_station do
     name { 'Simone FM' }
-    url { 'https://api01.simone.nl/playlist?station=SIMONEFM&limit=1' }
+    url { 'https://api01.simone.nl/playlist?station=SIMONEFM' }
     processor { 'simone_api_processor' }
     direct_stream_url { 'https://stream.simone.nl/simone' }
     slug { 'simone-fm' }

--- a/spec/services/track_scraper/simone_api_processor_spec.rb
+++ b/spec/services/track_scraper/simone_api_processor_spec.rb
@@ -9,15 +9,29 @@ describe TrackScraper::SimoneApiProcessor, type: :service do
   let(:radio_station) do
     RadioStation.find_by(name: 'Simone FM').presence || create(:simone_fm)
   end
-  let(:response) do
-    [
-      {
-        'station' => 'SIMONEFM',
-        'artist' => 'Red Hot Chili Peppers',
-        'title' => 'Scar tissue',
-        'timestamp' => '2026-03-30T09:51:13.124Z'
-      }
-    ]
+  let(:newest_track) do
+    {
+      'station' => 'SIMONEFM',
+      'artist' => 'Red Hot Chili Peppers',
+      'title' => 'Scar tissue',
+      'timestamp' => '2026-03-30T09:51:13.124Z'
+    }
+  end
+  let(:older_track) do
+    {
+      'station' => 'SIMONEFM',
+      'artist' => 'Foo Fighters',
+      'title' => 'Everlong',
+      'timestamp' => '2026-03-30T09:47:00.000Z'
+    }
+  end
+  let(:oldest_track) do
+    {
+      'station' => 'SIMONEFM',
+      'artist' => 'Pearl Jam',
+      'title' => 'Black',
+      'timestamp' => '2026-03-30T09:43:00.000Z'
+    }
   end
 
   describe '#last_played_song' do
@@ -26,7 +40,7 @@ describe TrackScraper::SimoneApiProcessor, type: :service do
     end
 
     context 'when the API response is valid' do
-      let(:api_response) { response }
+      let(:api_response) { [newest_track] }
 
       it 'returns true' do
         expect(last_played_song).to be true
@@ -66,6 +80,60 @@ describe TrackScraper::SimoneApiProcessor, type: :service do
 
       it 'returns false' do
         expect(last_played_song).to be false
+      end
+    end
+
+    context 'with multiple tracks and no prior import logs' do
+      let(:api_response) { [newest_track, older_track, oldest_track] }
+
+      it 'picks the oldest track to drain backlog in order', :aggregate_failures do
+        last_played_song
+        expect(processor.artist_name).to eq('Pearl Jam')
+        expect(processor.title).to eq('Black')
+        expect(processor.broadcasted_at).to eq(Time.zone.parse('2026-03-30T09:43:00.000Z'))
+      end
+    end
+
+    context 'with multiple tracks where the oldest was already imported' do
+      let(:api_response) { [newest_track, older_track, oldest_track] }
+
+      before do
+        SongImportLog.create!(
+          radio_station: radio_station,
+          status: :success,
+          import_source: :scraping,
+          scraped_artist: 'Pearl Jam',
+          scraped_title: 'Black',
+          broadcasted_at: Time.zone.parse('2026-03-30T09:43:00.000Z')
+        )
+      end
+
+      it 'picks the next-oldest unlogged track', :aggregate_failures do
+        last_played_song
+        expect(processor.artist_name).to eq('Foo Fighters')
+        expect(processor.title).to eq('Everlong')
+      end
+    end
+
+    context 'when every track is already in the import log' do
+      let(:api_response) { [newest_track, older_track] }
+
+      before do
+        [newest_track, older_track].each do |track|
+          SongImportLog.create!(
+            radio_station: radio_station,
+            status: :success,
+            import_source: :scraping,
+            scraped_artist: track['artist'].titleize,
+            scraped_title: TitleSanitizer.sanitize(track['title']).titleize,
+            broadcasted_at: Time.zone.parse(track['timestamp'])
+          )
+        end
+      end
+
+      it 'falls back to the newest track for SongImporter dedupe' do
+        last_played_song
+        expect(processor.broadcasted_at).to eq(Time.zone.parse(newest_track['timestamp']))
       end
     end
   end


### PR DESCRIPTION
## Summary
- Drop `&limit=1` from Simone FM's seeded playlist URL so the API returns its full ~16-track window.
- Have `TrackScraper::SimoneApiProcessor` pick the oldest track in the window that isn't already in `SongImportLog` within the last hour, falling back to the newest entry when everything is logged (so `SongImporter#recently_imported?` still dedupes).

## Why
Production logs for Simone FM showed multi-hour gaps in the day view (e.g. nothing between 09:06 and 12:24 on 2026-04-30 even though the upstream API still recorded Pitbull / Paul Young / Sam Feldt / Mr. President / KC and the Sunshine Band in that window). Two things compounded:

1. The seeded URL `?station=SIMONEFM&limit=1` made the Simone API return only the most recent track per call.
2. `SimoneApiProcessor#last_played_song` only ever consumed `response.first`.

So whenever more than one song aired between scrapes — long DJ shows like "Bert Vos Met Vinyl Classics", deploy windows, or any Sidekiq backlog — every older entry was lost. The dedupe logic in `SongImporter#recently_imported?` was already protecting us against repeats; what was missing was a way to *recover* missed tracks once the upstream API still had them in its window.

## Behavior after this change
- Each minute-tick the processor advances one step through any backlog of unlogged entries (oldest first), so chronological ordering is preserved on the timeline.
- Steady state is unchanged: once the latest track is logged, subsequent ticks fall back to the newest entry, which `recently_imported?` short-circuits as before.
- Cold start (no logs) imports the whole returned window over ~16 minutes.

## Test plan
- [x] `bundle exec rspec spec/services/track_scraper/simone_api_processor_spec.rb`
- [x] `bundle exec rubocop` on changed files
- [ ] After deploy + seed run, watch the Simone FM "Day" view in the UI to confirm new tracks fill in without holes during a multi-song interval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)