### PR TITLE
Add aka_names to artists from MusicBrainz aliases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,9 @@ bundle exec rake optimization:vacuum                           # PostgreSQL VACU
 # Hit Potential
 bundle exec rake hit_potential:backfill                        # Backfill hit_potential_score for songs with music profiles
 
+# Enrichment
+bundle exec rake enrichment:backfill_artist_aka_names          # Fetch alternative artist names from MusicBrainz
+
 # Slugs
 bundle exec rake slug:backfill_songs                           # Backfill slugs for songs without one
 bundle exec rake slug:backfill_artists                         # Backfill slugs for artists without one
@@ -79,7 +82,7 @@ The app uses service objects extensively in `app/services/`:
 - `Lastfm/` and `Wikipedia/` - Artist bio/info enrichment (Last.fm listeners/playcount/tags, Wikipedia nationality via Wikidata)
 - `Deezer/` and `Itunes/` - Additional enrichment sources (duration_ms, release_date backfill)
 - `ClientTokenGenerator` - Generates short-lived JWT tokens (10-minute expiry) for frontend client authentication
-- `MusicBrainz/` - ISRCs enrichment for songs
+- `MusicBrainz/` - ISRCs enrichment for songs and `ArtistAliasFetcher` for populating `Artist#aka_names` (legal names, stylization variants like P!nk/Pink, former names via `artist rename` relations)
 - `AudioStream/` - M3U8, MP3, and PersistentSegment stream handling
 - `PersistentStream/` - Long-lived ffmpeg processes for ad-free stream capture (see below)
 - `CombinedArtistSplitter` - Splits combined artist names (e.g., "Artist feat. Artist2") into individual Artist records
@@ -215,7 +218,7 @@ The score is calculated automatically by `MusicProfileJob` after creating a musi
 ### Key Models
 
 - `Song` - Core entity with Spotify/YouTube IDs, enrichment fields (`album_name`, `popularity`, `explicit`, `duration_ms`, `release_date`, `isrcs` array, `lastfm_listeners`, `lastfm_playcount`, `lastfm_tags`, `hit_potential_score`), `slug` for SEO-friendly URLs
-- `Artist` - Core entity with enrichment fields (`genres` array, `country_of_origin` array, `spotify_popularity`, `spotify_followers_count`, `lastfm_listeners`, `lastfm_playcount`, `lastfm_tags`), `slug` for SEO-friendly URLs
+- `Artist` - Core entity with enrichment fields (`genres` array, `country_of_origin` array, `spotify_popularity`, `spotify_followers_count`, `lastfm_listeners`, `lastfm_playcount`, `lastfm_tags`, `aka_names` array, `id_on_musicbrainz`), `slug` for SEO-friendly URLs
 - `AirPlay` - Song play events (unique per station/song/time, `broadcasted_at` presence validated)
 - `RadioStation` - Station metadata with last 12 airplay IDs (JSONB), `is_currently_playing` flag on last_played_songs endpoint, `slug` for SEO-friendly URLs
 - `ChartPosition` - Polymorphic rankings (can be Song or Artist), with popularity boost tiebreaker

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -5,9 +5,12 @@
 # Table name: artists
 #
 #  id                           :bigint           not null, primary key
+#  aka_names                    :string           default([]), is an Array
+#  aka_names_checked_at         :datetime
 #  country_of_origin            :string           default([]), is an Array
 #  country_of_origin_checked_at :datetime
 #  genres                       :string           default([]), is an Array
+#  id_on_musicbrainz            :string
 #  id_on_spotify                :string
 #  image                        :string
 #  instagram_url                :string
@@ -27,8 +30,10 @@
 #
 # Indexes
 #
-#  index_artists_on_name_trgm  (name) USING gin
-#  index_artists_on_slug       (slug) UNIQUE
+#  index_artists_on_aka_names          (aka_names) USING gin
+#  index_artists_on_id_on_musicbrainz  (id_on_musicbrainz) UNIQUE
+#  index_artists_on_name_trgm          (name) USING gin
+#  index_artists_on_slug               (slug) UNIQUE
 #
 
 class Artist < ApplicationRecord

--- a/app/serializers/artist_serializer.rb
+++ b/app/serializers/artist_serializer.rb
@@ -5,9 +5,12 @@
 # Table name: artists
 #
 #  id                           :bigint           not null, primary key
+#  aka_names                    :string           default([]), is an Array
+#  aka_names_checked_at         :datetime
 #  country_of_origin            :string           default([]), is an Array
 #  country_of_origin_checked_at :datetime
 #  genres                       :string           default([]), is an Array
