### PR TITLE
Prefer original-artist Tidal album over compilations

### DIFF
--- a/app/services/tidal/track_finder/result.rb
+++ b/app/services/tidal/track_finder/result.rb
@@ -53,14 +53,35 @@ module Tidal
       end
 
       def search_by_isrc
-        url = "/v2/tracks?countryCode=#{@country}&filter%5Bisrc%5D=#{ERB::Util.url_encode(@isrc_code)}&include=artists,albums"
+        url = "/v2/tracks?countryCode=#{@country}&filter%5Bisrc%5D=#{ERB::Util.url_encode(@isrc_code)}" \
+              '&include=artists,albums,albums.artists'
         response = make_request(url)
 
         return nil if response.blank? || response['data'].blank?
 
         included = Array(response['included'])
-        track = Array(response['data']).first
-        add_match_score(track, included)
+        candidates = response['data'].filter_map { |t| add_match_score(t, included) }
+        return nil if candidates.blank?
+
+        prefer_original_album(candidates)
+      end
+
+      # Tidal returns one track resource per album the recording appears on (singles,
+      # compilations, deluxe editions). Prefer entries where the album credits the
+      # same artist as the track itself — that rules out "Various Artists" comps.
+      # Tiebreak by Tidal's track popularity so we land on the most-played version.
+      def prefer_original_album(candidates)
+        primary = candidates.select { |t| album_artist_matches_track_artist?(t) }
+        pool = primary.presence || candidates
+        pool.max_by { |t| t.dig('attributes', 'popularity').to_f }
+      end
+
+      def album_artist_matches_track_artist?(track)
+        track_artist_ids = Array(track.dig('relationships', 'artists', 'data')).pluck('id')
+        album_artist_ids = Array(track['album_artist_ids'])
+        return false if track_artist_ids.blank? || album_artist_ids.blank?
+
+        track_artist_ids.intersect?(album_artist_ids)
       end
 
       def search_by_query
@@ -87,10 +108,17 @@ module Tidal
 
         track['artist_resources'] = artist_resources_for(track, included)
         track['album_resource'] = album_resource_for(track, included)
+        track['album_artist_ids'] = album_artist_ids_for(track['album_resource'])
 
         track['artist_distance'] = artist_distance(combined_artist_name(track))
         track['title_distance'] = title_distance(track.dig('attributes', 'title'))
         track
+      end
+
+      def album_artist_ids_for(album_resource)
+        return [] if album_resource.blank?
+
+        Array(album_resource.dig('relationships', 'artists', 'data')).pluck('id')
       end
 
       def artist_resources_for(track, included)

--- a/app/services/tidal/track_finder/result.rb
+++ b/app/services/tidal/track_finder/result.rb
@@ -59,29 +59,30 @@ module Tidal
 
         return nil if response.blank? || response['data'].blank?
 
-        included = Array(response['included'])
-        candidates = response['data'].filter_map { |t| add_match_score(t, included) }
-        return nil if candidates.blank?
+        index = build_included_index(response['included'])
+        winner = pick_isrc_winner(response['data'], index)
+        return nil if winner.blank?
 
-        prefer_original_album(candidates)
+        attach_resources(winner, index)
       end
 
       # Tidal returns one track resource per album the recording appears on (singles,
       # compilations, deluxe editions). Prefer entries where the album credits the
       # same artist as the track itself — that rules out "Various Artists" comps.
       # Tiebreak by Tidal's track popularity so we land on the most-played version.
-      def prefer_original_album(candidates)
-        primary = candidates.select { |t| album_artist_matches_track_artist?(t) }
-        pool = primary.presence || candidates
-        pool.max_by { |t| t.dig('attributes', 'popularity').to_f }
+      # Cheap album-artist filter runs first so we only pay for resource lookup +
+      # JaroWinkler on the final winner, not on all 20 candidates.
+      def pick_isrc_winner(tracks, index)
+        primary = tracks.select { |t| album_artist_matches_track_artist?(t, index) }
+        (primary.presence || tracks).max_by { |t| t.dig('attributes', 'popularity').to_f }
       end
 
