### PR TITLE
Qualify Rails as ::Rails inside module Sidekiq

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,8 @@
 inherit_from: .rubocop_todo.yml
 
+require:
+  - ./lib/rubocop/cop/airplays/rails_in_sidekiq_namespace
+
 ################################################################################
 # Rubocop default cops setting see: https://docs.rubocop.org/rubocop/index.html
 #################################################################################
@@ -186,3 +189,12 @@ RSpec/MultipleMemoizedHelpers:
 ################################################################################
 Performance:
   Enabled: true
+
+################################################################################
+# Custom cops (lib/rubocop/cop/airplays/)
+################################################################################
+Airplays/RailsInSidekiqNamespace:
+  Enabled: true
+  Include:
+    - 'app/**/*.rb'
+    - 'lib/**/*.rb'

--- a/config/application.rb
+++ b/config/application.rb
@@ -32,7 +32,7 @@ module Airplays
     config.middleware.use ActionDispatch::Cookies
     config.middleware.use ActionDispatch::Session::CookieStore, key: "_airplays_session"
 
-    config.autoload_lib(ignore: %w[assets tasks])
+    config.autoload_lib(ignore: %w[assets tasks rubocop])
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/lib/rubocop/cop/airplays/rails_in_sidekiq_namespace.rb
+++ b/lib/rubocop/cop/airplays/rails_in_sidekiq_namespace.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Airplays
+      # Sidekiq defines `Sidekiq::Rails` (its Rails engine class). Inside a
+      # reopened `module Sidekiq`, Ruby's constant lookup walks `Module.nesting`
+      # before falling through to the top level, so an unqualified `Rails`
+      # resolves to `Sidekiq::Rails` and `Rails.logger` raises NoMethodError at
+      # runtime. Force the explicit `::Rails` to skip the Sidekiq scope.
+      class RailsInSidekiqNamespace < Base
+        MSG = 'Use `::Rails` inside `module Sidekiq`; bare `Rails` resolves to `Sidekiq::Rails` (no `.logger`).'
+
+        extend AutoCorrector
+
+        def on_const(node)
+          return unless node.short_name == :Rails
+          return if node.namespace&.cbase_type?
+          return if node.namespace
+          return unless inside_top_level_sidekiq_module?(node)
+
+          add_offense(node) do |corrector|
+            corrector.replace(node, '::Rails')
+          end
+        end
+
+        private
+
+        def inside_top_level_sidekiq_module?(node)
+          module_ancestors = node.each_ancestor(:module).to_a
+          return false if module_ancestors.empty?
+
+          outermost = module_ancestors.last
+          identifier = outermost.identifier
+          identifier.short_name == :Sidekiq && identifier.namespace.nil?
+        end
+      end
+    end
+  end
+end

--- a/lib/sidekiq/memory_monitor_middleware.rb
+++ b/lib/sidekiq/memory_monitor_middleware.rb
@@ -73,7 +73,7 @@ module Sidekiq
     end
 
     def log_job_growth(job_class, rss_before, rss_after, growth, gc_freed)
-      Rails.logger.warn(
+      ::Rails.logger.warn(
         "[MemoryMonitor] Job #{job_class} grew #{format('%.1f', growth)}MB " \
         "(#{format('%.1f', rss_before)} -> #{format('%.1f', rss_after)}MB RSS, " \
         "GC freed: #{gc_freed} objects)"
@@ -102,7 +102,7 @@ module Sidekiq
                  "(#{stats[:runs]} runs, avg #{format('%.2f', avg)}MB, max #{format('%.1f', stats[:max_growth])}MB)"
       end
 
-      Rails.logger.warn(lines.join("\n"))
+      ::Rails.logger.warn(lines.join("\n"))
     end
 
     def gc_summary


### PR DESCRIPTION
## Summary
- Fix `NoMethodError: undefined method 'logger' for class Sidekiq::Rails` raised from `Sidekiq::MemoryMonitorMiddleware`. Inside the reopened `module Sidekiq`, Ruby's constant lookup walks `Module.nesting` first and resolves bare `Rails` to `Sidekiq::Rails` (Sidekiq 8's engine class) — which has no `.logger`. Both call sites in the middleware now use `::Rails.logger`.
- Add `Airplays/RailsInSidekiqNamespace` custom cop (with autocorrect) so the pattern can't be reintroduced. Scoped to `app/**` and `lib/**`. The cop only flags `module Sidekiq` at the top level, so a hypothetical nested `Other::Sidekiq` is left alone.

## Why this surfaced now
Every job runs through the memory monitor. The buggy `Rails.logger.warn` call only fires when a job's RSS grows ≥ `MEMORY_GROWTH_THRESHOLD_MB` (5 MB by default) or every `MEMORY_STATS_INTERVAL` jobs (100). `ImportSongJob` was the most frequent victim — that's why the Sidekiq retries page was full of it — but the bug applied to every job class equally.

## Test plan
- [x] `bundle exec rubocop lib/sidekiq/memory_monitor_middleware.rb lib/rubocop/cop/airplays/rails_in_sidekiq_namespace.rb` — clean
- [x] `bundle exec rubocop --only Airplays/RailsInSidekiqNamespace` across the whole repo — 392 files inspected, no offenses (confirms no other module-Sidekiq files have the same latent bug)
- [x] Reproduced original error in an isolated REPL: `module Sidekiq; class X; def f; Rails.logger; end; end; end` raises `NoMethodError: undefined method 'logger' for class Sidekiq::Rails`; switching to `::Rails.logger` resolves correctly
- [x] Cop catches the regression on a fixture file and autocorrects `Rails` → `::Rails`; leaves explicit `::Rails` alone; leaves nested `module Other; module Sidekiq` alone
- [ ] After merge: watch Sidekiq retries queue for `NoMethodError`s — should stop appearing