### PR TITLE
Add timeouts to Yoursafe ffmpeg + Tesseract calls

### DIFF
--- a/app/services/track_scraper/yoursafe_video_processor.rb
+++ b/app/services/track_scraper/yoursafe_video_processor.rb
@@ -3,6 +3,9 @@
 class TrackScraper::YoursafeVideoProcessor < TrackScraper
   ARTIST_TITLE_SEPARATOR = ' - '
   OCR_LANGUAGES = 'eng+nld+deu+fra+spa+ita+por+rus+tur'
+  FFMPEG_TIMEOUT_SECONDS = 15
+  OCR_TIMEOUT_SECONDS = 15
+  FFMPEG_RW_TIMEOUT_MICROSECONDS = '5000000'
 
   def last_played_song
     frame_file = extract_video_frame
@@ -33,19 +36,44 @@ class TrackScraper::YoursafeVideoProcessor < TrackScraper
 
   def extract_video_frame
     output_file = Rails.root.join("tmp/audio/yoursafe_frame_#{SecureRandom.hex(4)}.png").to_s
-    _stdout, _stderr, status = Open3.capture3(
-      'ffmpeg', '-y', '-t', '1',
+    status = run_ffmpeg(output_file)
+    status&.success? && File.exist?(output_file) ? output_file : nil
+  end
+
+  # Wraps the ffmpeg invocation in popen3 with a wall-clock kill so a hanging
+  # HLS read can't keep the Sidekiq worker thread occupied past ImportSongJob's
+  # 60s lock TTL. -rw_timeout makes ffmpeg fail fast on its own when possible;
+  # the kill is the safety net.
+  def run_ffmpeg(output_file)
+    cmd = [
+      'ffmpeg', '-y',
+      '-rw_timeout', FFMPEG_RW_TIMEOUT_MICROSECONDS,
+      '-t', '1',
       '-i', @radio_station.direct_stream_url,
       '-vframes', '1', '-update', '1',
       output_file
-    )
-
-    status.success? && File.exist?(output_file) ? output_file : nil
+    ]
+    Open3.popen3(*cmd) do |stdin, _stdout, _stderr, wait_thr|
+      stdin.close
+      if wait_thr.join(FFMPEG_TIMEOUT_SECONDS)
+        wait_thr.value
+      else
+        Process.kill('KILL', wait_thr.pid)
+        wait_thr.join
+        Rails.logger.warn("YoursafeVideoProcessor: ffmpeg timed out after #{FFMPEG_TIMEOUT_SECONDS}s")
+        nil
+      end
+    end
   end
 
   def ocr_frame(frame_file)
-    image = RTesseract.new(frame_file, lang: OCR_LANGUAGES)
-    image.to_s.strip
+    Timeout.timeout(OCR_TIMEOUT_SECONDS) do
+      image = RTesseract.new(frame_file, lang: OCR_LANGUAGES)
+      image.to_s.strip
+    end
+  rescue Timeout::Error
+    Rails.logger.warn("YoursafeVideoProcessor: OCR timed out after #{OCR_TIMEOUT_SECONDS}s")
+    ''
   end
 
   def extract_artist_title_line(text)


### PR DESCRIPTION
## Summary
- Wrap `ffmpeg` (HLS frame capture) in `Open3.popen3` with a 15s wall-clock kill so a hanging subprocess can't outlive `ImportSongJob`'s 60s `lock_ttl`.
- Pass `-rw_timeout 5s` so ffmpeg fails cleanly on its own when the network read stalls.
- Wrap the `RTesseract` OCR call in `Timeout.timeout(15)` and downgrade timeouts to a blank OCR result (the existing flow already treats blank as "no song available" and skips cleanly).

## Why
Sidekiq Busy view this afternoon showed **8 of 10 workers** wedged on `ImportSongJob` for `radio_station_id=16` (Yoursafe Radio), the oldest running for ~1 hour. With concurrency=10 and 8 slots permanently held, the `api_scraping` queue had 1–2 workers free for everything else — which is why Simone (and other stations) were getting irregular long gaps in `SongImportLog` even though their own processors were fine.

`TrackScraper::YoursafeVideoProcessor` shelled out to `ffmpeg` and `tesseract` (via `RTesseract`) with **no timeouts on either**. A hanging HLS read on ffmpeg ties up the worker thread until something external kills it, which evidently hadn't happened for an hour.

## Behaviour after
- Stalled ffmpeg subprocesses are SIGKILL'd at 15s — well under the 60s job lock — so workers free up on schedule.
- Stalled OCR raises `Timeout::Error`, gets rescued, returns blank text → existing skip path → clean exit.
- Other stations on the same queue stop being starved.
- Worth manually killing the 8 currently-stuck Yoursafe jobs in the Sidekiq Busy view to recover capacity immediately; this PR prevents the situation from re-occurring.

## Test plan
- [x] `bundle exec rspec spec/services/track_scraper/yoursafe_video_processor_spec.rb` (13 examples, 0 failures — existing specs stub the methods we're wrapping, so contracts are unchanged)
- [x] `bundle exec rubocop` on changed file
- [ ] After deploy, watch Sidekiq Busy view: confirm Yoursafe jobs complete or fail within ~15s instead of running for many minutes/hours.
- [ ] Watch `SongImportLog` cadence for Simone over a 1h window: confirm gaps shrink now that workers aren't starved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)