### PR TITLE
Switch Simone scraper to /playlist/nowplaying endpoint

### DIFF
--- a/app/services/track_scraper/simone_api_processor.rb
+++ b/app/services/track_scraper/simone_api_processor.rb
@@ -1,24 +1,23 @@
 # frozen_string_literal: true
 
 class TrackScraper::SimoneApiProcessor < TrackScraper
-  # Cap drain to the last hour so we don't backfill stale history when the API
-  # window stretches further back. Within that window prefer the *newest*
-  # unlogged track so the last-imported airplay reflects what's currently on
-  # air — keeps the radio station "now playing" widget correct. Older unlogged
-  # tracks still drain on subsequent ticks (in reverse chronological order).
-  TRACK_LOOKBACK = 1.hour
+  # Window we treat as "the same song still playing" — longer than any
+  # reasonable Simone track. While a song is in this window, we reuse its
+  # broadcasted_at so SongImporter#recently_imported? dedupes naturally.
+  SAME_SONG_WINDOW = 10.minutes
 
   def last_played_song
-    response = fetch_playlist
-    return false if response.blank?
-
-    @raw_response = response
-    track = pick_track(response)
+    track = fetch_now_playing
     return false if track.blank?
 
-    @artist_name = track['artist'].titleize
-    @title = TitleSanitizer.sanitize(track['title']).titleize
-    @broadcasted_at = Time.zone.parse(track['timestamp'])
+    artist = track['artist'].to_s.titleize
+    title = TitleSanitizer.sanitize(track['title'].to_s).titleize
+    return false if artist.blank? || title.blank?
+
+    @raw_response = track
+    @artist_name = artist
+    @title = title
+    @broadcasted_at = broadcasted_at_for(artist, title)
     true
   rescue StandardError => e
     Rails.logger.warn("SimoneApiProcessor: #{e.message}")
@@ -28,32 +27,25 @@ class TrackScraper::SimoneApiProcessor < TrackScraper
 
   private
 
-  def pick_track(response)
-    cutoff = TRACK_LOOKBACK.ago
-    recent = response.select { |t| Time.zone.parse(t['timestamp']) >= cutoff }
-    return nil if recent.empty?
+  # The /playlist/nowplaying endpoint has no timestamp. If the most recent log
+  # for this station is the same song within SAME_SONG_WINDOW, reuse its
+  # broadcasted_at — SongImporter#recently_imported? then matches and skips
+  # the duplicate scrape. New song → fresh Time.zone.now.
+  def broadcasted_at_for(artist, title)
+    last = SongImportLog
+             .where(radio_station: @radio_station, created_at: SAME_SONG_WINDOW.ago..)
+             .where.not(broadcasted_at: nil)
+             .order(created_at: :desc)
+             .first
 
-    newest_first = recent.sort_by { |t| Time.zone.parse(t['timestamp']) }.reverse
-    keys = recent_log_keys
-    newest_first.find { |t| keys.exclude?(log_key_for(t)) } || newest_first.first
+    if last && last.scraped_artist == artist && last.scraped_title == title
+      last.broadcasted_at
+    else
+      Time.zone.now
+    end
   end
 
-  def log_key_for(track)
-    [
-      track['artist'].titleize,
-      TitleSanitizer.sanitize(track['title']).titleize,
-      Time.zone.parse(track['timestamp'])
-    ]
-  end
-
-  def recent_log_keys
-    SongImportLog
-      .where(radio_station: @radio_station, created_at: 1.hour.ago..)
-      .pluck(:scraped_artist, :scraped_title, :broadcasted_at)
-      .to_set
-  end
-
-  def fetch_playlist
+  def fetch_now_playing
     response = connection.get(@radio_station.url)
     return nil unless response.success?
 

