### PR TITLE
Add Faraday timeouts to Simone scraper

### DIFF
--- a/app/services/track_scraper/simone_api_processor.rb
+++ b/app/services/track_scraper/simone_api_processor.rb
@@ -62,6 +62,8 @@ class TrackScraper::SimoneApiProcessor < TrackScraper
 
   def connection
     @connection ||= Faraday.new(@radio_station.url) do |conn|
+      conn.options.timeout = 10
+      conn.options.open_timeout = 5
       conn.response :json
     end
   end


### PR DESCRIPTION
## Summary
- Set explicit Faraday timeouts on `SimoneApiProcessor#connection` (5s open / 10s read) to match what the base `TrackScraper#connection` does for every other processor.

## Why
Today's Simone import logs show four sustained windows where the job did not run at all (20 min, 18 min, 27 min, 47 min). `SongImporter#safe_start_log` creates a `SongImportLog` on every entry into `import` — there were zero rows in those windows, meaning the job was being skipped *before* `SongImporter` was reached, while other stations on the same Sidekiq queue imported normally.

The Simone processor's `connection` was the only one without explicit Faraday timeouts. With Net::HTTP defaults (~60s connect / 60s read), one stalled upstream request can keep a worker busy for ~120s — past `ImportSongJob`'s `lock_ttl: 60`. While the thread is occupied, the next minute-tick's enqueue either hits the orphaned unique-jobs lock or piles onto the same hanging request, which is consistent with the irregular Simone-only no-log gaps we saw.

## Behaviour after
- A sluggish or hanging Simone API now fails the request after ~10s, releasing the worker well within the 60s lock TTL.
- Other stations are unaffected; their processors already had timeouts via the base class.
- If the upstream is genuinely down, we'll see `failed` `SongImportLog` rows instead of mysterious silences — easier to diagnose next time.

## Test plan
- [x] `bundle exec rspec spec/services/track_scraper/simone_api_processor_spec.rb` (12 examples, 0 failures)
- [x] `bundle exec rubocop` on changed file
- [ ] After deploy, watch `SongImportLog` for Simone over a 1h window and confirm the no-log gaps disappear (gaps should be replaced by `failed`/`skipped` rows when the upstream is slow, not absence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)