-      def album_artist_matches_track_artist?(track)
-        track_artist_ids = Array(track.dig('relationships', 'artists', 'data')).pluck('id')
-        album_artist_ids = Array(track['album_artist_ids'])
-        return false if track_artist_ids.blank? || album_artist_ids.blank?
+      def album_artist_matches_track_artist?(track, index)
+        track_artist_ids = track_artist_ids_for(track)
+        return false if track_artist_ids.blank?
 
-        track_artist_ids.intersect?(album_artist_ids)
+        album_artist_ids = album_artist_ids_via_index(track, index)
+        album_artist_ids.present? && track_artist_ids.intersect?(album_artist_ids)
       end
 
       def search_by_query
@@ -95,7 +96,8 @@ module Tidal
         track_resources = included.select { |r| r['type'] == 'tracks' }
         return nil if track_resources.blank?
 
-        scored = track_resources.filter_map { |t| add_match_score(t, included) }
+        index = build_included_index(included)
+        scored = track_resources.filter_map { |t| attach_resources(t, index) }
         valid = scored.select do |t|
           t['artist_distance'].to_i >= ARTIST_SIMILARITY_THRESHOLD &&
             t['title_distance'].to_i >= TITLE_SIMILARITY_THRESHOLD
@@ -103,36 +105,45 @@ module Tidal
         valid.max_by { |t| [t['artist_distance'], t['title_distance']].min }
       end
 
-      def add_match_score(track, included)
+      # Attach related artist/album resources and compute JaroWinkler distances.
+      # Mutates `track` once — only ever called on the winning candidate, so we
+      # don't pay JW twice for tracks we'll throw away.
+      def attach_resources(track, index)
         return nil if track.blank?
 
-        track['artist_resources'] = artist_resources_for(track, included)
-        track['album_resource'] = album_resource_for(track, included)
-        track['album_artist_ids'] = album_artist_ids_for(track['album_resource'])
-
+        track['artist_resources'] = artist_resources_via_index(track, index)
+        track['album_resource'] = album_resource_via_index(track, index)
         track['artist_distance'] = artist_distance(combined_artist_name(track))
         track['title_distance'] = title_distance(track.dig('attributes', 'title'))
         track
       end
 
-      def album_artist_ids_for(album_resource)
-        return [] if album_resource.blank?
+      # Build a `{ [type, id] => resource }` lookup so member-resolution stays O(1)
+      # instead of scanning `included` (~20 entries) per candidate (~20 candidates).
+      def build_included_index(included)
+        return {} if included.blank?
 
-        Array(album_resource.dig('relationships', 'artists', 'data')).pluck('id')
+        Array(included).index_by { |r| [r['type'], r['id']] }
       end
 
-      def artist_resources_for(track, included)
-        ids = Array(track.dig('relationships', 'artists', 'data')).pluck('id')
-        return [] if ids.blank?
-
-        included.select { |r| r['type'] == 'artists' && ids.include?(r['id']) }
+      def track_artist_ids_for(track)
+        Array(track.dig('relationships', 'artists', 'data')).pluck('id')
       end
 
-      def album_resource_for(track, included)
+      def album_artist_ids_via_index(track, index)
+        album = album_resource_via_index(track, index)
+        Array(album&.dig('relationships', 'artists', 'data')).pluck('id')
+      end
+
+      def artist_resources_via_index(track, index)
+        track_artist_ids_for(track).filter_map { |id| index[['artists', id]] }
+      end
+
+      def album_resource_via_index(track, index)
         album_id = track.dig('relationships', 'albums', 'data')&.first&.dig('id')
         return nil if album_id.blank?
 
-        included.find { |r| r['type'] == 'albums' && r['id'] == album_id }
+        index[['albums', album_id]]
       end
 
       def combined_artist_name(track)

--- a/spec/services/tidal/track_finder/result_spec.rb
+++ b/spec/services/tidal/track_finder/result_spec.rb
@@ -24,7 +24,8 @@ describe Tidal::TrackFinder::Result do
               'title' => 'Shape of You',
               'isrc' => 'GBAHS1600786',
               'duration' => 'PT3M53S',
