### PR TITLE
Simone scraper: newest-first within 1h lookback

### DIFF
--- a/app/services/track_scraper/simone_api_processor.rb
+++ b/app/services/track_scraper/simone_api_processor.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 class TrackScraper::SimoneApiProcessor < TrackScraper
+  # Cap drain to the last hour so we don't backfill stale history when the API
+  # window stretches further back. Within that window prefer the *newest*
+  # unlogged track so the last-imported airplay reflects what's currently on
+  # air — keeps the radio station "now playing" widget correct. Older unlogged
+  # tracks still drain on subsequent ticks (in reverse chronological order).
+  TRACK_LOOKBACK = 1.hour
+
   def last_played_song
     response = fetch_playlist
     return false if response.blank?
@@ -21,14 +28,14 @@ class TrackScraper::SimoneApiProcessor < TrackScraper
 
   private
 
-  # The Simone API returns the most-recent ~16 tracks. Pick the oldest one we
-  # haven't logged yet so a backlog (long DJ shows, missed scrapes) drains over
-  # successive ticks. Falls back to the newest track when every entry is already
-  # in SongImportLog — SongImporter#recently_imported? dedupes that case.
   def pick_track(response)
-    sorted = response.sort_by { |t| Time.zone.parse(t['timestamp']) }
+    cutoff = TRACK_LOOKBACK.ago
+    recent = response.select { |t| Time.zone.parse(t['timestamp']) >= cutoff }
+    return nil if recent.empty?
+
+    newest_first = recent.sort_by { |t| Time.zone.parse(t['timestamp']) }.reverse
     keys = recent_log_keys
-    sorted.find { |t| keys.exclude?(log_key_for(t)) } || sorted.last
+    newest_first.find { |t| keys.exclude?(log_key_for(t)) } || newest_first.first
   end
 
   def log_key_for(track)

--- a/spec/services/track_scraper/simone_api_processor_spec.rb
+++ b/spec/services/track_scraper/simone_api_processor_spec.rb
@@ -9,12 +9,13 @@ describe TrackScraper::SimoneApiProcessor, type: :service do
   let(:radio_station) do
     RadioStation.find_by(name: 'Simone FM').presence || create(:simone_fm)
   end
+  let(:now) { Time.zone.now }
   let(:newest_track) do
     {
       'station' => 'SIMONEFM',
       'artist' => 'Red Hot Chili Peppers',
       'title' => 'Scar tissue',
-      'timestamp' => '2026-03-30T09:51:13.124Z'
+      'timestamp' => (now - 4.minutes).iso8601(3)
     }
   end
   let(:older_track) do
@@ -22,7 +23,7 @@ describe TrackScraper::SimoneApiProcessor, type: :service do
       'station' => 'SIMONEFM',
       'artist' => 'Foo Fighters',
       'title' => 'Everlong',
-      'timestamp' => '2026-03-30T09:47:00.000Z'
+      'timestamp' => (now - 8.minutes).iso8601(3)
     }
   end
   let(:oldest_track) do
@@ -30,7 +31,7 @@ describe TrackScraper::SimoneApiProcessor, type: :service do
       'station' => 'SIMONEFM',
       'artist' => 'Pearl Jam',
       'title' => 'Black',
-      'timestamp' => '2026-03-30T09:43:00.000Z'
+      'timestamp' => (now - 12.minutes).iso8601(3)
     }
   end
 
@@ -58,7 +59,7 @@ describe TrackScraper::SimoneApiProcessor, type: :service do
 
       it 'sets the broadcasted_at timestamp' do
         last_played_song
-        expect(processor.broadcasted_at).to eq(Time.zone.parse('2026-03-30T09:51:13.124Z'))
+        expect(processor.broadcasted_at).to eq(Time.zone.parse(newest_track['timestamp']))
       end
 
       it 'sets the raw response' do
@@ -86,15 +87,14 @@ describe TrackScraper::SimoneApiProcessor, type: :service do
     context 'with multiple tracks and no prior import logs' do
       let(:api_response) { [newest_track, older_track, oldest_track] }
 
-      it 'picks the oldest track to drain backlog in order', :aggregate_failures do
+      it 'picks the newest track so now-playing stays fresh', :aggregate_failures do
         last_played_song
-        expect(processor.artist_name).to eq('Pearl Jam')
-        expect(processor.title).to eq('Black')
-        expect(processor.broadcasted_at).to eq(Time.zone.parse('2026-03-30T09:43:00.000Z'))
+        expect(processor.artist_name).to eq('Red Hot Chili Peppers')
+        expect(processor.title).to eq('Scar Tissue')
       end
     end
 
