### PR TITLE
Use Tidal /v2/searchresults as primary lookup

### DIFF
--- a/app/services/tidal/track_finder/result.rb
+++ b/app/services/tidal/track_finder/result.rb
@@ -39,55 +39,15 @@ module Tidal
 
       private
 
+      # Tidal's `/v2/searchresults` endpoint surfaces the most-played track per
+      # recording (the version users actually listen to), which gives us higher
+      # popularity scores and better matches than `/v2/tracks?filter[isrc]`.
+      # `filter` here only takes INCLUDE/EXCLUDE values (controls which result
+      # blocks come back), not arbitrary field filters — so when an ISRC is
+      # available we narrow client-side after the search returns.
       def find_best_match
-        if @isrc_code.present?
-          isrc_result = search_by_isrc
-          if isrc_result.present? &&
-             isrc_result['artist_distance'].to_i >= ARTIST_SIMILARITY_THRESHOLD &&
-             isrc_result['title_distance'].to_i >= TITLE_SIMILARITY_THRESHOLD
-            return isrc_result
-          end
-        end
-
-        search_by_query
-      end
-
-      def search_by_isrc
-        url = "/v2/tracks?countryCode=#{@country}&filter%5Bisrc%5D=#{ERB::Util.url_encode(@isrc_code)}" \
-              '&include=artists,albums,albums.artists'
-        response = make_request(url)
-
-        return nil if response.blank? || response['data'].blank?
-
-        index = build_included_index(response['included'])
-        winner = pick_isrc_winner(response['data'], index)
-        return nil if winner.blank?
-
-        attach_resources(winner, index)
-      end
-
-      # Tidal returns one track resource per album the recording appears on (singles,
-      # compilations, deluxe editions). Prefer entries where the album credits the
-      # same artist as the track itself — that rules out "Various Artists" comps.
-      # Tiebreak by Tidal's track popularity so we land on the most-played version.
-      # Cheap album-artist filter runs first so we only pay for resource lookup +
-      # JaroWinkler on the final winner, not on all 20 candidates.
-      def pick_isrc_winner(tracks, index)
-        primary = tracks.select { |t| album_artist_matches_track_artist?(t, index) }
-        (primary.presence || tracks).max_by { |t| t.dig('attributes', 'popularity').to_f }
-      end
-
-      def album_artist_matches_track_artist?(track, index)
-        track_artist_ids = track_artist_ids_for(track)
-        return false if track_artist_ids.blank?
-
-        album_artist_ids = album_artist_ids_via_index(track, index)
-        album_artist_ids.present? && track_artist_ids.intersect?(album_artist_ids)
-      end
-
-      def search_by_query
         query = ERB::Util.url_encode("#{@search_artists} #{@search_title}")
-        url = "/v2/searchresults/#{query}?countryCode=#{@country}&include=tracks,artists,albums"
+        url = "/v2/searchresults/#{query}?countryCode=#{@country}&include=tracks,artists"
         response = make_request(url)
 
         return nil if response.blank?
@@ -97,53 +57,55 @@ module Tidal
         return nil if track_resources.blank?
 
         index = build_included_index(included)
-        scored = track_resources.filter_map { |t| attach_resources(t, index) }
+        pool = isrc_filtered(track_resources)
+        pick_best_search_track(pool, index)
+      end
+
+      # When a song already has an ISRC (Spotify enrichment populated it), narrow
+      # the search results to entries with that exact ISRC. Falls back to the
+      # full pool if the search didn't surface a matching ISRC — better to
+      # validate via artist/title distance than to return nothing.
+      def isrc_filtered(tracks)
+        return tracks if @isrc_code.blank?
+
+        matched = tracks.select { |t| t.dig('attributes', 'isrc') == @isrc_code }
+        matched.presence || tracks
+      end
+
+      # Score every candidate (artist + title), keep ones over the thresholds,
+      # then pick the highest popularity. Popularity is the deciding signal here
+      # because /searchresults already pre-filters to relevant matches.
+      def pick_best_search_track(tracks, index)
+        scored = tracks.filter_map { |t| attach_resources(t, index) }
         valid = scored.select do |t|
           t['artist_distance'].to_i >= ARTIST_SIMILARITY_THRESHOLD &&
             t['title_distance'].to_i >= TITLE_SIMILARITY_THRESHOLD
         end