-              'explicit' => false
+              'explicit' => false,
+              'popularity' => 0.5
             },
             'relationships' => {
               'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] },
@@ -42,6 +43,9 @@ describe Tidal::TrackFinder::Result do
                 { 'href' => 'https://resources.tidal.com/images/small.jpg', 'meta' => { 'width' => 160, 'height' => 160 } },
                 { 'href' => 'https://resources.tidal.com/images/large.jpg', 'meta' => { 'width' => 640, 'height' => 640 } }
               ]
+            },
+            'relationships' => {
+              'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] }
             }
           }
         ]
@@ -117,6 +121,151 @@ describe Tidal::TrackFinder::Result do
 
       it 'returns the Tidal id' do
         expect(result.id).to eq('12345')
+      end
+    end
+
+    context 'when the ISRC returns multiple albums' do
+      let(:isrc) { 'GBAHS1600786' }
+      let(:multi_album_response) do
+        {
+          'data' => [
+            {
+              'id' => 'compilation_track', 'type' => 'tracks',
+              'attributes' => { 'title' => 'Shape of You', 'isrc' => 'GBAHS1600786', 'duration' => 'PT3M53S', 'popularity' => 0.9 },
+              'relationships' => {
+                'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] },
+                'albums' => { 'data' => [{ 'id' => 'compilation_album', 'type' => 'albums' }] }
+              }
+            },
+            {
+              'id' => 'original_track', 'type' => 'tracks',
+              'attributes' => { 'title' => 'Shape of You', 'isrc' => 'GBAHS1600786', 'duration' => 'PT3M53S', 'popularity' => 0.4 },
+              'relationships' => {
+                'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] },
+                'albums' => { 'data' => [{ 'id' => 'original_album', 'type' => 'albums' }] }
+              }
+            }
+          ],
+          'included' => [
+            { 'id' => '100', 'type' => 'artists', 'attributes' => { 'name' => 'Ed Sheeran' } },
+            { 'id' => '999', 'type' => 'artists', 'attributes' => { 'name' => 'Various Artists' } },
+            {
+              'id' => 'compilation_album', 'type' => 'albums', 'attributes' => { 'title' => 'Summer Hits' },
+              'relationships' => { 'artists' => { 'data' => [{ 'id' => '999', 'type' => 'artists' }] } }
+            },
+            {
+              'id' => 'original_album', 'type' => 'albums', 'attributes' => { 'title' => 'Divide' },
+              'relationships' => { 'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] } }
+            }
+          ]
+        }
+      end
+
+      before do
+        stub_request(:get, %r{openapi\.tidal\.com/v2/tracks\?.*filter}).to_return(
+          status: 200,
+          body: multi_album_response.to_json,
+          headers: { 'Content-Type' => 'application/vnd.api+json' }
+        )
+        result.execute
+      end
+
+      it 'picks the track on the original-artist album, even when the compilation is more popular' do
+        expect(result.id).to eq('original_track')
+      end
+    end
+
+    context 'when multiple original-artist albums exist' do
+      let(:isrc) { 'GBAHS1600786' }
+      let(:multi_original_response) do
+        {
+          'data' => [
+            {
+              'id' => 'single_track', 'type' => 'tracks',
+              'attributes' => { 'title' => 'Shape of You', 'isrc' => 'GBAHS1600786', 'duration' => 'PT3M53S', 'popularity' => 0.4 },
+              'relationships' => {
+                'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] },
+                'albums' => { 'data' => [{ 'id' => 'single_album', 'type' => 'albums' }] }
+              }
+            },
+            {
+              'id' => 'greatest_hits_track', 'type' => 'tracks',
+              'attributes' => { 'title' => 'Shape of You', 'isrc' => 'GBAHS1600786', 'duration' => 'PT3M53S', 'popularity' => 0.95 },
+              'relationships' => {
+                'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] },
+                'albums' => { 'data' => [{ 'id' => 'greatest_hits_album', 'type' => 'albums' }] }
+              }
+            }
+          ],
+          'included' => [
+            { 'id' => '100', 'type' => 'artists', 'attributes' => { 'name' => 'Ed Sheeran' } },
+            {
+              'id' => 'single_album', 'type' => 'albums', 'attributes' => { 'title' => 'Shape of You' },
+              'relationships' => { 'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] } }
+            },
+            {
+              'id' => 'greatest_hits_album', 'type' => 'albums', 'attributes' => { 'title' => 'Greatest Hits' },
+              'relationships' => { 'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] } }
+            }
+          ]
+        }
+      end
+
+      before do
+        stub_request(:get, %r{openapi\.tidal\.com/v2/tracks\?.*filter}).to_return(
+          status: 200,
+          body: multi_original_response.to_json,
+          headers: { 'Content-Type' => 'application/vnd.api+json' }
+        )
+        result.execute
+      end
+
+      it 'picks the most popular original-artist track' do
+        expect(result.id).to eq('greatest_hits_track')
+      end
+    end
+
+    context 'when no album lists an artist that matches the track artist' do
+      let(:isrc) { 'GBAHS1600786' }
+      let(:no_overlap_response) do
+        {
+          'data' => [
+            {
+              'id' => 'low_pop', 'type' => 'tracks',
+              'attributes' => { 'title' => 'Shape of You', 'isrc' => 'GBAHS1600786', 'duration' => 'PT3M53S', 'popularity' => 0.2 },
+              'relationships' => {
+                'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] },
+                'albums' => { 'data' => [{ 'id' => 'a1', 'type' => 'albums' }] }
+              }
+            },
+            {
+              'id' => 'high_pop', 'type' => 'tracks',
+              'attributes' => { 'title' => 'Shape of You', 'isrc' => 'GBAHS1600786', 'duration' => 'PT3M53S', 'popularity' => 0.8 },
+              'relationships' => {
+                'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] },
+                'albums' => { 'data' => [{ 'id' => 'a2', 'type' => 'albums' }] }
+              }
+            }
+          ],
+          'included' => [
+            { 'id' => '100', 'type' => 'artists', 'attributes' => { 'name' => 'Ed Sheeran' } },
+            { 'id' => 'a1', 'type' => 'albums', 'attributes' => { 'title' => 'Mix A' } },
+            { 'id' => 'a2', 'type' => 'albums', 'attributes' => { 'title' => 'Mix B' } }
+          ]
+        }
+      end
+
+      before do
+        stub_request(:get, %r{openapi\.tidal\.com/v2/tracks\?.*filter}).to_return(
+          status: 200,
+          body: no_overlap_response.to_json,
+          headers: { 'Content-Type' => 'application/vnd.api+json' }
+        )
+        result.execute
+      end
+
+      it 'falls back to picking the most popular track' do
+        expect(result.id).to eq('high_pop')
       end
     end
 


### PR DESCRIPTION
## Summary
- Tidal's ISRC endpoint returns one track resource per album the recording appears on (single, deluxe edition, \"Various Artists\" compilation, …) — all with identical track-level artist credit. Picking the first entry was effectively random and routinely landed on a compilation.
- Use deep include \`albums.artists\` to compare each album's primary artist against the track's. Keep only candidates whose album credits the same artist as the track; tiebreak by \`attributes.popularity\` so we land on the most-played original-artist version (single → greatest hits → deluxe edition).
- Falls back to plain popularity ranking when no candidate has an artist-id overlap (defensive — shouldn't happen for normal catalog).

## Out of scope
- **Cover art**: Tidal's album resource doesn't carry \`imageLinks\` directly; artwork sits behind a \`coverArt\` relationship. Separate PR.
- **\`search_by_query\`** path: same multi-album shape applies but enrichment hits ISRC first since Spotify already populates \`isrcs\`. Will fix once we see compilations being picked there.

## Test plan
- [x] \`bundle exec rspec spec/services/tidal\` — 30 examples, all green
  - New regression: compilation-vs-original picks original even when compilation is more popular
  - New regression: among multiple original-artist albums (single, greatest hits), most popular wins
  - New regression: when no album-artist overlap exists, falls back to plain popularity
- [x] \`bundle exec rubocop\` clean
- [ ] Verify on prod: \`Tidal::SongEnricher.new(song).send(:find_on_tidal).valid_match?\` for a known song lands on a Bruno Mars album, not a comp. Cache flush still required: \`Rails.cache.delete_matched(\"/v2/tracks*\")\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)