### PR TITLE
Fix Tidal searchResults: URL casing + missing artist data

### DIFF
--- a/app/services/tidal/track_finder/result.rb
+++ b/app/services/tidal/track_finder/result.rb
@@ -33,38 +33,39 @@ module Tidal
       def valid_match?
         return false if @track.blank?
 
-        @track['artist_distance'].to_i >= ARTIST_SIMILARITY_THRESHOLD &&
-          @track['title_distance'].to_i >= TITLE_SIMILARITY_THRESHOLD
+        @track['title_distance'].to_i >= TITLE_SIMILARITY_THRESHOLD
       end
 
       private
 
-      # Tidal's `/v2/searchresults` endpoint surfaces the most-played track per
-      # recording (the version users actually listen to), which gives us higher
-      # popularity scores and better matches than `/v2/tracks?filter[isrc]`.
-      # `filter` here only takes INCLUDE/EXCLUDE values (controls which result
-      # blocks come back), not arbitrary field filters — so when an ISRC is
-      # available we narrow client-side after the search returns.
+      # Tidal's `/v2/searchResults` endpoint (camelCase, case-sensitive) surfaces
+      # the most-played version of each recording with higher popularity scores
+      # than `/v2/tracks?filter[isrc]`. The endpoint's `filter` query parameter
+      # only accepts INCLUDE/EXCLUDE values (controlling which result-block
+      # kinds come back) — not arbitrary field filters — so ISRC narrowing
+      # happens client-side. `include=tracks` is the only useful include here:
+      # tracks expose their artists via a `relationships.artists.links`
+      # sub-resource, not inline data, so we can't compute artist_distance from
+      # this response. We rely on Tidal's search ranking to pre-filter to
+      # relevant artists, then validate via title distance and ISRC.
       def find_best_match
         query = ERB::Util.url_encode("#{@search_artists} #{@search_title}")
-        url = "/v2/searchresults/#{query}?countryCode=#{@country}&include=tracks,artists"
+        url = "/v2/searchResults/#{query}?countryCode=#{@country}&include=tracks"
         response = make_request(url)
 
         return nil if response.blank?
 
-        included = Array(response['included'])
-        track_resources = included.select { |r| r['type'] == 'tracks' }
+        track_resources = Array(response['included']).select { |r| r['type'] == 'tracks' }
         return nil if track_resources.blank?
 
-        index = build_included_index(included)
         pool = isrc_filtered(track_resources)
-        pick_best_search_track(pool, index)
+        pick_best_search_track(pool)
       end
 
-      # When a song already has an ISRC (Spotify enrichment populated it), narrow
-      # the search results to entries with that exact ISRC. Falls back to the
-      # full pool if the search didn't surface a matching ISRC — better to
-      # validate via artist/title distance than to return nothing.
+      # When a song already has an ISRC (Spotify enrichment populated it),
+      # narrow the search results to entries with that exact ISRC. Falls back
+      # to the full pool when nothing matches — title distance still gates the
+      # final selection.
       def isrc_filtered(tracks)
         return tracks if @isrc_code.blank?
 
@@ -72,51 +73,29 @@ module Tidal
         matched.presence || tracks
       end
 
-      # Score every candidate (artist + title), keep ones over the thresholds,
-      # then pick the highest popularity. Popularity is the deciding signal here
-      # because /searchresults already pre-filters to relevant matches.
-      def pick_best_search_track(tracks, index)
-        scored = tracks.filter_map { |t| attach_resources(t, index) }
-        valid = scored.select do |t|
-          t['artist_distance'].to_i >= ARTIST_SIMILARITY_THRESHOLD &&
-            t['title_distance'].to_i >= TITLE_SIMILARITY_THRESHOLD
-        end
+      # Score by title, keep ones over the threshold, pick the highest
+      # popularity. Popularity alone would land on the wrong song when the
+      # artist has multiple hits — searching "Bruno Mars I Just Might"
+      # surfaces "Just the Way You Are" with higher popularity than the actual
+      # match — so the title gate is required.
+      def pick_best_search_track(tracks)
+        scored = tracks.filter_map { |t| attach_title_score(t) }
+        valid = scored.select { |t| t['title_distance'].to_i >= TITLE_SIMILARITY_THRESHOLD }
         valid.max_by { |t| t.dig('attributes', 'popularity').to_f }
       end
 