-        valid.max_by { |t| [t['artist_distance'], t['title_distance']].min }
+        valid.max_by { |t| t.dig('attributes', 'popularity').to_f }
       end
 
-      # Attach related artist/album resources and compute JaroWinkler distances.
-      # Mutates `track` once — only ever called on the winning candidate, so we
-      # don't pay JW twice for tracks we'll throw away.
+      # Attach artist resources and compute JaroWinkler distances. Mutates
+      # `track` so the winner can carry its scores into the setter chain.
       def attach_resources(track, index)
         return nil if track.blank?
 
         track['artist_resources'] = artist_resources_via_index(track, index)
-        track['album_resource'] = album_resource_via_index(track, index)
         track['artist_distance'] = artist_distance(combined_artist_name(track))
         track['title_distance'] = title_distance(track.dig('attributes', 'title'))
         track
       end
 
-      # Build a `{ [type, id] => resource }` lookup so member-resolution stays O(1)
-      # instead of scanning `included` (~20 entries) per candidate (~20 candidates).
+      # Build a `{ [type, id] => resource }` lookup so member-resolution stays
+      # O(1) instead of scanning `included` per candidate.
       def build_included_index(included)
         return {} if included.blank?
 
         Array(included).index_by { |r| [r['type'], r['id']] }
       end
 
-      def track_artist_ids_for(track)
-        Array(track.dig('relationships', 'artists', 'data')).pluck('id')
-      end
-
-      def album_artist_ids_via_index(track, index)
-        album = album_resource_via_index(track, index)
-        Array(album&.dig('relationships', 'artists', 'data')).pluck('id')
-      end
-
       def artist_resources_via_index(track, index)
-        track_artist_ids_for(track).filter_map { |id| index[['artists', id]] }
-      end
-
-      def album_resource_via_index(track, index)
-        album_id = track.dig('relationships', 'albums', 'data')&.first&.dig('id')
-        return nil if album_id.blank?
-
-        index[['albums', album_id]]
+        ids = Array(track.dig('relationships', 'artists', 'data')).pluck('id')
+        ids.filter_map { |id| index[['artists', id]] }
       end
 
       def combined_artist_name(track)
@@ -175,10 +137,11 @@ module Tidal
         "https://tidal.com/browse/track/#{@id}"
       end
 
+      # Tidal exposes album cover art behind a separate `coverArt` relationship
+      # rather than inline on the track or album resource. Skipping for now —
+      # would need an extra include or follow-up call to populate.
       def set_artwork_url
-        image_links = @track&.dig('album_resource', 'attributes', 'imageLinks') || []
-        largest = image_links.max_by { |link| link.dig('meta', 'width').to_i }
-        largest&.dig('href')
+        nil
       end
 
       def set_duration_ms

--- a/spec/services/tidal/track_finder/result_spec.rb
+++ b/spec/services/tidal/track_finder/result_spec.rb
@@ -13,58 +13,46 @@ describe Tidal::TrackFinder::Result do
     allow(Tidal::Token).to receive(:new).and_return(instance_double(Tidal::Token, token: 'fake_token'))
   end
 
+  def search_response(tracks:, artists:)
+    {
+      'data' => {
+        'id' => 'shape of you',
+        'type' => 'searchResults',
+        'attributes' => { 'trackingId' => 'abc' },
+        'relationships' => { 'tracks' => { 'data' => tracks.map { |t| { 'id' => t['id'], 'type' => 'tracks' } } } }
+      },
+      'included' => tracks + artists
+    }
+  end
+
+  def stub_search(body)
+    stub_request(:get, %r{openapi\.tidal\.com/v2/searchresults}).to_return(
+      status: 200,
+      body: body.to_json,
+      headers: { 'Content-Type' => 'application/vnd.api+json' }
+    )
+  end
+
   describe '#execute' do
