### PR TITLE
Cap ImportSongJob at 60s wall-clock and bump lock_ttl past it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ On-demand enrichment jobs (triggered by import flow, not scheduled):
 - `MusicProfileJob` - Creates Spotify audio feature profiles for songs, then calculates `hit_potential_score` via `HitPotentialCalculator`
 - `AcoustidPopulationJob` - Downloads YouTube audio, generates fingerprints, submits to AcoustID
 
-**Important:** `ImportSongJob` uses `sidekiq-unique-jobs` with `lock: :until_executed` and `lock_ttl: 60`. The TTL prevents stuck locks after Sidekiq crashes — without it, locks persist indefinitely in Redis and silently block imports.
+**Important:** `ImportSongJob` uses `sidekiq-unique-jobs` with `lock: :until_executed` and `lock_ttl: 90`, plus a 60-second `Timeout.timeout` wrapper around `SongImporter#import`. The wall-clock timeout caps each job at one minute (covering edge-case hangs not handled by inner subprocess/HTTP timeouts), and `lock_ttl` is set higher than the timeout so the unique lock spans the full execution — otherwise the per-minute scheduler would enqueue duplicates while a slow job is still running, and they would pile up across worker threads.
 
 ### Sidekiq Memory Monitor
 

--- a/app/jobs/import_song_job.rb
+++ b/app/jobs/import_song_job.rb
@@ -1,13 +1,24 @@
 # frozen_string_literal: true
 
 class ImportSongJob
+  IMPORT_TIMEOUT_SECONDS = 60
+
   include Sidekiq::Worker
 
-  sidekiq_options lock: :until_executed, lock_ttl: 60
+  # lock_ttl must outlive IMPORT_TIMEOUT_SECONDS so the unique-jobs lock spans
+  # the full execution. If the job ran longer than lock_ttl, the lock would
+  # auto-expire and the per-minute scheduler would enqueue a duplicate while
+  # the original is still running, causing pile-up across all worker threads.
+  sidekiq_options lock: :until_executed, lock_ttl: 90
 
   def perform(id)
     radio_station = RadioStation.find(id)
-    SongImporter.new(radio_station: radio_station).import
+    Timeout.timeout(IMPORT_TIMEOUT_SECONDS) do
+      SongImporter.new(radio_station: radio_station).import
+    end
+  rescue Timeout::Error => e
+    Rails.logger.warn "ImportSongJob timed out after #{IMPORT_TIMEOUT_SECONDS}s for #{radio_station&.name}"
+    ExceptionNotifier.notify(e, 'ImportSongJob timeout')
   rescue StandardError => e
     Rails.logger.error "ImportSongJob error for #{radio_station&.name}: #{e.message}"
     ExceptionNotifier.notify(e, 'ImportSongJob')

--- a/spec/jobs/import_song_job_spec.rb
+++ b/spec/jobs/import_song_job_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ImportSongJob do
+  describe '#perform' do
+    let(:radio_station) { create(:radio_station) }
+    let(:job) { described_class.new }
+    let(:importer) { instance_double(SongImporter, import: true) }
+
+    before do
+      allow(SongImporter).to receive(:new).with(radio_station: radio_station).and_return(importer)
+      allow(ExceptionNotifier).to receive(:notify)
+    end
+
+    context 'when import completes within the timeout' do
+      it 'invokes SongImporter#import and does not notify' do
+        job.perform(radio_station.id)
+
+        expect(importer).to have_received(:import)
+      end
+
+      it 'does not notify ExceptionNotifier on success' do
+        job.perform(radio_station.id)
+
+        expect(ExceptionNotifier).not_to have_received(:notify)
+      end
+    end
+
+    context 'when import exceeds IMPORT_TIMEOUT_SECONDS' do
+      before do
+        allow(Timeout).to receive(:timeout).with(described_class::IMPORT_TIMEOUT_SECONDS).and_raise(Timeout::Error)
+      end
+
+      it 'rescues the Timeout::Error and notifies', :aggregate_failures do
+        expect { job.perform(radio_station.id) }.not_to raise_error
+        expect(ExceptionNotifier).to have_received(:notify).with(instance_of(Timeout::Error), 'ImportSongJob timeout')
+      end
+    end
+
+    context 'when SongImporter raises an error' do
+      before do
+        allow(importer).to receive(:import).and_raise(StandardError, 'boom')
+      end
+
+      it 'rescues the error and notifies', :aggregate_failures do
+        expect { job.perform(radio_station.id) }.not_to raise_error
+        expect(ExceptionNotifier).to have_received(:notify).with(instance_of(StandardError), 'ImportSongJob')
+      end
+    end
+  end
+
+  describe 'sidekiq options' do
+    it 'configures unique-jobs lock with TTL exceeding the wall-clock timeout', :aggregate_failures do
+      options = described_class.get_sidekiq_options
+
+      expect(options['lock']).to eq(:until_executed)
+      expect(options['lock_ttl']).to be > described_class::IMPORT_TIMEOUT_SECONDS
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Wrap `SongImporter#import` in `Timeout.timeout(60)` so each `ImportSongJob` is bounded at one minute regardless of which sub-step hangs
- Raise `sidekiq-unique-jobs` `lock_ttl` from 60 → 90 so the unique lock outlives the wall-clock timeout and duplicates can no longer enqueue while a slow job is still running
- Add `spec/jobs/import_song_job_spec.rb` covering the happy path, timeout, error rescue, and the lock_ttl > timeout invariant

## Why
Sidekiq Busy view showed multiple ImportSongJobs running concurrently for Yoursafe Radio (station 16), with the oldest running 1+ hour. The per-minute `ImportSongsAllRadioStationsJob` was enqueueing duplicates whenever a job legitimately exceeded 60s (Yoursafe ffmpeg+OCR + Spotify/Deezer/iTunes/LLM with all sub-timeouts can sum past one minute), since the unique-jobs lock auto-expired at 60s.

The combination of (1) inner subprocess/HTTP timeouts, (2) outer 60s wall-clock, (3) 90s lock TTL gives both real time-boxing and real uniqueness.

## Test plan
- [x] `bundle exec rspec spec/jobs/import_song_job_spec.rb` (5 examples, 0 failures)
- [x] `bundle exec rspec spec/jobs/import_songs_all_radio_stations_job_spec.rb` (regression, 5 examples, 0 failures)
- [x] `bundle exec rubocop app/jobs/import_song_job.rb spec/jobs/import_song_job_spec.rb`
- [ ] After merge: stop currently-stuck Yoursafe jobs via Sidekiq Web UI before the new image is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)