+#  id_on_musicbrainz            :string
 #  id_on_spotify                :string
 #  image                        :string
 #  instagram_url                :string
@@ -27,8 +30,10 @@
 #
 # Indexes
 #
-#  index_artists_on_name_trgm  (name) USING gin
-#  index_artists_on_slug       (slug) UNIQUE
+#  index_artists_on_aka_names          (aka_names) USING gin
+#  index_artists_on_id_on_musicbrainz  (id_on_musicbrainz) UNIQUE
+#  index_artists_on_name_trgm          (name) USING gin
+#  index_artists_on_slug               (slug) UNIQUE
 #
 class ArtistSerializer
   include FastJsonapi::ObjectSerializer

--- a/app/services/music_brainz/artist_alias_fetcher.rb
+++ b/app/services/music_brainz/artist_alias_fetcher.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+module MusicBrainz
+  class ArtistAliasFetcher
+    SEARCH_ENDPOINT = 'https://musicbrainz.org/ws/2/artist'
+    LOOKUP_ENDPOINT = 'https://musicbrainz.org/ws/2/artist'
+    USER_AGENT = 'Airplays/1.0.0 (https://airplays.nl)'
+    RATE_LIMIT_DELAY = 1.0
+    SEARCH_SCORE_THRESHOLD = 90
+    NAME_SIMILARITY_THRESHOLD = 90
+    USEFUL_ALIAS_TYPES = ['Artist name', 'Legal name', 'Search hint'].freeze
+    KEPT_LOCALES = [nil, 'en'].freeze
+
+    def initialize(artist)
+      @artist = artist
+    end
+
+    def call
+      mbid = @artist.id_on_musicbrainz.presence || lookup_mbid
+      return false if mbid.blank?
+
+      data = fetch_artist(mbid)
+      return false if data.blank?
+
+      names = collected_names(data)
+      names.concat(rename_target_names(data))
+
+      @artist.update!(
+        id_on_musicbrainz: mbid,
+        aka_names: names.uniq.compact_blank,
+        aka_names_checked_at: Time.current
+      )
+      true
+    end
+
+    private
+
+    def lookup_mbid
+      data = search_by_name
+      return nil if data.blank?
+
+      candidate = data['artists']&.first
+      return nil if candidate.blank?
+      return nil if candidate['score'].to_i < SEARCH_SCORE_THRESHOLD
+      return nil unless name_matches?(candidate['name'])
+
+      candidate['id']
+    end
+
+    def search_by_name
+      sleep(RATE_LIMIT_DELAY)
+      uri = URI(SEARCH_ENDPOINT)
+      uri.query = URI.encode_www_form(query: "artist:\"#{@artist.name}\"", fmt: 'json', limit: 1)
+
+      response = make_request(uri)
+      return nil unless response.is_a?(Net::HTTPSuccess)
+
+      JSON.parse(response.body)
+    rescue JSON::ParserError => e
+      Rails.logger.error "MusicBrainz::ArtistAliasFetcher: Invalid JSON in search: #{e.message}"
+      nil
+    rescue StandardError => e
+      Rails.logger.error "MusicBrainz::ArtistAliasFetcher: Search error: #{e.message}"
+      nil
+    end
+
+    def name_matches?(candidate_name)
+      score = (JaroWinkler.similarity(candidate_name.to_s.downcase, @artist.name.to_s.downcase) * 100).to_i
+      score >= NAME_SIMILARITY_THRESHOLD
+    end
+
+    def fetch_artist(mbid)
+      sleep(RATE_LIMIT_DELAY)
+      uri = URI("#{LOOKUP_ENDPOINT}/#{mbid}")
+      uri.query = URI.encode_www_form(inc: 'aliases artist-rels', fmt: 'json')
+
+      response = make_request(uri)
+      return nil unless response.is_a?(Net::HTTPSuccess)
+
+      JSON.parse(response.body)
+    rescue JSON::ParserError => e
+      Rails.logger.error "MusicBrainz::ArtistAliasFetcher: Invalid JSON in lookup: #{e.message}"
+      nil
+    rescue StandardError => e
+      Rails.logger.error "MusicBrainz::ArtistAliasFetcher: Lookup error: #{e.message}"
+      nil
+    end
+
+    def collected_names(data)
+      names = data['aliases'].to_a.filter_map { |alias_entry| keep_alias?(alias_entry) ? alias_entry['name'] : nil }
+      names << data['name'] if data['name'].present?
+      names
+    end
+
+    def keep_alias?(alias_entry)
+      return false if alias_entry['type'].blank?
+      return false unless USEFUL_ALIAS_TYPES.include?(alias_entry['type'])
+
+      KEPT_LOCALES.include?(alias_entry['locale'])
+    end
+
+    def rename_target_names(data)
+      data['relations'].to_a.filter_map do |relation|
+        next unless relation['type'] == 'artist rename'
+
+        related_id = relation.dig('artist', 'id')
+        next if related_id.blank?
+
+        related_data = fetch_artist(related_id)
+        next if related_data.blank?
+
+        collected_names(related_data)
+      end.flatten
+    end
+
+    def make_request(uri)
+      https = Net::HTTP.new(uri.host, uri.port)
+      https.use_ssl = true
+      https.open_timeout = 10
+      https.read_timeout = 10
+
+      request = Net::HTTP::Get.new(uri)
+      request['User-Agent'] = USER_AGENT
+      request['Accept'] = 'application/json'
+
+      https.request(request)
+    end
+  end
+end