-      # Attach artist resources and compute JaroWinkler distances. Mutates
-      # `track` so the winner can carry its scores into the setter chain.
-      def attach_resources(track, index)
+      def attach_title_score(track)
         return nil if track.blank?
 
-        track['artist_resources'] = artist_resources_via_index(track, index)
-        track['artist_distance'] = artist_distance(combined_artist_name(track))
         track['title_distance'] = title_distance(track.dig('attributes', 'title'))
         track
       end
 
-      # Build a `{ [type, id] => resource }` lookup so member-resolution stays
-      # O(1) instead of scanning `included` per candidate.
-      def build_included_index(included)
-        return {} if included.blank?
-
-        Array(included).index_by { |r| [r['type'], r['id']] }
-      end
-
-      def artist_resources_via_index(track, index)
-        ids = Array(track.dig('relationships', 'artists', 'data')).pluck('id')
-        ids.filter_map { |id| index[['artists', id]] }
-      end
-
-      def combined_artist_name(track)
-        names = Array(track['artist_resources']).filter_map { |a| a.dig('attributes', 'name') }
-        names.join(' & ')
-      end
-
+      # /searchResults doesn't return track-artist data inline. Leaving artists
+      # empty until we either deep-include or fetch the winner's artists via a
+      # follow-up call.
       def set_artists
-        Array(@track&.dig('artist_resources')).map do |resource|
-          { 'name' => resource.dig('attributes', 'name'), 'id' => resource['id'] }
-        end
+        []
       end
 
       def set_title

--- a/spec/services/tidal/track_finder/result_spec.rb
+++ b/spec/services/tidal/track_finder/result_spec.rb
@@ -5,170 +5,148 @@ require 'rails_helper'
 describe Tidal::TrackFinder::Result do
   subject(:result) { described_class.new(artists: artists, title: title, isrc: isrc) }
 
-  let(:artists) { 'Ed Sheeran' }
-  let(:title) { 'Shape of You' }
+  let(:artists) { 'Bruno Mars' }
+  let(:title) { 'I Just Might' }
   let(:isrc) { nil }
 
   before do
     allow(Tidal::Token).to receive(:new).and_return(instance_double(Tidal::Token, token: 'fake_token'))
   end
 
-  def search_response(tracks:, artists:)
+  def search_response(tracks)
     {
       'data' => {
-        'id' => 'shape of you',
-        'type' => 'searchResults',
+        'id' => 'q', 'type' => 'searchResults',
         'attributes' => { 'trackingId' => 'abc' },
         'relationships' => { 'tracks' => { 'data' => tracks.map { |t| { 'id' => t['id'], 'type' => 'tracks' } } } }
       },
-      'included' => tracks + artists
+      'included' => tracks
     }
   end
 
   def stub_search(body)