-    context 'with multiple tracks where the oldest was already imported' do
+    context 'with multiple tracks where the newest was already imported' do
       let(:api_response) { [newest_track, older_track, oldest_track] }
 
       before do
@@ -102,13 +102,13 @@ describe TrackScraper::SimoneApiProcessor, type: :service do
           radio_station: radio_station,
           status: :success,
           import_source: :scraping,
-          scraped_artist: 'Pearl Jam',
-          scraped_title: 'Black',
-          broadcasted_at: Time.zone.parse('2026-03-30T09:43:00.000Z')
+          scraped_artist: 'Red Hot Chili Peppers',
+          scraped_title: 'Scar Tissue',
+          broadcasted_at: Time.zone.parse(newest_track['timestamp'])
         )
       end
 
-      it 'picks the next-oldest unlogged track', :aggregate_failures do
+      it 'drains the next-newest unlogged track', :aggregate_failures do
         last_played_song
         expect(processor.artist_name).to eq('Foo Fighters')
         expect(processor.title).to eq('Everlong')
@@ -134,6 +134,39 @@ describe TrackScraper::SimoneApiProcessor, type: :service do
       it 'falls back to the newest track for SongImporter dedupe' do
         last_played_song
         expect(processor.broadcasted_at).to eq(Time.zone.parse(newest_track['timestamp']))
+      end
+    end
+
+    context 'when older entries fall outside the 1h lookback' do
+      let(:stale_track) do
+        {
+          'station' => 'SIMONEFM',
+          'artist' => 'Soundgarden',
+          'title' => 'Black hole sun',
+          'timestamp' => (now - 2.hours).iso8601(3)
+        }
+      end
+      let(:api_response) { [newest_track, stale_track] }
+
+      it 'ignores tracks older than the cutoff' do
+        last_played_song
+        expect(processor.broadcasted_at).to eq(Time.zone.parse(newest_track['timestamp']))
+      end
+    end
+
+    context 'when every entry is outside the 1h lookback' do
+      let(:stale_track) do
+        {
+          'station' => 'SIMONEFM',
+          'artist' => 'Soundgarden',
+          'title' => 'Black hole sun',
+          'timestamp' => (now - 2.hours).iso8601(3)
+        }
+      end
+      let(:api_response) { [stale_track] }
+
+      it 'returns false' do
+        expect(last_played_song).to be false
       end
     end
   end


### PR DESCRIPTION
## Summary
- Cap Simone's playlist drain to the last hour and pick the *newest* unlogged track each tick instead of the oldest.
- Backlog still drains across successive ticks (now in reverse chronological order); `SongImporter#recently_imported?` dedupes the fallback path.

## Why
After PR #2081 dropped `&limit=1` from the seeded URL, the Simone API started returning ~30 entries spanning ~5h of history. The previous oldest-first picker dutifully drained all of it, which produced two regressions:

1. **Stale history imports.** A fresh deploy backfilled 8am tracks at lunchtime — `8:28 UB40 / 8:37 Bronski Beat / 8:45 Golden Earring …` showed up in the day view as freshly imported airplays.
2. **Now-playing widget broken.** `RadioStation.last_played_songs` returns the most recently *created* airplay (`last_added_air_plays.first` ordered by `created_at`). With oldest-first drain, that was always the next-oldest backlog entry, not the actual current track. Live response confirmed Simone reporting `is_currently_playing: false` with `broadcasted_at: 12:20` while the station was actually airing The Pretenders ~80 minutes later.

## Behaviour after this change
- Newest-unlogged-within-1h is picked per tick → the most recently imported airplay is always the most recent broadcast we've seen, so `is_currently_playing` is computed against fresh data.
- 1h cutoff stops the deep-history drain — anything older than `TRACK_LOOKBACK.ago` is ignored.
- Backlog still resolves: each subsequent tick picks the next-newest unlogged entry, so a 5-track gap drains across 5 ticks (reverse chronological) instead of all-at-once.
- Trade-off: tracks that age past 1h before they "surface" in the API window (only triggered by 1h+ DJ shows like Bert Vos) are not re-imported. Day view stays complete for normal operation; this affects only post-show backfill of multi-hour pre-recorded segments.

## Test plan
- [x] `bundle exec rspec spec/services/track_scraper/simone_api_processor_spec.rb` (12 examples, 0 failures)
- [x] `bundle exec rubocop` on changed files
- [ ] After deploy, watch `/api/v1/radio_stations/last_played_songs` for Simone FM and confirm `is_currently_playing` flips to `true` once a fresh track is imported, and that the day view stops gaining 8am entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)