--- a/db/migrate/20260501093422_add_aka_names_to_artists.rb
+++ b/db/migrate/20260501093422_add_aka_names_to_artists.rb
@@ -1,0 +1,12 @@
+class AddAkaNamesToArtists < ActiveRecord::Migration[8.1]
+  def change
+    change_table :artists, bulk: true do |t|
+      t.string :aka_names, array: true, default: []
+      t.string :id_on_musicbrainz
+      t.datetime :aka_names_checked_at
+    end
+
+    add_index :artists, :aka_names, using: :gin
+    add_index :artists, :id_on_musicbrainz, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_27_183525) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_01_093422) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -85,10 +85,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_27_183525) do
   end
 
   create_table "artists", force: :cascade do |t|
+    t.string "aka_names", default: [], array: true
+    t.datetime "aka_names_checked_at"
     t.string "country_of_origin", default: [], array: true
     t.datetime "country_of_origin_checked_at"
     t.datetime "created_at", precision: nil, null: false
     t.string "genres", default: [], array: true
+    t.string "id_on_musicbrainz"
     t.string "id_on_spotify"
     t.string "image"
     t.string "instagram_url"
@@ -104,6 +107,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_27_183525) do
     t.integer "spotify_popularity"
     t.datetime "updated_at", precision: nil, null: false
     t.string "website_url"
+    t.index ["aka_names"], name: "index_artists_on_aka_names", using: :gin
+    t.index ["id_on_musicbrainz"], name: "index_artists_on_id_on_musicbrainz", unique: true
     t.index ["name"], name: "index_artists_on_name_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["slug"], name: "index_artists_on_slug", unique: true
   end

--- a/lib/tasks/enrichment.rake
+++ b/lib/tasks/enrichment.rake
@@ -34,6 +34,24 @@ namespace :enrichment do
     puts 'Done.'
   end
 
+  desc 'Backfill aka_names from MusicBrainz (synchronous, respects 1 req/sec rate limit)'
+  task backfill_artist_aka_names: :environment do
+    scope = Artist.where(aka_names_checked_at: nil).where.not(name: [nil, ''])
+    total = scope.count
+    puts "Backfilling aka_names for #{total} artists..."
+
+    processed = 0
+    failed = 0
+    scope.find_each do |artist|
+      success = MusicBrainz::ArtistAliasFetcher.new(artist).()
+      success ? (processed += 1) : (failed += 1)
+      done = processed + failed
+      print "\rProcessed #{done}/#{total} (failed: #{failed})..." if (done % 10).zero?
+    end
+
+    puts "\nDone! Backfilled #{processed} artists, #{failed} did not match a MusicBrainz record."
+  end
+
   desc 'Backfill Last.fm data for artists and songs'
   task backfill_lastfm: :environment do
     puts 'Enqueueing artists and songs for Last.fm backfill...'

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -3,9 +3,12 @@
 # Table name: artists
 #
 #  id                           :bigint           not null, primary key
+#  aka_names                    :string           default([]), is an Array
+#  aka_names_checked_at         :datetime
 #  country_of_origin            :string           default([]), is an Array
 #  country_of_origin_checked_at :datetime
 #  genres                       :string           default([]), is an Array
+#  id_on_musicbrainz            :string
 #  id_on_spotify                :string
 #  image                        :string
 #  instagram_url                :string
@@ -25,8 +28,10 @@
 #
 # Indexes
 #