-    let(:tidal_track_response) do
+    let(:ed_sheeran) { { 'id' => '100', 'type' => 'artists', 'attributes' => { 'name' => 'Ed Sheeran' } } }
+    let(:track_resource) do
       {
-        'data' => [
-          {
-            'id' => '12345',
-            'type' => 'tracks',
-            'attributes' => {
-              'title' => 'Shape of You',
-              'isrc' => 'GBAHS1600786',
-              'duration' => 'PT3M53S',
-              'explicit' => false,
-              'popularity' => 0.5
-            },
-            'relationships' => {
-              'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] },
-              'albums' => { 'data' => [{ 'id' => '200', 'type' => 'albums' }] }
-            }
-          }
-        ],
-        'included' => [
-          { 'id' => '100', 'type' => 'artists', 'attributes' => { 'name' => 'Ed Sheeran' } },
-          {
-            'id' => '200', 'type' => 'albums',
-            'attributes' => {
-              'title' => 'Divide',
-              'imageLinks' => [
-                { 'href' => 'https://resources.tidal.com/images/small.jpg', 'meta' => { 'width' => 160, 'height' => 160 } },
-                { 'href' => 'https://resources.tidal.com/images/large.jpg', 'meta' => { 'width' => 640, 'height' => 640 } }
-              ]
-            },
-            'relationships' => {
-              'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] }
-            }
-          }
-        ]
+        'id' => '12345', 'type' => 'tracks',
+        'attributes' => {
+          'title' => 'Shape of You', 'isrc' => 'GBAHS1600786', 'duration' => 'PT3M53S',
+          'explicit' => false, 'popularity' => 0.5
+        },
+        'relationships' => { 'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] } }
       }
     end
 
-    context 'when the track is found by ISRC' do
-      let(:isrc) { 'GBAHS1600786' }
-
+    context 'when the search returns a single matching track' do
       before do
-        stub_request(:get, %r{openapi\.tidal\.com/v2/tracks\?.*filter}).to_return(
-          status: 200,
-          body: tidal_track_response.to_json,
-          headers: { 'Content-Type' => 'application/vnd.api+json' }
-        )
+        stub_search(search_response(tracks: [track_resource], artists: [ed_sheeran]))
         result.execute
       end
 
-      it 'returns the correct title' do
+      it 'returns the title' do
         expect(result.title).to eq('Shape of You')
       end
 
@@ -74,10 +62,6 @@ describe Tidal::TrackFinder::Result do
 
       it 'returns the song URL' do
         expect(result.tidal_song_url).to eq('https://tidal.com/browse/track/12345')
-      end
-
-      it 'returns the largest artwork URL' do
-        expect(result.tidal_artwork_url).to eq('https://resources.tidal.com/images/large.jpg')
       end
 
       it 'returns the ISRC' do
@@ -91,191 +75,102 @@ describe Tidal::TrackFinder::Result do
       it 'returns the artist name' do
         expect(result.artists.first['name']).to eq('Ed Sheeran')
       end
+
+      it 'returns nil artwork (album not included in this iteration)' do
+        expect(result.tidal_artwork_url).to be_nil
+      end
     end
 
-    context 'when the track is found by query search' do
-      let(:search_response) do
-        {
-          'data' => {
-            'id' => 'shape of you',
-            'type' => 'searchResults',
-            'attributes' => { 'trackingId' => 'abc' },
-            'relationships' => { 'tracks' => { 'data' => [{ 'id' => '12345', 'type' => 'tracks' }] } }
-          },
-          'included' => tidal_track_response['data'] + tidal_track_response['included']
-        }
+    context 'when the search returns several tracks' do
+      let(:low_pop_track) do
+        track_resource.merge('id' => 'low', 'attributes' => track_resource['attributes'].merge('popularity' => 0.1))
+      end
+      let(:high_pop_track) do
+        track_resource.merge('id' => 'high', 'attributes' => track_resource['attributes'].merge('popularity' => 0.95))
       end
 
       before do
-        stub_request(:get, %r{openapi\.tidal\.com/v2/searchresults}).to_return(
-          status: 200,
-          body: search_response.to_json,
-          headers: { 'Content-Type' => 'application/vnd.api+json' }
-        )
+        stub_search(search_response(tracks: [low_pop_track, high_pop_track], artists: [ed_sheeran]))
         result.execute
       end
 
-      it 'returns the correct title' do
-        expect(result.title).to eq('Shape of You')
-      end
-
-      it 'returns the Tidal id' do
-        expect(result.id).to eq('12345')
+      it 'picks the most popular track' do
+        expect(result.id).to eq('high')
       end
     end
 
-    context 'when the ISRC returns multiple albums' do
+    context 'when an ISRC is supplied and search returns multiple ISRCs' do
       let(:isrc) { 'GBAHS1600786' }
-      let(:multi_album_response) do
-        {
-          'data' => [
-            {
-              'id' => 'compilation_track', 'type' => 'tracks',
-              'attributes' => { 'title' => 'Shape of You', 'isrc' => 'GBAHS1600786', 'duration' => 'PT3M53S', 'popularity' => 0.9 },
-              'relationships' => {
-                'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] },
-                'albums' => { 'data' => [{ 'id' => 'compilation_album', 'type' => 'albums' }] }
-              }
-            },
-            {
-              'id' => 'original_track', 'type' => 'tracks',
-              'attributes' => { 'title' => 'Shape of You', 'isrc' => 'GBAHS1600786', 'duration' => 'PT3M53S', 'popularity' => 0.4 },
-              'relationships' => {
-                'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] },
-                'albums' => { 'data' => [{ 'id' => 'original_album', 'type' => 'albums' }] }
-              }
-            }
-          ],
-          'included' => [
-            { 'id' => '100', 'type' => 'artists', 'attributes' => { 'name' => 'Ed Sheeran' } },
-            { 'id' => '999', 'type' => 'artists', 'attributes' => { 'name' => 'Various Artists' } },
-            {
-              'id' => 'compilation_album', 'type' => 'albums', 'attributes' => { 'title' => 'Summer Hits' },
-              'relationships' => { 'artists' => { 'data' => [{ 'id' => '999', 'type' => 'artists' }] } }
-            },
-            {
-              'id' => 'original_album', 'type' => 'albums', 'attributes' => { 'title' => 'Divide' },
-              'relationships' => { 'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] } }
-            }
-          ]
-        }
+      let(:matching_track) do
+        track_resource.merge('id' => 'matches', 'attributes' => track_resource['attributes'].merge('popularity' => 0.2))
+      end
+      let(:wrong_isrc_track) do
+        track_resource.merge(
+          'id' => 'mismatch',
+          'attributes' => track_resource['attributes'].merge('isrc' => 'OTHER000000', 'popularity' => 0.99)
+        )
       end
 
       before do
-        stub_request(:get, %r{openapi\.tidal\.com/v2/tracks\?.*filter}).to_return(
-          status: 200,
-          body: multi_album_response.to_json,
-          headers: { 'Content-Type' => 'application/vnd.api+json' }
-        )
+        stub_search(search_response(tracks: [wrong_isrc_track, matching_track], artists: [ed_sheeran]))
         result.execute
       end
 
-      it 'picks the track on the original-artist album, even when the compilation is more popular' do
-        expect(result.id).to eq('original_track')
+      it 'narrows to tracks with the matching ISRC even when a wrong-ISRC track is more popular' do
+        expect(result.id).to eq('matches')
       end
     end
 
-    context 'when multiple original-artist albums exist' do
-      let(:isrc) { 'GBAHS1600786' }
-      let(:multi_original_response) do
-        {
-          'data' => [
-            {
-              'id' => 'single_track', 'type' => 'tracks',
-              'attributes' => { 'title' => 'Shape of You', 'isrc' => 'GBAHS1600786', 'duration' => 'PT3M53S', 'popularity' => 0.4 },
-              'relationships' => {
-                'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] },
-                'albums' => { 'data' => [{ 'id' => 'single_album', 'type' => 'albums' }] }
-              }
-            },
-            {
-              'id' => 'greatest_hits_track', 'type' => 'tracks',
-              'attributes' => { 'title' => 'Shape of You', 'isrc' => 'GBAHS1600786', 'duration' => 'PT3M53S', 'popularity' => 0.95 },
-              'relationships' => {
-                'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] },
-                'albums' => { 'data' => [{ 'id' => 'greatest_hits_album', 'type' => 'albums' }] }
-              }
-            }
-          ],
-          'included' => [
-            { 'id' => '100', 'type' => 'artists', 'attributes' => { 'name' => 'Ed Sheeran' } },
-            {
-              'id' => 'single_album', 'type' => 'albums', 'attributes' => { 'title' => 'Shape of You' },
-              'relationships' => { 'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] } }
-            },
-            {
-              'id' => 'greatest_hits_album', 'type' => 'albums', 'attributes' => { 'title' => 'Greatest Hits' },
-              'relationships' => { 'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] } }
-            }
-          ]
-        }
+    context 'when an ISRC is supplied but no result has that ISRC' do
+      let(:isrc) { 'NONEXISTENT' }
+      let(:other_track) do
+        track_resource.merge('id' => 'other', 'attributes' => track_resource['attributes'].merge('isrc' => 'OTHER000000'))
       end
 
       before do
-        stub_request(:get, %r{openapi\.tidal\.com/v2/tracks\?.*filter}).to_return(
-          status: 200,
-          body: multi_original_response.to_json,
-          headers: { 'Content-Type' => 'application/vnd.api+json' }
-        )
+        stub_search(search_response(tracks: [other_track], artists: [ed_sheeran]))
         result.execute
       end
 
-      it 'picks the most popular original-artist track' do
-        expect(result.id).to eq('greatest_hits_track')
+      it 'falls back to the full pool and validates via artist/title distance' do
+        expect(result.id).to eq('other')
       end
     end
 
-    context 'when no album lists an artist that matches the track artist' do
-      let(:isrc) { 'GBAHS1600786' }
-      let(:no_overlap_response) do
-        {
-          'data' => [
-            {
-              'id' => 'low_pop', 'type' => 'tracks',
-              'attributes' => { 'title' => 'Shape of You', 'isrc' => 'GBAHS1600786', 'duration' => 'PT3M53S', 'popularity' => 0.2 },
-              'relationships' => {
-                'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] },
-                'albums' => { 'data' => [{ 'id' => 'a1', 'type' => 'albums' }] }
-              }
-            },
-            {
-              'id' => 'high_pop', 'type' => 'tracks',
-              'attributes' => { 'title' => 'Shape of You', 'isrc' => 'GBAHS1600786', 'duration' => 'PT3M53S', 'popularity' => 0.8 },
-              'relationships' => {
-                'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] },
-                'albums' => { 'data' => [{ 'id' => 'a2', 'type' => 'albums' }] }
-              }
-            }
-          ],
-          'included' => [
-            { 'id' => '100', 'type' => 'artists', 'attributes' => { 'name' => 'Ed Sheeran' } },
-            { 'id' => 'a1', 'type' => 'albums', 'attributes' => { 'title' => 'Mix A' } },
-            { 'id' => 'a2', 'type' => 'albums', 'attributes' => { 'title' => 'Mix B' } }
-          ]
-        }
+    context 'when the title does not pass the threshold' do
+      let(:wrong_title_track) do
+        track_resource.merge('attributes' => track_resource['attributes'].merge('title' => 'Completely Different Song'))
       end
 
       before do
-        stub_request(:get, %r{openapi\.tidal\.com/v2/tracks\?.*filter}).to_return(
-          status: 200,
-          body: no_overlap_response.to_json,
-          headers: { 'Content-Type' => 'application/vnd.api+json' }
-        )
+        stub_search(search_response(tracks: [wrong_title_track], artists: [ed_sheeran]))
         result.execute
       end
 
-      it 'falls back to picking the most popular track' do
-        expect(result.id).to eq('high_pop')
+      it 'rejects the match' do
+        expect(result.track).to be_nil
       end
     end
 
-    context 'when the track is not found' do
+    context 'when the artist does not pass the threshold' do
+      let(:wrong_artist) { { 'id' => '999', 'type' => 'artists', 'attributes' => { 'name' => 'Some Other Artist' } } }
+      let(:wrong_artist_track) do
+        track_resource.merge('relationships' => { 'artists' => { 'data' => [{ 'id' => '999', 'type' => 'artists' }] } })
+      end
+
       before do
-        stub_request(:get, /openapi\.tidal\.com/).to_return(
-          status: 200,
-          body: { 'data' => [], 'included' => [] }.to_json,
-          headers: { 'Content-Type' => 'application/vnd.api+json' }
-        )
+        stub_search(search_response(tracks: [wrong_artist_track], artists: [wrong_artist]))
+        result.execute
+      end
+
+      it 'rejects the match' do
+        expect(result.track).to be_nil
+      end
+    end
+
+    context 'when search returns nothing' do
+      before do
+        stub_search('data' => { 'id' => 'q', 'type' => 'searchResults', 'attributes' => {} }, 'included' => [])
         result.execute
       end
 


### PR DESCRIPTION
## Summary
Switches the Tidal track finder from a two-path strategy (`/v2/tracks?filter[isrc]` for ISRC songs → `/v2/searchresults` fallback) to a single `/v2/searchresults` call. The search-results endpoint surfaces the most-played version of each recording directly, where `/tracks?filter[isrc]` returned ~20 entries per recording with diluted popularity. Empirically the search-results variants have substantially higher \`popularity\` scores and produce better matches.

ISRC narrowing now happens client-side after the search returns:
- If the song carries an ISRC and any returned track shares it → restrict the candidate pool to those.
- Otherwise → validate against the full pool via artist/title distance.

Server-side ISRC narrowing isn't possible: the \`filter\` query parameter on \`/searchresults\` only accepts INCLUDE/EXCLUDE values (controlling which result-block kinds come back), not arbitrary field filters.

\`include\` is \`tracks,artists\` — artists are required to keep the artist_distance threshold (≥80%) honest.

## Trade-offs
- Album-artist compilation filter is gone (it lived on \`/tracks?filter[isrc]\` where we got 20 entries; \`/searchresults\` returns the canonical version directly, so the filter becomes redundant).
- Album-cover artwork extraction is gone for now — Tidal exposes album art via a separate \`coverArt\` relationship rather than inline. \`tidal_artwork_url\` returns nil. Will revisit in a follow-up if needed.

## Test plan
- [x] \`bundle exec rspec spec/services/tidal\` — 30 examples, 0 failures
  - search returns single track → enriches correctly
  - several tracks → picks highest popularity
  - ISRC supplied + matching track present → narrows to ISRC-matched even when wrong-ISRC entry is more popular
  - ISRC supplied but no matching ISRC → falls back to full pool, validates via distance
  - title or artist below threshold → rejects match
  - empty search → returns nil
- [x] \`bundle exec rubocop\` clean
- [ ] Verify on prod against a known song (cache flush still required: \`Rails.cache.delete_matched(\"/v2/searchresults*\")\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)