### PR TITLE
Document Tidal Open API in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -450,6 +450,7 @@ Weekly grouped updates for the `github-actions` ecosystem. Keeps action versions
 - **yt-dlp** - YouTube audio downloading for AcoustID fingerprint population
 - **Sentry** - Error tracking and performance monitoring (env var: `SENTRY_DSN`)
 - **OpenAI** - GPT-4.1-mini for natural language search query translation (env var: `OPENAI_API_KEY`)
+- **Tidal Open API** - Catalog enrichment for songs (env vars: `TIDAL_CLIENT_ID`, `TIDAL_CLIENT_SECRET`). Auth at `auth.tidal.com/v1/oauth2/token`, data at `openapi.tidal.com/v2/...`. API reference: https://tidal-music.github.io/tidal-api-reference/. Paths are case-sensitive (e.g. `/v2/searchResults`, not `/v2/searchresults`).
 
 ## Audio Recognition
 


### PR DESCRIPTION
## Summary
Adds Tidal to the External Dependencies section: env vars (\`TIDAL_CLIENT_ID\`/\`TIDAL_CLIENT_SECRET\`), auth + data hosts, a pointer to Tidal's official API reference, and the case-sensitive-path note that cost us a PR cycle during integration.

## Test plan
- [x] Docs-only change. CI should pass without action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)