### PR TITLE
Add timeouts to SongRecognizer + AcoustidRecognizer

### DIFF
--- a/app/services/acoustid_recognizer.rb
+++ b/app/services/acoustid_recognizer.rb
@@ -39,6 +39,9 @@ class AcoustidRecognizer
 
   ACOUSTID_API_URL = 'https://api.acoustid.org/v2/lookup'
   MINIMUM_SCORE = 0.5
+  FPCALC_TIMEOUT_SECONDS = 15
+  HTTP_OPEN_TIMEOUT_SECONDS = 5
+  HTTP_READ_TIMEOUT_SECONDS = 10
 
   attr_reader :result, :title, :artist_name, :recording_id, :score
 
@@ -70,10 +73,7 @@ class AcoustidRecognizer
   private
 
   def generate_fingerprint
-    output, error, status = Open3.capture3('fpcalc', '-json', @audio_file_path.to_s)
-
-    raise FingerprintError, "fpcalc failed: #{error.presence || 'unknown error'}" unless status.success?
-
+    output = run_fpcalc
     result = JSON.parse(output)
     {
       fingerprint: result['fingerprint'],
@@ -81,6 +81,26 @@ class AcoustidRecognizer
     }
   rescue JSON::ParserError => e
     raise FingerprintError, "Invalid fpcalc output: #{e.message}"
+  end
+
+  # popen3 + wall-clock kill so a stalled fpcalc can't keep the Sidekiq worker
+  # thread occupied past ImportSongJob's 60s lock TTL. fpcalc can hang on
+  # malformed/truncated mp3 segments produced by upstream HLS stalls.
+  def run_fpcalc
+    Open3.popen3('fpcalc', '-json', @audio_file_path.to_s) do |stdin, stdout, stderr, wait_thr|
+      stdin.close
+      if wait_thr.join(FPCALC_TIMEOUT_SECONDS)
+        output = stdout.read
+        error = stderr.read
+        raise FingerprintError, "fpcalc failed: #{error.presence || 'unknown error'}" unless wait_thr.value.success?
+
+        output
+      else
+        ::Process.kill('KILL', wait_thr.pid)
+        wait_thr.join
+        raise FingerprintError, "fpcalc timed out after #{FPCALC_TIMEOUT_SECONDS}s"
+      end
+    end
   end
 
   def lookup_fingerprint(fingerprint_data)
@@ -93,7 +113,7 @@ class AcoustidRecognizer
     }
     uri.query = URI.encode_www_form(params)
 
-    response = Net::HTTP.get_response(uri)
+    response = http_client(uri).get(uri.request_uri)
 
     raise ApiError, "AcoustID API returned #{response.code}: #{response.body.truncate(200)}" unless response.is_a?(Net::HTTPSuccess)
 
@@ -102,6 +122,14 @@ class AcoustidRecognizer
     raise ApiError, "Invalid API response: #{e.message}"
   rescue StandardError => e
     raise ApiError, "API request failed: #{e.message}"
+  end
+
+  def http_client(uri)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = (uri.scheme == 'https')
+    http.open_timeout = HTTP_OPEN_TIMEOUT_SECONDS
+    http.read_timeout = HTTP_READ_TIMEOUT_SECONDS
+    http
   end
 
   def handle_response(response)

--- a/app/services/song_recognizer.rb
+++ b/app/services/song_recognizer.rb
@@ -61,6 +61,8 @@ class SongRecognizer
     /retry after/i
   ].freeze
 
+  SONGREC_TIMEOUT_SECONDS = 15
+
   attr_reader :audio_stream, :result, :title, :artist_name, :broadcasted_at, :spotify_url, :isrc_code
 
   # @param radio_station [RadioStation] The radio station to capture audio from
@@ -92,13 +94,24 @@ class SongRecognizer
 
   private
 
+  # Wraps the songrec invocation in popen3 with a wall-clock kill so a hanging
+  # Shazam request can't keep the Sidekiq worker thread occupied past
+  # ImportSongJob's 60s lock TTL. Without this, a stalled songrec process
+  # piles duplicate jobs onto the queue once the lock expires.
   def run_song_recognizer
     raise RecognitionError, "Audio file not found: #{@output_file}" unless File.exist?(@output_file)
 
-    Open3.popen3('songrec', 'audio-file-to-recognized-song', @output_file.to_s) do |_stdin, stdout, stderr, _wait_thr|
-      output = stdout.read
-      error = stderr.read
-      output.presence || error
+    Open3.popen3('songrec', 'audio-file-to-recognized-song', @output_file.to_s) do |stdin, stdout, stderr, wait_thr|
+      stdin.close
+      if wait_thr.join(SONGREC_TIMEOUT_SECONDS)
+        output = stdout.read
+        error = stderr.read
+        output.presence || error
+      else
+        ::Process.kill('KILL', wait_thr.pid)
+        wait_thr.join
+        raise RecognitionError, "songrec timed out after #{SONGREC_TIMEOUT_SECONDS}s"
+      end
     end
   end
 

--- a/spec/services/acoustid_recognizer_spec.rb
+++ b/spec/services/acoustid_recognizer_spec.rb
@@ -37,6 +37,18 @@ RSpec.describe AcoustidRecognizer, type: :service do
     allow(File).to receive(:exist?).with(audio_file_path).and_return(true)
   end
 
