### PR TITLE
Order airplays by broadcasted_at in last_played scope

### DIFF
--- a/app/models/air_play.rb
+++ b/app/models/air_play.rb
@@ -59,7 +59,7 @@ class AirPlay < ApplicationRecord
       .played_on(params[:radio_station_ids])
       .matching(params[:search_term])
       .group(:id, 'songs.id', 'radio_stations.id')
-      .order(created_at: :desc)
+      .order(broadcasted_at: :desc)
   end
 
   def deduplicate


### PR DESCRIPTION
## Summary
- `AirPlay.last_played` now orders by `broadcasted_at: :desc` instead of `created_at: :desc`, so the `/api/v1/air_plays` endpoint reflects actual broadcast order rather than insertion order (which drifts when scrapers backfill or imports are delayed).

## Test plan
- [x] `bundle exec rspec spec/models/air_play_spec.rb` (25 examples, 0 failures)
- [ ] Spot-check `/api/v1/air_plays` response ordering in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)