-    stub_request(:get, %r{openapi\.tidal\.com/v2/searchresults}).to_return(
+    stub_request(:get, %r{openapi\.tidal\.com/v2/searchResults}).to_return(
       status: 200,
       body: body.to_json,
       headers: { 'Content-Type' => 'application/vnd.api+json' }
     )
   end
 
-  describe '#execute' do
-    let(:ed_sheeran) { { 'id' => '100', 'type' => 'artists', 'attributes' => { 'name' => 'Ed Sheeran' } } }
-    let(:track_resource) do
-      {
-        'id' => '12345', 'type' => 'tracks',
-        'attributes' => {
-          'title' => 'Shape of You', 'isrc' => 'GBAHS1600786', 'duration' => 'PT3M53S',
-          'explicit' => false, 'popularity' => 0.5
-        },
-        'relationships' => { 'artists' => { 'data' => [{ 'id' => '100', 'type' => 'artists' }] } }
+  def track_resource(id:, title:, isrc:, popularity:)
+    {
+      'id' => id, 'type' => 'tracks',
+      'attributes' => {
+        'title' => title, 'isrc' => isrc, 'duration' => 'PT3M33S',
+        'explicit' => false, 'popularity' => popularity
       }
-    end
+    }
+  end
 
-    context 'when the search returns a single matching track' do
+  describe '#execute' do
+    context 'when search returns the matching ISRC' do
+      let(:isrc) { 'USAT22509144' }
+
+      let(:tracks) do
+        [
+          track_resource(id: '5274607', title: 'Just the Way You Are', isrc: 'USAT21001269', popularity: 0.85),
+          track_resource(id: '67237704', title: "That's What I Like", isrc: 'USAT21602948', popularity: 0.82),
+          track_resource(id: '488282494', title: 'I Just Might', isrc: 'USAT22509144', popularity: 0.72),
+          track_resource(id: '498194649', title: 'I Just Might (Austin Millz Remix)', isrc: 'USAT22600280', popularity: 0.41)
+        ]
+      end
+
       before do
-        stub_search(search_response(tracks: [track_resource], artists: [ed_sheeran]))
+        stub_search(search_response(tracks))
         result.execute
       end
 
-      it 'returns the title' do
-        expect(result.title).to eq('Shape of You')
+      it 'picks the track whose ISRC matches, ignoring more popular Bruno Mars hits' do
+        expect(result.id).to eq('488282494')
       end
 
-      it 'returns the Tidal id' do
-        expect(result.id).to eq('12345')
+      it 'returns the matching ISRC' do
+        expect(result.isrc).to eq('USAT22509144')
+      end
+
+      it 'returns the track title' do
+        expect(result.title).to eq('I Just Might')
       end
 
       it 'returns the song URL' do
-        expect(result.tidal_song_url).to eq('https://tidal.com/browse/track/12345')
+        expect(result.tidal_song_url).to eq('https://tidal.com/browse/track/488282494')
       end
 
-      it 'returns the ISRC' do
-        expect(result.isrc).to eq('GBAHS1600786')
+      it 'returns duration_ms' do
+        expect(result.duration_ms).to eq(213_000)
       end
 
-      it 'returns duration in milliseconds' do
-        expect(result.duration_ms).to eq(233_000)
+      it 'leaves artists empty (endpoint does not return inline artist data)' do
+        expect(result.artists).to eq([])
       end
 
-      it 'returns the artist name' do
-        expect(result.artists.first['name']).to eq('Ed Sheeran')
-      end
-
-      it 'returns nil artwork (album not included in this iteration)' do
+      it 'leaves artwork empty (endpoint does not expose cover art inline)' do
         expect(result.tidal_artwork_url).to be_nil
       end
     end
 
-    context 'when the search returns several tracks' do
-      let(:low_pop_track) do
-        track_resource.merge('id' => 'low', 'attributes' => track_resource['attributes'].merge('popularity' => 0.1))
-      end
-      let(:high_pop_track) do
-        track_resource.merge('id' => 'high', 'attributes' => track_resource['attributes'].merge('popularity' => 0.95))
-      end
-
-      before do
-        stub_search(search_response(tracks: [low_pop_track, high_pop_track], artists: [ed_sheeran]))
-        result.execute
-      end
-
-      it 'picks the most popular track' do
-        expect(result.id).to eq('high')
-      end
-    end
-
-    context 'when an ISRC is supplied and search returns multiple ISRCs' do
-      let(:isrc) { 'GBAHS1600786' }
-      let(:matching_track) do
-        track_resource.merge('id' => 'matches', 'attributes' => track_resource['attributes'].merge('popularity' => 0.2))
-      end
-      let(:wrong_isrc_track) do
-        track_resource.merge(
-          'id' => 'mismatch',
-          'attributes' => track_resource['attributes'].merge('isrc' => 'OTHER000000', 'popularity' => 0.99)
-        )
+    context 'when no ISRC is provided' do
+      let(:tracks) do
+        [
+          track_resource(id: '5274607', title: 'Just the Way You Are', isrc: 'USAT21001269', popularity: 0.85),
+          track_resource(id: '488282494', title: 'I Just Might', isrc: 'USAT22509144', popularity: 0.72),
+          track_resource(id: '492008674', title: 'I Just Might (Originally Performed by Bruno Mars) [Instrumental]',
+                         isrc: 'QZPJ32532049', popularity: 0.11)
+        ]
       end
 
       before do
-        stub_search(search_response(tracks: [wrong_isrc_track, matching_track], artists: [ed_sheeran]))
+        stub_search(search_response(tracks))
         result.execute
       end
 
-      it 'narrows to tracks with the matching ISRC even when a wrong-ISRC track is more popular' do
-        expect(result.id).to eq('matches')
+      it 'rejects "Just the Way You Are" via title distance even though it is more popular' do
+        expect(result.id).to eq('488282494')
       end
     end
 
-    context 'when an ISRC is supplied but no result has that ISRC' do
+    context 'when ISRC is provided but no candidate matches it' do
       let(:isrc) { 'NONEXISTENT' }
-      let(:other_track) do
-        track_resource.merge('id' => 'other', 'attributes' => track_resource['attributes'].merge('isrc' => 'OTHER000000'))
+      let(:tracks) do
+        [
+          track_resource(id: '488282494', title: 'I Just Might', isrc: 'USAT22509144', popularity: 0.72),
+          track_resource(id: '5274607', title: 'Just the Way You Are', isrc: 'USAT21001269', popularity: 0.85)
+        ]
       end
 
       before do
-        stub_search(search_response(tracks: [other_track], artists: [ed_sheeran]))
+        stub_search(search_response(tracks))
         result.execute
       end
 
-      it 'falls back to the full pool and validates via artist/title distance' do
-        expect(result.id).to eq('other')
+      it 'falls back to the full pool and lets title distance pick the right track' do
+        expect(result.id).to eq('488282494')
       end
     end
 
-    context 'when the title does not pass the threshold' do
-      let(:wrong_title_track) do
-        track_resource.merge('attributes' => track_resource['attributes'].merge('title' => 'Completely Different Song'))
+    context 'when no candidate passes the title threshold' do
+      let(:tracks) do
+        [
+          track_resource(id: 'wrong-1', title: 'Completely Different Song', isrc: 'X', popularity: 0.9),
+          track_resource(id: 'wrong-2', title: 'Another Mismatch', isrc: 'Y', popularity: 0.8)
+        ]
       end
 
       before do
-        stub_search(search_response(tracks: [wrong_title_track], artists: [ed_sheeran]))
+        stub_search(search_response(tracks))
         result.execute
       end
 
-      it 'rejects the match' do
+      it 'returns nil for track' do
         expect(result.track).to be_nil
       end
     end
 
-    context 'when the artist does not pass the threshold' do
-      let(:wrong_artist) { { 'id' => '999', 'type' => 'artists', 'attributes' => { 'name' => 'Some Other Artist' } } }
-      let(:wrong_artist_track) do
-        track_resource.merge('relationships' => { 'artists' => { 'data' => [{ 'id' => '999', 'type' => 'artists' }] } })
-      end
-
-      before do
-        stub_search(search_response(tracks: [wrong_artist_track], artists: [wrong_artist]))
-        result.execute
-      end
-
-      it 'rejects the match' do
-        expect(result.track).to be_nil
-      end
-    end
-
-    context 'when search returns nothing' do
+    context 'when search returns no tracks' do
       before do
         stub_search('data' => { 'id' => 'q', 'type' => 'searchResults', 'attributes' => {} }, 'included' => [])
         result.execute
@@ -185,9 +163,9 @@ describe Tidal::TrackFinder::Result do
   end
 
   describe '#valid_match?' do
-    context 'when both artist and title distances are high' do
+    context 'when title_distance is above the threshold' do
       before do
-        result.instance_variable_set(:@track, { 'artist_distance' => 85, 'title_distance' => 85 })
+        result.instance_variable_set(:@track, { 'title_distance' => 85 })
       end
 
       it 'returns true' do
@@ -195,9 +173,9 @@ describe Tidal::TrackFinder::Result do
       end
     end
 
-    context 'when artist_distance is high but title_distance is low' do
+    context 'when title_distance is below the threshold' do
       before do
-        result.instance_variable_set(:@track, { 'artist_distance' => 85, 'title_distance' => 50 })
+        result.instance_variable_set(:@track, { 'title_distance' => 50 })
       end
 
       it 'returns false' do


### PR DESCRIPTION
## Summary
Two production bugs from the prior pass were causing every Tidal enrichment to return \`@track=nil\`:

1. **URL casing**: code used \`/v2/searchresults\` (lowercase). Tidal's path is case-sensitive — the correct form is \`/v2/searchResults\`. Lowercase returned an autocomplete-style payload (\`data.attributes.suggestions\` strings, no tracks), which my parser threw away.
2. **Missing artist data**: \`/searchResults\` doesn't return track-artist info inline. Each track's \`relationships.artists\` only has a \`links.self\` sub-resource (no \`data\` array), and the top-level \`data.relationships.artists\` describes *artists matching the query* (a different result block), not the artists *of* the returned tracks. So \`artist_distance\` was always ~0 and \`valid_match?\` rejected every candidate.

## Strategy
- Hit \`/v2/searchResults/{query}?countryCode=NL&include=tracks\`.
- If the song has an ISRC → narrow client-side to tracks with matching \`attributes.isrc\` (lands directly on the canonical recording).
- Otherwise → require \`title_distance ≥ 70\`, then pick by \`attributes.popularity\`.
- Drop the artist_distance threshold for this endpoint. The user's earlier guidance was \"keep artist distance if it helps get better results\" — without artist data on this endpoint it can't help, it just blocks everything.

The title gate is essential, not redundant: searching \"Bruno Mars I Just Might\" puts \"Just the Way You Are\" (popularity 0.85) and \"That's What I Like\" (0.82) ahead of the actual match \"I Just Might\" (0.72). Popularity alone would land on the wrong song.

## Trade-off
\`set_artists\` returns \`[]\` for now since the endpoint doesn't expose track artists. \`SongEnricher\` only consumes \`id\` / \`song_url\` / \`artwork_url\`, so empty artists doesn't break enrichment. If false positives show up in practice, follow-up options are: (a) one extra GET to \`/v2/tracks/{id}/relationships/artists\` for the winner only, or (b) try \`include=tracks.artists\` deep include if Tidal supports it.

## Test plan
- [x] \`bundle exec rspec spec/services/tidal\` — 28 examples, 0 failures
  - new fixture mirrors the actual prod response (Bruno Mars search returning multiple Bruno Mars hits ahead of the target track)
  - ISRC match wins over more popular non-matching ISRC
  - no-ISRC: title distance rejects \"Just the Way You Are\" in favor of \"I Just Might\"
  - missing-ISRC fallback: full pool, title distance still picks correctly
  - all-mismatches: returns nil
- [x] \`bundle exec rubocop\` clean
- [ ] Verify on prod: \`Rails.cache.delete_matched(\"/v2/search*\")\` then re-run enrichment for a known song. Expect track 488282494 for \"I Just Might\" by Bruno Mars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)