+  def stub_fpcalc(output: fingerprint_output, error: '', success: true, joined: true)
+    status = instance_double(Process::Status, success?: success)
+    wait_thr = instance_double(Process::Waiter, pid: 12_345, value: status)
+    allow(wait_thr).to receive(:join).and_return(joined ? wait_thr : nil, wait_thr)
+    stdin = instance_double(IO, close: nil)
+    stdout = instance_double(IO, read: output)
+    stderr = instance_double(IO, read: error)
+    allow(Open3).to receive(:popen3).with('fpcalc', '-json', audio_file_path.to_s).and_yield(stdin, stdout, stderr, wait_thr)
+    allow(::Process).to receive(:kill)
+    wait_thr
+  end
+
   describe '#recognized?' do
     context 'when API key is missing' do
       let(:api_key) { nil }
@@ -58,8 +70,7 @@ RSpec.describe AcoustidRecognizer, type: :service do
 
     context 'when fpcalc fails' do
       before do
-        allow(Open3).to receive(:capture3)
-                          .and_return(['', 'fpcalc error', instance_double(Process::Status, success?: false)])
+        stub_fpcalc(output: '', error: 'fpcalc error', success: false)
       end
 
       it 'returns false' do
@@ -73,14 +84,34 @@ RSpec.describe AcoustidRecognizer, type: :service do
       end
     end
 
+    context 'when fpcalc times out' do
+      before do
+        stub_fpcalc(joined: false)
+      end
+
+      it 'returns false' do
+        expect(recognizer.recognized?).to be false
+      end
+
+      it 'kills the fpcalc process' do
+        recognizer.recognized?
+        expect(::Process).to have_received(:kill).with('KILL', 12_345)
+      end
+
+      it 'logs a warning about the timeout' do
+        allow(Rails.logger).to receive(:warn)
+        recognizer.recognized?
+        expect(Rails.logger).to have_received(:warn).with(/timed out/)
+      end
+    end
+
     context 'when fpcalc succeeds but API returns no results' do
       let(:empty_api_response) do
         { 'status' => 'ok', 'results' => [] }
       end
 
       before do
-        allow(Open3).to receive(:capture3)
-                          .and_return([fingerprint_output, '', instance_double(Process::Status, success?: true)])
+        stub_fpcalc
         stub_request(:get, /api.acoustid.org/)
           .to_return(status: 200, body: empty_api_response.to_json)
       end
@@ -99,8 +130,7 @@ RSpec.describe AcoustidRecognizer, type: :service do
       end
 
       before do
-        allow(Open3).to receive(:capture3)
-                          .and_return([fingerprint_output, '', instance_double(Process::Status, success?: true)])
+        stub_fpcalc
         stub_request(:get, /api.acoustid.org/)
           .to_return(status: 200, body: low_score_response.to_json)
       end
@@ -112,8 +142,7 @@ RSpec.describe AcoustidRecognizer, type: :service do
 
     context 'when recognition is successful' do
       before do
-        allow(Open3).to receive(:capture3)
-                          .and_return([fingerprint_output, '', instance_double(Process::Status, success?: true)])
+        stub_fpcalc
         stub_request(:get, /api.acoustid.org/)
           .to_return(status: 200, body: successful_api_response.to_json)
       end
@@ -173,8 +202,7 @@ RSpec.describe AcoustidRecognizer, type: :service do
       end
 
       before do
-        allow(Open3).to receive(:capture3)
-                          .and_return([fingerprint_output, '', instance_double(Process::Status, success?: true)])
+        stub_fpcalc
         stub_request(:get, /api.acoustid.org/)
           .to_return(status: 200, body: multi_artist_response.to_json)
       end
@@ -191,8 +219,7 @@ RSpec.describe AcoustidRecognizer, type: :service do
       end
 
       before do
-        allow(Open3).to receive(:capture3)
-                          .and_return([fingerprint_output, '', instance_double(Process::Status, success?: true)])
+        stub_fpcalc
         stub_request(:get, /api.acoustid.org/)
           .to_return(status: 200, body: error_response.to_json)
       end
@@ -210,8 +237,7 @@ RSpec.describe AcoustidRecognizer, type: :service do
 
     context 'when API returns HTTP error' do
       before do
-        allow(Open3).to receive(:capture3)
-                          .and_return([fingerprint_output, '', instance_double(Process::Status, success?: true)])
+        stub_fpcalc
         stub_request(:get, /api.acoustid.org/)
           .to_return(status: 500, body: 'Internal Server Error')
       end


### PR DESCRIPTION
## Summary
- Yesterday's #2084 added timeouts to the Yoursafe **OCR scraper**, but the recognition path that runs when scrape returns nil was still unbounded. `songrec`, `fpcalc`, and the AcoustID HTTP call could each hang on broken/truncated mp3 segments produced by upstream HLS stalls — keeping the Sidekiq worker thread occupied past `ImportSongJob`'s 60s lock TTL and piling duplicate jobs onto the queue (the symptom Sam reported on station 16).
- Wraps `songrec` and `fpcalc` in `popen3` + wall-clock kill (15s each), and sets explicit `open_timeout`/`read_timeout` on the AcoustID HTTP lookup. Same pattern as `YoursafeVideoProcessor`.
- Updates `acoustid_recognizer_spec.rb` to stub `popen3` instead of `capture3`, and adds a timeout test that asserts `Process.kill('KILL', pid)` is called.

## Test plan
- [x] `bundle exec rspec spec/services/acoustid_recognizer_spec.rb` (20 examples, 0 failures)
- [x] `bundle exec rspec spec/services/song_importer*` + concerns (171 examples, 0 failures)
- [x] `bundle exec rubocop app/services/song_recognizer.rb app/services/acoustid_recognizer.rb spec/services/acoustid_recognizer_spec.rb` (no offenses)
- [ ] After deploy: watch Sidekiq Busy view for station 16 — pile-up should clear within a few minutes