### PR TITLE
Trim Spotify response and skip uniqueness query on import

### DIFF
--- a/app/models/radio_station.rb
+++ b/app/models/radio_station.rb
@@ -44,7 +44,7 @@ class RadioStation < ActiveRecord::Base
   has_many :tags, dependent: :destroy, as: :taggable
 
   validates :name, presence: true
-  validates :name, uniqueness: true
+  validates :name, uniqueness: true, if: :will_save_change_to_name?
   validates :processor, inclusion: { in: VALID_PROCESSORS }, allow_blank: true
   validates :direct_stream_url, format: { with: %r{\Ahttps://}i, message: 'must start with https://' }, allow_blank: true
 

--- a/app/services/song_import_logger.rb
+++ b/app/services/song_import_logger.rb
@@ -64,7 +64,7 @@ class SongImportLogger
       spotify_title: spotify_track.title,
       spotify_track_id: spotify_track.id,
       spotify_isrc: spotify_track.isrc,
-      spotify_raw_response: spotify_track.track || {}
+      spotify_raw_response: slim_spotify_response(spotify_track.track)
     )
   end
 
@@ -137,6 +137,17 @@ class SongImportLogger
     return nil unless spotify_track.artists
 
     spotify_track.artists.filter_map { |a| a&.dig('name') }.join(', ')
+  end
+
+  # Spotify track responses include an `available_markets` array (~1 KB of
+  # country codes) on both the track and album. Nothing in the app reads it,
+  # so drop it before storing the raw response to keep SongImportLog rows lean.
+  def slim_spotify_response(track_hash)
+    return {} if track_hash.blank?
+
+    trimmed = track_hash.except('available_markets')
+    trimmed['album'] = trimmed['album'].except('available_markets') if trimmed['album'].is_a?(Hash)
+    trimmed
   end
 
   def extract_deezer_artist(deezer_track)

--- a/spec/models/radio_station_spec.rb
+++ b/spec/models/radio_station_spec.rb
@@ -122,6 +122,30 @@ describe RadioStation, :use_vcr, :with_valid_token do
     end
   end
 
+  describe '#update_last_added_air_play_ids' do
+    let(:air_play) { create(:air_play, radio_station:) }
+
+    it 'appends the air play id to the list' do
+      radio_station.update_last_added_air_play_ids(air_play.id)
+      expect(radio_station.reload.last_added_air_play_ids).to eq([air_play.id])
+    end
+
+    it 'caps the list at 12 entries' do
+      radio_station.update!(last_added_air_play_ids: (1..12).to_a)
+      radio_station.update_last_added_air_play_ids(air_play.id)
+      expect(radio_station.reload.last_added_air_play_ids).to eq((2..12).to_a + [air_play.id])
+    end
+
+    it 'does not run the name uniqueness query when name is unchanged' do
+      ids = [radio_station.id, air_play.id]
+      queries = []
+      ActiveSupport::Notifications.subscribed(->(*a) { queries << a.last[:sql] }, 'sql.active_record') do
+        described_class.find(ids[0]).update_last_added_air_play_ids(ids[1])
+      end
+      expect(queries.compact).to all(satisfy { |sql| !sql.match?(/SELECT 1.*FROM "radio_stations".*"name"/m) })
+    end
+  end
+
   describe '.last_played_songs' do
     let(:song) { create(:song, duration_ms: 210_000) }
 

--- a/spec/services/song_import_logger_spec.rb
+++ b/spec/services/song_import_logger_spec.rb
@@ -174,6 +174,31 @@ describe SongImportLogger do
         expect(logger.log.spotify_artist).to eq('Artist One, Artist Two')
       end
     end
+
+    context 'when track response includes available_markets noise' do
+      let(:spotify_track) do
+        instance_double(
+          Spotify::TrackFinder::Result,
+          artists: [{ 'name' => 'Spotify Artist' }],
+          title: 'Spotify Song',
+          id: 'spotify123',
+          isrc: 'USSPOTIFY1234',
+          track: {
+            'id' => 'spotify123',
+            'name' => 'Spotify Song',
+            'available_markets' => %w[US NL DE FR],
+            'album' => { 'id' => 'album1', 'available_markets' => %w[US NL] }
+          }
+        )
+      end
+
+      it 'strips available_markets from track and album', :aggregate_failures do
+        logger.log_spotify(spotify_track)
+        expect(logger.log.spotify_raw_response).not_to have_key('available_markets')
+        expect(logger.log.spotify_raw_response['album']).not_to have_key('available_markets')
+        expect(logger.log.spotify_raw_response['album']['id']).to eq('album1')
+      end
+    end
   end
 
   describe '#log_deezer' do


### PR DESCRIPTION
## Summary
Two small, safe wins surfaced from a per-import query trace:

1. **Trim `spotify_raw_response`** — Spotify's track payload includes a ~1KB `available_markets` array (and another on the album). Nothing in the app reads it, so it's dropped before storing on `SongImportLog`. Cuts log row size and helps `SongImportLogCleanupJob`.
2. **Conditional uniqueness on `RadioStation#name`** — `validates :name, uniqueness: true, if: :will_save_change_to_name?`. Removes one `SELECT 1 FROM radio_stations` per successful import (and any other update path that doesn't touch name). Constraint still fires when name actually changes.

Both changes preserve existing behavior — imports work as before, just with less DB chatter.

## Test plan
- [x] `bundle exec rspec spec/services/song_import_logger_spec.rb spec/models/radio_station_spec.rb` (101 examples, 0 failures)
- [x] `bundle exec rspec spec/services/song_importer*` + concerns (128 examples, 0 failures)
- [x] `bundle exec rubocop` on changed files (no offenses)
- [x] New test asserts no `SELECT 1 FROM radio_stations WHERE name` query during `update_last_added_air_play_ids`