-#  index_artists_on_name_trgm  (name) USING gin
-#  index_artists_on_slug       (slug) UNIQUE
+#  index_artists_on_aka_names          (aka_names) USING gin
+#  index_artists_on_id_on_musicbrainz  (id_on_musicbrainz) UNIQUE
+#  index_artists_on_name_trgm          (name) USING gin
+#  index_artists_on_slug               (slug) UNIQUE
 #
 
 describe Artist do

--- a/spec/services/music_brainz/artist_alias_fetcher_spec.rb
+++ b/spec/services/music_brainz/artist_alias_fetcher_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MusicBrainz::ArtistAliasFetcher, type: :service do
+  let(:artist) { create(:artist, name: 'P!nk') }
+  let(:mbid) { 'f4d5cc07-3bc9-4836-9b15-88a08359bc63' }
+  let(:fetcher) { described_class.new(artist) }
+
+  before { allow(fetcher).to receive(:sleep) }
+
+  describe '#call' do
+    context 'when artist already has id_on_musicbrainz' do
+      before do
+        artist.update!(id_on_musicbrainz: mbid)
+        stub_request(:get, %r{musicbrainz.org/ws/2/artist/#{mbid}})
+          .to_return(status: 200, body: lookup_response.to_json, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      let(:lookup_response) do
+        {
+          'id' => mbid,
+          'name' => 'P!nk',
+          'aliases' => [
+            { 'name' => 'Pink', 'type' => 'Artist name', 'locale' => nil },
+            { 'name' => 'Alecia Beth Moore', 'type' => 'Legal name', 'locale' => nil },
+            { 'name' => 'P.nk', 'type' => 'Search hint', 'locale' => nil },
+            { 'name' => 'ピンク', 'type' => 'Artist name', 'locale' => 'ja' }
+          ],
+          'relations' => []
+        }
+      end
+
+      it 'persists filtered aliases and the canonical name', :aggregate_failures do
+        fetcher.()
+        artist.reload
+        expect(artist.aka_names).to contain_exactly('P!nk', 'Pink', 'Alecia Beth Moore', 'P.nk')
+        expect(artist.aka_names_checked_at).to be_within(5.seconds).of(Time.current)
+      end
+
+      it 'skips aliases with foreign locales' do
+        fetcher.()
+        expect(artist.reload.aka_names).not_to include('ピンク')
+      end
+
+      it 'skips untyped alias entries' do
+        lookup_response['aliases'] << { 'name' => 'Pinkk typo', 'type' => nil, 'locale' => nil }
+        fetcher.()
+        expect(artist.reload.aka_names).not_to include('Pinkk typo')
+      end
+    end
+
+    context 'when artist needs MBID lookup and the top match passes validation' do
+      before do
+        stub_request(:get, %r{musicbrainz.org/ws/2/artist\?}).to_return(
+          status: 200, body: search_response.to_json, headers: { 'Content-Type' => 'application/json' }
+        )
+        stub_request(:get, %r{musicbrainz.org/ws/2/artist/#{mbid}}).to_return(
+          status: 200, body: { 'id' => mbid, 'name' => 'P!nk', 'aliases' => [], 'relations' => [] }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+
+      let(:search_response) do
+        { 'artists' => [{ 'id' => mbid, 'name' => 'P!nk', 'score' => 100 }] }
+      end
+
+      it 'persists the discovered MBID' do
+        fetcher.()
+        expect(artist.reload.id_on_musicbrainz).to eq(mbid)
+      end
+    end
+
+    context 'when search score is below threshold' do
+      before do
+        stub_request(:get, %r{musicbrainz.org/ws/2/artist\?}).to_return(
+          status: 200,
+          body: { 'artists' => [{ 'id' => mbid, 'name' => 'P!nk', 'score' => 80 }] }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+
+      it 'leaves the artist unchanged', :aggregate_failures do
+        expect(fetcher.()).to be(false)
+        expect(artist.reload.id_on_musicbrainz).to be_nil
+        expect(artist.aka_names).to be_empty
+      end
+    end
+
+    context 'when search returns a name that is not similar enough' do
+      before do
+        stub_request(:get, %r{musicbrainz.org/ws/2/artist\?}).to_return(
+          status: 200,
+          body: { 'artists' => [{ 'id' => mbid, 'name' => 'Pink Martini', 'score' => 100 }] }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+
+      it 'rejects the candidate' do
+        expect(fetcher.()).to be(false)
+      end
+    end
+
+    context 'when artist has artist-rename relations' do
+      let(:artist) { create(:artist, name: "Terence Trent D'Arby") }
+      let(:related_mbid) { '66e8f2b9-69c3-4ded-8095-b65657940473' }
+      let(:lookup_with_rename) do
+        {
+          'id' => mbid,
+          'name' => "Terence Trent D'Arby",
+          'aliases' => [{ 'name' => "Terence Trent D'Arby", 'type' => 'Artist name', 'locale' => nil }],
+          'relations' => [{ 'type' => 'artist rename', 'artist' => { 'id' => related_mbid, 'name' => 'Sananda Maitreya' } }]
+        }
+      end
+      let(:rename_target_lookup) do
+        {
+          'id' => related_mbid,
+          'name' => 'Sananda Maitreya',
+          'aliases' => [{ 'name' => 'Sananda Francesco Maitreya', 'type' => 'Legal name', 'locale' => nil }],
+          'relations' => []
+        }
+      end
+
+      before do
+        artist.update!(id_on_musicbrainz: mbid)
+        stub_request(:get, %r{musicbrainz.org/ws/2/artist/#{mbid}}).to_return(
+          status: 200, body: lookup_with_rename.to_json, headers: { 'Content-Type' => 'application/json' }
+        )
+        stub_request(:get, %r{musicbrainz.org/ws/2/artist/#{related_mbid}}).to_return(
+          status: 200, body: rename_target_lookup.to_json, headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+
+      it 'merges names from the rename target into aka_names', :aggregate_failures do
+        fetcher.()
+        names = artist.reload.aka_names
+        expect(names).to include("Terence Trent D'Arby", 'Sananda Maitreya', 'Sananda Francesco Maitreya')
+      end
+    end
+
+    context 'when the lookup API returns an error' do
+      before do
+        artist.update!(id_on_musicbrainz: mbid)
+        stub_request(:get, %r{musicbrainz.org/ws/2/artist/#{mbid}}).to_return(status: 503, body: 'Service Unavailable')
+      end
+
+      it 'returns false and leaves aka_names empty', :aggregate_failures do
+        expect(fetcher.()).to be(false)
+        expect(artist.reload.aka_names).to be_empty
+      end
+    end
+
+    context 'when the lookup response is invalid JSON' do
+      before do
+        artist.update!(id_on_musicbrainz: mbid)
+        stub_request(:get, %r{musicbrainz.org/ws/2/artist/#{mbid}}).to_return(
+          status: 200, body: 'not json', headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+
+      it 'returns false' do
+        expect(fetcher.()).to be(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds `Artist#aka_names` (string array, GIN-indexed) and `Artist#id_on_musicbrainz` (unique index) columns
- New `MusicBrainz::ArtistAliasFetcher` service populates aliases via the MusicBrainz `/ws/2/artist` endpoint, including a one-hop walk of `artist rename` relations to capture former names (e.g., Terence Trent D'Arby ↔ Sananda Maitreya)
- Validates search candidates with JaroWinkler ≥ 90 on top of MB's own score threshold to avoid mismatches like "Pink" → "Pink Martini"
- Backfill via `rake enrichment:backfill_artist_aka_names`

A periodic re-fetch job is intentionally deferred to a follow-up to keep this PR focused.

### Why these aliases

Prototype against four real MBIDs showed:
| Artist | Aliases captured (kept types) |
|---|---|
| P!nk | `Pink`, `P.nk`, `Alecia Beth Moore`, `P!nk` |
| Prince | 17 typed aliases incl. `Prince Rogers Nelson`, `Alexander Nevermind`, `Joey Coco`, symbol stylizations |
| Terence Trent D'Arby | `Sananda Maitreya` (Artist name alias) + walks to Sananda's MBID for `Sananda Francesco Maitreya` |
| Sananda Maitreya | walks back to TTD's MBID via `artist rename` relation |

Untyped/foreign-locale aliases (typos like "Terance Trent Darby", Japanese transliterations) are filtered out to keep the array clean.

## Test plan
- [x] `bundle exec rspec spec/services/music_brainz/artist_alias_fetcher_spec.rb` — 9 examples, 0 failures
- [x] `bundle exec rspec spec/jobs/artist_enrichment_job_spec.rb spec/models/artist_spec.rb` — existing tests still pass
- [x] `bundle exec rubocop` on all changed files — clean
- [x] Migration up/down on local + test DB
- [ ] Run `rake enrichment:backfill_artist_aka_names` against production data (manual, post-merge — sleeps 1 sec/request, ~3 sec per artist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)