### PR TITLE
Add Artist#fetch_aka_names and MusicBrainz::ArtistAliasJob

### DIFF
--- a/app/jobs/music_brainz/artist_alias_job.rb
+++ b/app/jobs/music_brainz/artist_alias_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module MusicBrainz
+  class ArtistAliasJob
+    include Sidekiq::Job
+    sidekiq_options queue: 'low'
+
+    def perform(artist_id)
+      artist = Artist.find_by(id: artist_id)
+      return if artist.blank?
+
+      artist.fetch_aka_names
+    end
+  end
+end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -158,6 +158,10 @@ class Artist < ApplicationRecord
     update(website_url: official_website) if official_website.present?
   end
 
+  def fetch_aka_names
+    MusicBrainz::ArtistAliasFetcher.new(self).()
+  end
+
   private
 
   def slug_source

--- a/spec/jobs/music_brainz/artist_alias_job_spec.rb
+++ b/spec/jobs/music_brainz/artist_alias_job_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MusicBrainz::ArtistAliasJob do
+  describe '#perform' do
+    let(:job) { described_class.new }
+
+    context 'when artist exists' do
+      let(:artist) { create(:artist, name: 'P!nk') }
+      let(:fetcher) { instance_double(MusicBrainz::ArtistAliasFetcher, call: true) }
+
+      before { allow(MusicBrainz::ArtistAliasFetcher).to receive(:new).and_return(fetcher) }
+
+      it 'invokes the alias fetcher for the artist', :aggregate_failures do
+        job.perform(artist.id)
+        expect(MusicBrainz::ArtistAliasFetcher).to have_received(:new).with(an_object_having_attributes(id: artist.id))
+        expect(fetcher).to have_received(:call)
+      end
+    end
+
+    context 'when artist does not exist' do
+      before { allow(MusicBrainz::ArtistAliasFetcher).to receive(:new) }
+
+      it 'does not raise and does not invoke the fetcher', :aggregate_failures do
+        expect { job.perform(999_999) }.not_to raise_error
+        expect(MusicBrainz::ArtistAliasFetcher).not_to have_received(:new)
+      end
+    end
+  end
+end

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -540,4 +540,17 @@ describe Artist do
       end
     end
   end
+
+  describe '#fetch_aka_names' do
+    let(:artist) { create(:artist, name: 'P!nk') }
+    let(:fetcher) { instance_double(MusicBrainz::ArtistAliasFetcher, call: true) }
+
+    before { allow(MusicBrainz::ArtistAliasFetcher).to receive(:new).with(artist).and_return(fetcher) }
+
+    it 'delegates to MusicBrainz::ArtistAliasFetcher', :aggregate_failures do
+      artist.fetch_aka_names
+      expect(MusicBrainz::ArtistAliasFetcher).to have_received(:new).with(artist)
+      expect(fetcher).to have_received(:call)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- `Artist#fetch_aka_names` — instance method that delegates to `MusicBrainz::ArtistAliasFetcher` (synchronous)
- `MusicBrainz::ArtistAliasJob` — Sidekiq job in the `low` queue that calls `fetch_aka_names` after looking up the artist by id

Builds on #2089. Lets callers (import flow, future batch enqueuers, ad-hoc reruns) trigger alias enrichment without instantiating the service directly.

Throttling note: each alias fetch makes 2-3 MusicBrainz requests at 1 sec apart, so a future batch enqueuer should use `perform_in(index * THROTTLE_INTERVAL.seconds, ...)` (≥ 5 sec interval) to stay under MB's 1 req/sec limit when the queue runs in parallel.

## Test plan
- [x] `bundle exec rspec spec/jobs/music_brainz/artist_alias_job_spec.rb spec/models/artist_spec.rb` — 59 examples, 0 failures
- [x] `bundle exec rubocop` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)