--- a/db/fixtures/001_radio_stations.rb
+++ b/db/fixtures/001_radio_stations.rb
@@ -163,7 +163,7 @@ RadioStation.seed(
   },
   {
     name: 'Simone FM',
-    url: 'https://api01.simone.nl/playlist?station=SIMONEFM',
+    url: 'https://api01.simone.nl/playlist/nowplaying?station=SIMONEFM',
     processor: 'simone_api_processor',
     direct_stream_url: 'https://stream.simone.nl/simone',
     slug: 'simone-fm',

--- a/spec/factories/radio_station.rb
+++ b/spec/factories/radio_station.rb
@@ -167,7 +167,7 @@ FactoryBot.define do
 
   factory :simone_fm, parent: :radio_station do
     name { 'Simone FM' }
-    url { 'https://api01.simone.nl/playlist?station=SIMONEFM' }
+    url { 'https://api01.simone.nl/playlist/nowplaying?station=SIMONEFM' }
     processor { 'simone_api_processor' }
     direct_stream_url { 'https://stream.simone.nl/simone' }
     slug { 'simone-fm' }

--- a/spec/services/track_scraper/simone_api_processor_spec.rb
+++ b/spec/services/track_scraper/simone_api_processor_spec.rb
@@ -9,39 +9,15 @@ describe TrackScraper::SimoneApiProcessor, type: :service do
   let(:radio_station) do
     RadioStation.find_by(name: 'Simone FM').presence || create(:simone_fm)
   end
-  let(:now) { Time.zone.now }
-  let(:newest_track) do
-    {
-      'station' => 'SIMONEFM',
-      'artist' => 'Red Hot Chili Peppers',
-      'title' => 'Scar tissue',
-      'timestamp' => (now - 4.minutes).iso8601(3)
-    }
-  end
-  let(:older_track) do
-    {
-      'station' => 'SIMONEFM',
-      'artist' => 'Foo Fighters',
-      'title' => 'Everlong',
-      'timestamp' => (now - 8.minutes).iso8601(3)
-    }
-  end
-  let(:oldest_track) do
-    {
-      'station' => 'SIMONEFM',
-      'artist' => 'Pearl Jam',
-      'title' => 'Black',
-      'timestamp' => (now - 12.minutes).iso8601(3)
-    }
-  end
+  let(:now_playing) { { 'artist' => 'Sandra', 'title' => "(I'll never be) Maria Magdalena" } }
 
   describe '#last_played_song' do
     before do
-      allow(processor).to receive(:fetch_playlist).and_return(api_response)
+      allow(processor).to receive(:fetch_now_playing).and_return(api_response)
     end
 
     context 'when the API response is valid' do
-      let(:api_response) { [newest_track] }
+      let(:api_response) { now_playing }
 
       it 'returns true' do
         expect(last_played_song).to be true
@@ -49,22 +25,22 @@ describe TrackScraper::SimoneApiProcessor, type: :service do
 
       it 'sets the artist name' do
         last_played_song
-        expect(processor.artist_name).to eq('Red Hot Chili Peppers')
+        expect(processor.artist_name).to eq('Sandra')
       end
 
       it 'sets the title' do
         last_played_song
-        expect(processor.title).to eq('Scar Tissue')
+        expect(processor.title).to eq("(I'll Never Be) Maria Magdalena")
       end
 
-      it 'sets the broadcasted_at timestamp' do
+      it 'sets broadcasted_at to now when no recent log exists' do
         last_played_song
-        expect(processor.broadcasted_at).to eq(Time.zone.parse(newest_track['timestamp']))
+        expect(processor.broadcasted_at).to be_within(1.second).of(Time.zone.now)
       end
 
       it 'sets the raw response' do
         last_played_song
-        expect(processor.raw_response).to be_present
+        expect(processor.raw_response).to eq(now_playing)
       end
     end
 
@@ -76,97 +52,81 @@ describe TrackScraper::SimoneApiProcessor, type: :service do
       end
     end
 
-    context 'when the track is blank' do
-      let(:api_response) { [] }
+    context 'when the artist is missing' do
+      let(:api_response) { { 'artist' => nil, 'title' => 'Foo' } }
 
       it 'returns false' do
         expect(last_played_song).to be false
       end
     end
 
-    context 'with multiple tracks and no prior import logs' do
-      let(:api_response) { [newest_track, older_track, oldest_track] }
+    context 'when the title is missing' do
+      let(:api_response) { { 'artist' => 'Sandra', 'title' => '' } }
 
-      it 'picks the newest track so now-playing stays fresh', :aggregate_failures do
-        last_played_song
-        expect(processor.artist_name).to eq('Red Hot Chili Peppers')
-        expect(processor.title).to eq('Scar Tissue')
+      it 'returns false' do
+        expect(last_played_song).to be false
       end
     end
 
-    context 'with multiple tracks where the newest was already imported' do
-      let(:api_response) { [newest_track, older_track, oldest_track] }
+    context 'when the same song is already in a recent log' do
+      let(:api_response) { now_playing }
+      let(:earlier_broadcasted_at) { 3.minutes.ago }
 
       before do
         SongImportLog.create!(
           radio_station: radio_station,
           status: :success,
           import_source: :scraping,
-          scraped_artist: 'Red Hot Chili Peppers',
-          scraped_title: 'Scar Tissue',
-          broadcasted_at: Time.zone.parse(newest_track['timestamp'])
+          scraped_artist: 'Sandra',
+          scraped_title: "(I'll Never Be) Maria Magdalena",
+          broadcasted_at: earlier_broadcasted_at
         )
       end
 
-      it 'drains the next-newest unlogged track', :aggregate_failures do
+      it 'reuses the prior log broadcasted_at so SongImporter dedupes' do
         last_played_song
-        expect(processor.artist_name).to eq('Foo Fighters')
-        expect(processor.title).to eq('Everlong')
+        expect(processor.broadcasted_at).to be_within(1.second).of(earlier_broadcasted_at)
       end
     end
 
-    context 'when every track is already in the import log' do
-      let(:api_response) { [newest_track, older_track] }
+    context 'when the most recent log is a different song' do
+      let(:api_response) { now_playing }
 
       before do
-        [newest_track, older_track].each do |track|
-          SongImportLog.create!(
-            radio_station: radio_station,
-            status: :success,
-            import_source: :scraping,
-            scraped_artist: track['artist'].titleize,
-            scraped_title: TitleSanitizer.sanitize(track['title']).titleize,
-            broadcasted_at: Time.zone.parse(track['timestamp'])
-          )
-        end
+        SongImportLog.create!(
+          radio_station: radio_station,
+          status: :success,
+          import_source: :scraping,
+          scraped_artist: 'Pearl Jam',
+          scraped_title: 'Black',
+          broadcasted_at: 4.minutes.ago
+        )
       end
 
-      it 'falls back to the newest track for SongImporter dedupe' do
+      it 'mints a fresh broadcasted_at' do
         last_played_song
-        expect(processor.broadcasted_at).to eq(Time.zone.parse(newest_track['timestamp']))
+        expect(processor.broadcasted_at).to be_within(1.second).of(Time.zone.now)
       end
     end
 
-    context 'when older entries fall outside the 1h lookback' do
-      let(:stale_track) do
-        {
-          'station' => 'SIMONEFM',
-          'artist' => 'Soundgarden',
-          'title' => 'Black hole sun',
-          'timestamp' => (now - 2.hours).iso8601(3)
-        }
-      end
-      let(:api_response) { [newest_track, stale_track] }
+    context 'when the same song last played outside the same-song window' do
+      let(:api_response) { now_playing }
 
-      it 'ignores tracks older than the cutoff' do
+      before do
+        SongImportLog.create!(
+          radio_station: radio_station,
+          status: :success,
+          import_source: :scraping,
+          scraped_artist: 'Sandra',
+          scraped_title: "(I'll Never Be) Maria Magdalena",
+          broadcasted_at: 30.minutes.ago,
+          created_at: 30.minutes.ago
+        )
+      end
+
+      it 'mints a fresh broadcasted_at for the new airplay' do
         last_played_song
-        expect(processor.broadcasted_at).to eq(Time.zone.parse(newest_track['timestamp']))
-      end
-    end
-
-    context 'when every entry is outside the 1h lookback' do
-      let(:stale_track) do
-        {
-          'station' => 'SIMONEFM',
-          'artist' => 'Soundgarden',
-          'title' => 'Black hole sun',
-          'timestamp' => (now - 2.hours).iso8601(3)
-        }
-      end
-      let(:api_response) { [stale_track] }
-
-      it 'returns false' do
-        expect(last_played_song).to be false
+        expect(processor.broadcasted_at).to be_within(1.second).of(Time.zone.now)
       end
     end
   end


### PR DESCRIPTION
## Summary
- Repoint Simone's URL at `https://api01.simone.nl/playlist/nowplaying?station=SIMONEFM`.
- Rewrite `TrackScraper::SimoneApiProcessor` for the new single-track JSON contract.
- Drop `pick_track` / `recent_log_keys` / 1h cutoff — none of that is meaningful when the endpoint returns just the current track.

## Why
The `/playlist` endpoint forced us into a sequence of compromises (drain whole window, then cap at 1h, then try to square that with now-playing freshness) and we still saw inconsistent imports. `/playlist/nowplaying` returns exactly what the import flow needs:

```json
{"artist": "Sandra", "title": "(I'll never be) Maria Magdalena"}
```

## Dedupe handling
The endpoint has no timestamp. The processor sets `broadcasted_at = Time.zone.now` for new songs. While the same song is still playing — matched against the most recent `SongImportLog` for this station within `SAME_SONG_WINDOW = 10.minutes` — it **reuses the prior log's `broadcasted_at`** so `SongImporter#recently_imported?` finds an exact match and skips. Net result: one airplay per play, no per-minute duplicates while a song streams.

## Trade-offs
- ✅ Half the LoC, no DB query inside the picker beyond a single ordered lookup, no array sorting.
- ✅ Now-playing is fresh by definition — we're only ever importing the current track.
- ✅ Faraday timeouts (5s open / 10s read) from #2083 carry over.
- ❌ No backlog recovery for tracks the Simone API doesn't expose as "current" at scrape time (DJ-show transitions, brief stalls). Those weren't being captured reliably with any of the previous approaches either.

## Test plan
- [x] `bundle exec rspec spec/services/track_scraper/simone_api_processor_spec.rb` (11 examples, 0 failures)
- [x] `bundle exec rubocop` on changed files
- [ ] After deploy, watch `SongImportLog` for Simone over a 1h window and confirm: (a) one `success` log per song play, (b) `skipped` logs with reason "Duplicate: same scraped data recently imported" while a song continues, (c) the now-playing widget on the radio-station page tracks live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)