### PR TITLE
Enrich artists with Tidal, Deezer, and iTunes IDs

### DIFF
--- a/app/jobs/artist_external_ids_enrichment_job.rb
+++ b/app/jobs/artist_external_ids_enrichment_job.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class ArtistExternalIdsEnrichmentJob
+  include Sidekiq::Job
+
+  sidekiq_options queue: :low, retry: 3
+
+  def self.enqueue_all
+    scope = Artist
+              .where(id_on_tidal: nil)
+              .or(Artist.where(id_on_deezer: nil))
+              .or(Artist.where(id_on_itunes: nil))
+
+    scope.find_each { |artist| perform_async(artist.id) }
+  end
+
+  def perform(artist_id)
+    artist = Artist.find_by(id: artist_id)
+    return if artist.blank?
+    return unless artist.needs_external_ids_enrichment?
+
+    artist.enrich_with_external_services
+  end
+end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -9,11 +9,17 @@
 #  aka_names_checked_at         :datetime
 #  country_of_origin            :string           default([]), is an Array
 #  country_of_origin_checked_at :datetime
+#  deezer_artist_url            :string
+#  deezer_artwork_url           :string
 #  genres                       :string           default([]), is an Array
+#  id_on_deezer                 :string
+#  id_on_itunes                 :string
 #  id_on_musicbrainz            :string
 #  id_on_spotify                :string
+#  id_on_tidal                  :string
 #  image                        :string
 #  instagram_url                :string
+#  itunes_artist_url            :string
 #  lastfm_enriched_at           :datetime
 #  lastfm_listeners             :bigint
 #  lastfm_playcount             :bigint
@@ -24,6 +30,7 @@
 #  spotify_artwork_url          :string
 #  spotify_followers_count      :integer
 #  spotify_popularity           :integer
+#  tidal_artist_url             :string
 #  website_url                  :string
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
@@ -31,7 +38,10 @@
 # Indexes
 #
 #  index_artists_on_aka_names          (aka_names) USING gin
+#  index_artists_on_id_on_deezer       (id_on_deezer)
+#  index_artists_on_id_on_itunes       (id_on_itunes)
 #  index_artists_on_id_on_musicbrainz  (id_on_musicbrainz) UNIQUE
+#  index_artists_on_id_on_tidal        (id_on_tidal)
 #  index_artists_on_name_trgm          (name) USING gin
 #  index_artists_on_slug               (slug) UNIQUE
 #
@@ -65,6 +75,16 @@ class Artist < ApplicationRecord
 
   validates :name, presence: true
 
+  MOST_PLAYED_COLUMNS = %w[
+    id name slug image
+    id_on_spotify spotify_artist_url spotify_artwork_url spotify_popularity spotify_followers_count
+    id_on_tidal tidal_artist_url
+    id_on_deezer deezer_artist_url deezer_artwork_url
+    id_on_itunes itunes_artist_url
+    instagram_url website_url genres country_of_origin
+    lastfm_listeners lastfm_playcount lastfm_tags
+  ].map { |c| "artists.#{c}" }.freeze
+
   def self.most_played(params = {})
     start_time, end_time = time_range_from_params(params, default_period: 'week')
 
@@ -73,23 +93,7 @@ class Artist < ApplicationRecord
       .played_between(start_time, end_time)
       .played_on(params[:radio_station_ids])
       .matching(params[:search_term])
-      .select("artists.id,
-                   artists.name,
-                   artists.slug,
-                   artists.image,
-                   artists.id_on_spotify,
-                   artists.spotify_artist_url,
-                   artists.spotify_artwork_url,
-                   artists.instagram_url,
-                   artists.website_url,
-                   artists.genres,
-                   artists.spotify_popularity,
-                   artists.spotify_followers_count,
-                   artists.country_of_origin,
-                   artists.lastfm_listeners,
-                   artists.lastfm_playcount,
-                   artists.lastfm_tags,
-                   COUNT(DISTINCT air_plays.id) AS counter")
+      .select(*MOST_PLAYED_COLUMNS, 'COUNT(DISTINCT air_plays.id) AS counter')
       .group(:id)
       .order('COUNTER DESC')
   end
@@ -162,7 +166,41 @@ class Artist < ApplicationRecord
     MusicBrainz::ArtistAliasFetcher.new(self).()
   end
 
+  def enrich_with_tidal
+    Tidal::ArtistEnricher.new(self).enrich
+  end
+
+  def enrich_with_deezer
+    Deezer::ArtistEnricher.new(self).enrich
+  end
+
+  def enrich_with_itunes
+    Itunes::ArtistEnricher.new(self).enrich
+  end
+
+  def enrich_with_external_services
+    enrich_with_tidal if should_enrich_with_tidal?
+    enrich_with_deezer if should_enrich_with_deezer?
+    enrich_with_itunes if should_enrich_with_itunes?
+  end
+
+  def needs_external_ids_enrichment?
+    should_enrich_with_tidal? || should_enrich_with_deezer? || should_enrich_with_itunes?
+  end
+
   private
+
+  def should_enrich_with_tidal?
+    id_on_tidal.blank? && name.present?
+  end
+
+  def should_enrich_with_deezer?
+    id_on_deezer.blank? && name.present?
+  end
+
+  def should_enrich_with_itunes?
+    id_on_itunes.blank? && name.present?
+  end
 
   def slug_source
     name

--- a/app/serializers/artist_serializer.rb
+++ b/app/serializers/artist_serializer.rb
@@ -9,11 +9,17 @@
 #  aka_names_checked_at         :datetime
 #  country_of_origin            :string           default([]), is an Array
 #  country_of_origin_checked_at :datetime
+#  deezer_artist_url            :string
+#  deezer_artwork_url           :string
 #  genres                       :string           default([]), is an Array
+#  id_on_deezer                 :string
+#  id_on_itunes                 :string
 #  id_on_musicbrainz            :string
 #  id_on_spotify                :string
+#  id_on_tidal                  :string
 #  image                        :string
 #  instagram_url                :string
+#  itunes_artist_url            :string
 #  lastfm_enriched_at           :datetime
 #  lastfm_listeners             :bigint
 #  lastfm_playcount             :bigint
@@ -24,6 +30,7 @@
 #  spotify_artwork_url          :string
 #  spotify_followers_count      :integer
 #  spotify_popularity           :integer
+#  tidal_artist_url             :string
 #  website_url                  :string
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
@@ -31,7 +38,10 @@
 # Indexes
 #
 #  index_artists_on_aka_names          (aka_names) USING gin
+#  index_artists_on_id_on_deezer       (id_on_deezer)
+#  index_artists_on_id_on_itunes       (id_on_itunes)
 #  index_artists_on_id_on_musicbrainz  (id_on_musicbrainz) UNIQUE
+#  index_artists_on_id_on_tidal        (id_on_tidal)
 #  index_artists_on_name_trgm          (name) USING gin
 #  index_artists_on_slug               (slug) UNIQUE
 #
@@ -40,7 +50,10 @@ class ArtistSerializer
 
   attributes :id, :name, :slug, :spotify_artist_url, :spotify_artwork_url, :instagram_url, :website_url, :genres,
              :spotify_popularity, :spotify_followers_count, :country_of_origin,
-             :lastfm_listeners, :lastfm_playcount, :lastfm_tags
+             :lastfm_listeners, :lastfm_playcount, :lastfm_tags,
+             :id_on_tidal, :tidal_artist_url,
+             :id_on_deezer, :deezer_artist_url, :deezer_artwork_url,
+             :id_on_itunes, :itunes_artist_url
 
   has_many :songs
 

--- a/app/services/deezer/artist_enricher.rb
+++ b/app/services/deezer/artist_enricher.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Deezer
+  class ArtistEnricher
+    def initialize(artist)
+      @artist = artist
+    end
+
+    def enrich
+      return if @artist.blank?
+      return if @artist.id_on_deezer.present?
+      return if @artist.name.blank?
+
+      result = find_on_deezer
+      return unless result&.valid_match?
+
+      @artist.update(build_attributes(result))
+    end
+
+    private
+
+    def build_attributes(result)
+      {
+        id_on_deezer: result.id,
+        deezer_artist_url: result.deezer_artist_url,
+        deezer_artwork_url: result.deezer_artwork_url
+      }
+    end
+
+    def find_on_deezer
+      result = Deezer::ArtistFinder::Result.new(name: @artist.name)
+      result.execute
+      result
+    end
+  end
+end

--- a/app/services/deezer/artist_finder/result.rb
+++ b/app/services/deezer/artist_finder/result.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Deezer
+  module ArtistFinder
+    class Result < Base
+      attr_reader :artist, :name, :id, :deezer_artist_url, :deezer_artwork_url
+
+      def initialize(args)
+        super(artists: args[:name])
+        @search_name = args[:name]
+      end
+
+      def execute
+        @artist = find_best_match
+        return nil if @artist.blank?
+
+        @name = @artist['name']
+        @id = @artist['id']&.to_s
+        @deezer_artist_url = @artist['link']
+        @deezer_artwork_url = @artist['picture_xl'] || @artist['picture_big'] || @artist['picture']
+        @artist
+      end
+
+      def valid_match?
+        return false if @artist.blank?
+
+        @artist['name_distance'].to_i >= ARTIST_SIMILARITY_THRESHOLD
+      end
+
+      private
+
+      def find_best_match
+        query = ERB::Util.url_encode(@search_name.to_s)
+        url = "/search/artist?q=#{query}&limit=10"
+        response = make_request(url)
+
+        return nil if response.blank? || response['error'].present? || response['data'].blank?
+
+        scored = response['data'].map { |artist| attach_name_score(artist) }
+        scored.find { |a| a['name_distance'].to_i >= ARTIST_SIMILARITY_THRESHOLD }
+      end
+
+      def attach_name_score(artist)
+        artist['name_distance'] = artist_distance(artist['name'])
+        artist
+      end
+    end
+  end
+end

--- a/app/services/itunes/artist_enricher.rb
+++ b/app/services/itunes/artist_enricher.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Itunes
+  class ArtistEnricher
+    def initialize(artist)
+      @artist = artist
+    end
+
+    def enrich
+      return if @artist.blank?
+      return if @artist.id_on_itunes.present?
+      return if @artist.name.blank?
+
+      result = find_on_itunes
+      return unless result&.valid_match?
+
+      @artist.update(build_attributes(result))
+    end
+
+    private
+
+    def build_attributes(result)
+      {
+        id_on_itunes: result.id,
+        itunes_artist_url: result.itunes_artist_url
+      }
+    end
+
+    def find_on_itunes
+      result = Itunes::ArtistFinder::Result.new(name: @artist.name)
+      result.execute
+      result
+    end
+  end
+end

--- a/app/services/itunes/artist_finder/result.rb
+++ b/app/services/itunes/artist_finder/result.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Itunes
+  module ArtistFinder
+    class Result < Base
+      attr_reader :artist, :name, :id, :itunes_artist_url
+
+      def initialize(args)
+        super(artists: args[:name])
+        @search_name = args[:name]
+        @country = args[:country] || DEFAULT_COUNTRY
+      end
+
+      def execute
+        @artist = find_best_match
+        return nil if @artist.blank?
+
+        @name = @artist['artistName']
+        @id = @artist['artistId']&.to_s
+        @itunes_artist_url = @artist['artistLinkUrl']
+        @artist
+      end
+
+      def valid_match?
+        return false if @artist.blank?
+
+        @artist['name_distance'].to_i >= ARTIST_SIMILARITY_THRESHOLD
+      end
+
+      private
+
+      def find_best_match
+        term = ERB::Util.url_encode(@search_name.to_s)
+        url = "/search?term=#{term}&entity=musicArtist&country=#{@country}&limit=10"
+        response = make_request(url)
+
+        return nil if response.blank? || response['results'].blank?
+
+        scored = response['results'].map { |artist| attach_name_score(artist) }
+        scored.find { |a| a['name_distance'].to_i >= ARTIST_SIMILARITY_THRESHOLD }
+      end
+
+      def attach_name_score(artist)
+        artist['name_distance'] = artist_distance(artist['artistName'])
+        artist
+      end
+    end
+  end
+end

--- a/app/services/song_importer/concerns/air_play_creation.rb
+++ b/app/services/song_importer/concerns/air_play_creation.rb
@@ -68,6 +68,13 @@ module SongImporter::Concerns
       @radio_station.songs << song unless RadioStationSong.exists?(radio_station: @radio_station, song:)
       MusicProfileJob.perform_async(song.id, @radio_station.id)
       SongExternalIdsEnrichmentJob.perform_async(song.id)
+      enqueue_artist_external_ids_enrichment
+    end
+
+    def enqueue_artist_external_ids_enrichment
+      song.artists.each do |artist|
+        ArtistExternalIdsEnrichmentJob.perform_async(artist.id) if artist.needs_external_ids_enrichment?
+      end
     end
   end
 end

--- a/app/services/tidal/artist_enricher.rb
+++ b/app/services/tidal/artist_enricher.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Tidal
+  class ArtistEnricher
+    def initialize(artist)
+      @artist = artist
+    end
+
+    def enrich
+      return if @artist.blank?
+      return if @artist.id_on_tidal.present?
+      return if @artist.name.blank?
+
+      result = find_on_tidal
+      return unless result&.valid_match?
+
+      @artist.update(build_attributes(result))
+    end
+
+    private
+
+    def build_attributes(result)
+      {
+        id_on_tidal: result.id,
+        tidal_artist_url: result.tidal_artist_url
+      }
+    end
+
+    def find_on_tidal
+      result = Tidal::ArtistFinder::Result.new(name: @artist.name)
+      result.execute
+      result
+    end
+  end
+end

--- a/app/services/tidal/artist_finder/result.rb
+++ b/app/services/tidal/artist_finder/result.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Tidal
+  module ArtistFinder
+    class Result < Base
+      attr_reader :artist, :name, :id, :tidal_artist_url
+
+      def initialize(args)
+        super(artists: args[:name])
+        @search_name = args[:name]
+        @country = args[:country] || DEFAULT_COUNTRY
+      end
+
+      def execute
+        @artist = find_best_match
+        return nil if @artist.blank?
+
+        @name = @artist.dig('attributes', 'name')
+        @id = @artist['id']&.to_s
+        @tidal_artist_url = @id.present? ? "https://tidal.com/browse/artist/#{@id}" : nil
+        @artist
+      end
+
+      def valid_match?
+        return false if @artist.blank?
+
+        @artist['name_distance'].to_i >= ARTIST_SIMILARITY_THRESHOLD
+      end
+
+      private
+
+      # Tidal's `/v2/searchResults/{query}?include=artists` returns artists in
+      # search-ranking order via `data.relationships.artists.data`, while the
+      # `included` array holds full artist resources without preserving order.
+      # We walk the relationship list in rank order, resolve each from
+      # `included`, score by name distance, and pick the first that passes the
+      # threshold — preserving relevance over raw popularity.
+      def find_best_match
+        query = ERB::Util.url_encode(@search_name.to_s)
+        url = "/v2/searchResults/#{query}?countryCode=#{@country}&include=artists"
+        response = make_request(url)
+
+        return nil if response.blank?
+
+        ranked_ids = Array(response.dig('data', 'relationships', 'artists', 'data')).map { |r| r['id'] }
+        return nil if ranked_ids.blank?
+
+        included_by_id = Array(response['included']).select { |r| r['type'] == 'artists' }.index_by { |r| r['id'] }
+        candidates = ranked_ids.filter_map { |id| included_by_id[id] }
+
+        scored = candidates.map { |a| attach_name_score(a) }
+        scored.find { |a| a['name_distance'].to_i >= ARTIST_SIMILARITY_THRESHOLD }
+      end
+
+      def attach_name_score(artist)
+        artist['name_distance'] = artist_distance(artist.dig('attributes', 'name'))
+        artist
+      end
+    end
+  end
+end

--- a/db/migrate/20260503200000_add_external_ids_to_artists.rb
+++ b/db/migrate/20260503200000_add_external_ids_to_artists.rb
@@ -1,0 +1,17 @@
+class AddExternalIdsToArtists < ActiveRecord::Migration[8.1]
+  def change
+    change_table :artists, bulk: true do |t|
+      t.string :id_on_tidal
+      t.string :tidal_artist_url
+      t.string :id_on_deezer
+      t.string :deezer_artist_url
+      t.string :deezer_artwork_url
+      t.string :id_on_itunes
+      t.string :itunes_artist_url
+    end
+
+    add_index :artists, :id_on_tidal
+    add_index :artists, :id_on_deezer
+    add_index :artists, :id_on_itunes
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_03_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_03_200000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -90,11 +90,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_03_120000) do
     t.string "country_of_origin", default: [], array: true
     t.datetime "country_of_origin_checked_at"
     t.datetime "created_at", precision: nil, null: false
+    t.string "deezer_artist_url"
+    t.string "deezer_artwork_url"
     t.string "genres", default: [], array: true
+    t.string "id_on_deezer"
+    t.string "id_on_itunes"
     t.string "id_on_musicbrainz"
     t.string "id_on_spotify"
+    t.string "id_on_tidal"
     t.string "image"
     t.string "instagram_url"
+    t.string "itunes_artist_url"
     t.datetime "lastfm_enriched_at"
     t.bigint "lastfm_listeners"
     t.bigint "lastfm_playcount"
@@ -105,10 +111,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_03_120000) do
     t.string "spotify_artwork_url"
     t.integer "spotify_followers_count"
     t.integer "spotify_popularity"
+    t.string "tidal_artist_url"
     t.datetime "updated_at", precision: nil, null: false
     t.string "website_url"
     t.index ["aka_names"], name: "index_artists_on_aka_names", using: :gin
+    t.index ["id_on_deezer"], name: "index_artists_on_id_on_deezer"
+    t.index ["id_on_itunes"], name: "index_artists_on_id_on_itunes"
     t.index ["id_on_musicbrainz"], name: "index_artists_on_id_on_musicbrainz", unique: true
+    t.index ["id_on_tidal"], name: "index_artists_on_id_on_tidal"
     t.index ["name"], name: "index_artists_on_name_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["slug"], name: "index_artists_on_slug", unique: true
   end

--- a/lib/tasks/enrichment.rake
+++ b/lib/tasks/enrichment.rake
@@ -52,6 +52,17 @@ namespace :enrichment do
     puts "\nDone! Backfilled #{processed} artists, #{failed} did not match a MusicBrainz record."
   end
 
+  desc 'Backfill Tidal/Deezer/iTunes IDs for artists missing one or more'
+  task backfill_artist_external_ids: :environment do
+    scope = Artist.where(id_on_tidal: nil).or(Artist.where(id_on_deezer: nil)).or(Artist.where(id_on_itunes: nil))
+    total = scope.count
+    puts "Enqueueing #{total} artists for external IDs backfill..."
+
+    scope.find_each { |artist| ArtistExternalIdsEnrichmentJob.perform_async(artist.id) }
+
+    puts 'Done.'
+  end
+
   desc 'Backfill Last.fm data for artists and songs'
   task backfill_lastfm: :environment do
     puts 'Enqueueing artists and songs for Last.fm backfill...'

--- a/spec/jobs/artist_external_ids_enrichment_job_spec.rb
+++ b/spec/jobs/artist_external_ids_enrichment_job_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ArtistExternalIdsEnrichmentJob do
+  describe '#perform' do
+    let(:job) { described_class.new }
+
+    context 'when artist exists and is missing IDs' do
+      let(:artist) { create(:artist, name: 'Bruno Mars', id_on_tidal: nil, id_on_deezer: nil, id_on_itunes: nil) }
+
+      before do
+        allow(Tidal::ArtistEnricher).to receive(:new).and_return(instance_double(Tidal::ArtistEnricher, enrich: true))
+        allow(Deezer::ArtistEnricher).to receive(:new).and_return(instance_double(Deezer::ArtistEnricher, enrich: true))
+        allow(Itunes::ArtistEnricher).to receive(:new).and_return(instance_double(Itunes::ArtistEnricher, enrich: true))
+      end
+
+      it 'calls all three enrichers', :aggregate_failures do
+        job.perform(artist.id)
+
+        expect(Tidal::ArtistEnricher).to have_received(:new).with(artist)
+        expect(Deezer::ArtistEnricher).to have_received(:new).with(artist)
+        expect(Itunes::ArtistEnricher).to have_received(:new).with(artist)
+      end
+    end
+
+    context 'when artist already has every external ID' do
+      let(:artist) do
+        create(:artist, name: 'Bruno Mars', id_on_tidal: '3658521', id_on_deezer: '429675', id_on_itunes: '278873078')
+      end
+
+      before do
+        allow(Tidal::ArtistEnricher).to receive(:new)
+        allow(Deezer::ArtistEnricher).to receive(:new)
+        allow(Itunes::ArtistEnricher).to receive(:new)
+        job.perform(artist.id)
+      end
+
+      it 'does not call any enricher', :aggregate_failures do
+        expect(Tidal::ArtistEnricher).not_to have_received(:new)
+        expect(Deezer::ArtistEnricher).not_to have_received(:new)
+        expect(Itunes::ArtistEnricher).not_to have_received(:new)
+      end
+    end
+
+    context 'when artist does not exist' do
+      it 'does not raise an error' do
+        expect { job.perform(999_999) }.not_to raise_error
+      end
+    end
+  end
+
+  describe '.enqueue_all' do
+    let!(:missing_tidal) { create(:artist, name: 'A', id_on_tidal: nil, id_on_deezer: '1', id_on_itunes: '2') }
+    let!(:missing_deezer) { create(:artist, name: 'B', id_on_tidal: '1', id_on_deezer: nil, id_on_itunes: '2') }
+    let!(:missing_itunes) { create(:artist, name: 'C', id_on_tidal: '1', id_on_deezer: '2', id_on_itunes: nil) }
+    let!(:complete) { create(:artist, name: 'D', id_on_tidal: '1', id_on_deezer: '2', id_on_itunes: '3') }
+
+    it 'enqueues only artists missing at least one ID', :aggregate_failures do
+      allow(described_class).to receive(:perform_async)
+
+      described_class.enqueue_all
+
+      expect(described_class).to have_received(:perform_async).with(missing_tidal.id)
+      expect(described_class).to have_received(:perform_async).with(missing_deezer.id)
+      expect(described_class).to have_received(:perform_async).with(missing_itunes.id)
+      expect(described_class).not_to have_received(:perform_async).with(complete.id)
+    end
+  end
+end

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -7,11 +7,17 @@
 #  aka_names_checked_at         :datetime
 #  country_of_origin            :string           default([]), is an Array
 #  country_of_origin_checked_at :datetime
+#  deezer_artist_url            :string
+#  deezer_artwork_url           :string
 #  genres                       :string           default([]), is an Array
+#  id_on_deezer                 :string
+#  id_on_itunes                 :string
 #  id_on_musicbrainz            :string
 #  id_on_spotify                :string
+#  id_on_tidal                  :string
 #  image                        :string
 #  instagram_url                :string
+#  itunes_artist_url            :string
 #  lastfm_enriched_at           :datetime
 #  lastfm_listeners             :bigint
 #  lastfm_playcount             :bigint
@@ -22,6 +28,7 @@
 #  spotify_artwork_url          :string
 #  spotify_followers_count      :integer
 #  spotify_popularity           :integer
+#  tidal_artist_url             :string
 #  website_url                  :string
 #  created_at                   :datetime         not null
 #  updated_at                   :datetime         not null
@@ -29,7 +36,10 @@
 # Indexes
 #
 #  index_artists_on_aka_names          (aka_names) USING gin
+#  index_artists_on_id_on_deezer       (id_on_deezer)
+#  index_artists_on_id_on_itunes       (id_on_itunes)
 #  index_artists_on_id_on_musicbrainz  (id_on_musicbrainz) UNIQUE
+#  index_artists_on_id_on_tidal        (id_on_tidal)
 #  index_artists_on_name_trgm          (name) USING gin
 #  index_artists_on_slug               (slug) UNIQUE
 #

--- a/spec/services/deezer/artist_enricher_spec.rb
+++ b/spec/services/deezer/artist_enricher_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Deezer::ArtistEnricher do
+  subject(:enricher) { described_class.new(artist) }
+
+  let(:artist) { create(:artist, name: 'Bruno Mars', id_on_deezer: nil) }
+
+  describe '#enrich' do
+    context 'when artist is blank' do
+      subject(:enricher) { described_class.new(nil) }
+
+      it 'returns nil' do
+        expect(enricher.enrich).to be_nil
+      end
+    end
+
+    context 'when artist already has id_on_deezer' do
+      let(:artist) { create(:artist, name: 'Bruno Mars', id_on_deezer: '429675') }
+
+      before do
+        allow(Deezer::ArtistFinder::Result).to receive(:new)
+      end
+
+      it 'does not fetch from Deezer' do
+        enricher.enrich
+        expect(Deezer::ArtistFinder::Result).not_to have_received(:new)
+      end
+    end
+
+    context 'when Deezer returns a valid match' do
+      let(:deezer_result) do
+        instance_double(
+          Deezer::ArtistFinder::Result,
+          execute: {},
+          valid_match?: true,
+          id: '429675',
+          deezer_artist_url: 'https://www.deezer.com/artist/429675',
+          deezer_artwork_url: 'https://cdn.example.com/xl.jpg'
+        )
+      end
+
+      before do
+        allow(Deezer::ArtistFinder::Result).to receive(:new).and_return(deezer_result)
+      end
+
+      it 'updates the artist with id_on_deezer, URL, and artwork', :aggregate_failures do
+        enricher.enrich
+        artist.reload
+        expect(artist.id_on_deezer).to eq('429675')
+        expect(artist.deezer_artist_url).to eq('https://www.deezer.com/artist/429675')
+        expect(artist.deezer_artwork_url).to eq('https://cdn.example.com/xl.jpg')
+      end
+    end
+
+    context 'when Deezer returns no valid match' do
+      let(:deezer_result) do
+        instance_double(Deezer::ArtistFinder::Result, execute: nil, valid_match?: false)
+      end
+
+      before do
+        allow(Deezer::ArtistFinder::Result).to receive(:new).and_return(deezer_result)
+      end
+
+      it 'does not update the artist' do
+        enricher.enrich
+        expect(artist.reload.id_on_deezer).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/deezer/artist_finder/result_spec.rb
+++ b/spec/services/deezer/artist_finder/result_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Deezer::ArtistFinder::Result do
+  subject(:result) { described_class.new(name: name) }
+
+  let(:name) { 'Bruno Mars' }
+
+  def deezer_response(artists)
+    { 'data' => artists }
+  end
+
+  def stub_search(body)
+    stub_request(:get, %r{api\.deezer\.com/search/artist}).to_return(
+      status: 200,
+      body: body.to_json,
+      headers: { 'Content-Type' => 'application/json' }
+    )
+  end
+
+  def artist_payload(id:, name:, link: nil, picture_xl: nil)
+    {
+      'id' => id,
+      'name' => name,
+      'link' => link || "https://www.deezer.com/artist/#{id}",
+      'picture_xl' => picture_xl || "https://cdn.example.com/#{id}/xl.jpg"
+    }
+  end
+
+  describe '#execute' do
+    context 'when the first result matches the search name' do
+      let(:artists) do
+        [
+          artist_payload(id: 429_675, name: 'Bruno Mars'),
+          artist_payload(id: 372_058_021, name: 'Bruno Mars & Rose'),
+          artist_payload(id: 1_445_229, name: 'Bruno Mars Cover Band')
+        ]
+      end
+
+      before do
+        stub_search(deezer_response(artists))
+        result.execute
+      end
+
+      it 'picks the exact-name match' do
+        expect(result.id).to eq('429675')
+      end
+
+      it 'exposes the artist URL' do
+        expect(result.deezer_artist_url).to eq('https://www.deezer.com/artist/429675')
+      end
+
+      it 'exposes the artwork URL' do
+        expect(result.deezer_artwork_url).to eq('https://cdn.example.com/429675/xl.jpg')
+      end
+
+      it 'is a valid match' do
+        expect(result.valid_match?).to be true
+      end
+    end
+
+    context 'when the first result fails the threshold but a later one passes' do
+      let(:artists) do
+        [
+          artist_payload(id: 1, name: 'Completely Different'),
+          artist_payload(id: 429_675, name: 'Bruno Mars')
+        ]
+      end
+
+      before do
+        stub_search(deezer_response(artists))
+        result.execute
+      end
+
+      it 'falls back to the next valid candidate' do
+        expect(result.id).to eq('429675')
+      end
+    end
+
+    context 'when no candidate passes the threshold' do
+      let(:artists) do
+        [artist_payload(id: 1, name: 'Completely Different')]
+      end
+
+      before do
+        stub_search(deezer_response(artists))
+        result.execute
+      end
+
+      it 'returns nil' do
+        expect(result.artist).to be_nil
+      end
+    end
+
+    context 'when Deezer returns an error response' do
+      before do
+        stub_search('error' => { 'type' => 'OAuthException' })
+        result.execute
+      end
+
+      it 'returns nil' do
+        expect(result.artist).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/itunes/artist_enricher_spec.rb
+++ b/spec/services/itunes/artist_enricher_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Itunes::ArtistEnricher do
+  subject(:enricher) { described_class.new(artist) }
+
+  let(:artist) { create(:artist, name: 'Bruno Mars', id_on_itunes: nil) }
+
+  describe '#enrich' do
+    context 'when artist is blank' do
+      subject(:enricher) { described_class.new(nil) }
+
+      it 'returns nil' do
+        expect(enricher.enrich).to be_nil
+      end
+    end
+
+    context 'when artist already has id_on_itunes' do
+      let(:artist) { create(:artist, name: 'Bruno Mars', id_on_itunes: '278873078') }
+
+      before do
+        allow(Itunes::ArtistFinder::Result).to receive(:new)
+      end
+
+      it 'does not fetch from iTunes' do
+        enricher.enrich
+        expect(Itunes::ArtistFinder::Result).not_to have_received(:new)
+      end
+    end
+
+    context 'when iTunes returns a valid match' do
+      let(:itunes_result) do
+        instance_double(
+          Itunes::ArtistFinder::Result,
+          execute: {},
+          valid_match?: true,
+          id: '278873078',
+          itunes_artist_url: 'https://music.apple.com/nl/artist/bruno-mars/278873078'
+        )
+      end
+
+      before do
+        allow(Itunes::ArtistFinder::Result).to receive(:new).and_return(itunes_result)
+      end
+
+      it 'updates the artist with id_on_itunes and URL', :aggregate_failures do
+        enricher.enrich
+        artist.reload
+        expect(artist.id_on_itunes).to eq('278873078')
+        expect(artist.itunes_artist_url).to eq('https://music.apple.com/nl/artist/bruno-mars/278873078')
+      end
+    end
+
+    context 'when iTunes returns no valid match' do
+      let(:itunes_result) do
+        instance_double(Itunes::ArtistFinder::Result, execute: nil, valid_match?: false)
+      end
+
+      before do
+        allow(Itunes::ArtistFinder::Result).to receive(:new).and_return(itunes_result)
+      end
+
+      it 'does not update the artist' do
+        enricher.enrich
+        expect(artist.reload.id_on_itunes).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/itunes/artist_finder/result_spec.rb
+++ b/spec/services/itunes/artist_finder/result_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Itunes::ArtistFinder::Result do
+  subject(:result) { described_class.new(name: name) }
+
+  let(:name) { 'Bruno Mars' }
+
+  def itunes_response(artists)
+    { 'results' => artists }
+  end
+
+  def stub_search(body)
+    stub_request(:get, %r{itunes\.apple\.com/search}).to_return(
+      status: 200,
+      body: body.to_json,
+      headers: { 'Content-Type' => 'application/json' }
+    )
+  end
+
+  def artist_payload(artist_id:, artist_name:, artist_link_url: nil)
+    {
+      'wrapperType' => 'artist',
+      'artistType' => 'Artist',
+      'artistId' => artist_id,
+      'artistName' => artist_name,
+      'artistLinkUrl' => artist_link_url || "https://music.apple.com/nl/artist/#{artist_id}"
+    }
+  end
+
+  describe '#execute' do
+    context 'when the first result matches the search name' do
+      let(:artists) do
+        [
+          artist_payload(artist_id: 278_873_078, artist_name: 'Bruno Mars'),
+          artist_payload(artist_id: 1_556_097_160, artist_name: 'Silk Sonic'),
+          artist_payload(artist_id: 2_307_416, artist_name: 'Thirty Seconds to Mars')
+        ]
+      end
+
+      before do
+        stub_search(itunes_response(artists))
+        result.execute
+      end
+
+      it 'picks the exact-name match' do
+        expect(result.id).to eq('278873078')
+      end
+
+      it 'exposes the artist URL' do
+        expect(result.itunes_artist_url).to eq('https://music.apple.com/nl/artist/278873078')
+      end
+
+      it 'is a valid match' do
+        expect(result.valid_match?).to be true
+      end
+    end
+
+    context 'when no candidate passes the threshold' do
+      let(:artists) do
+        [
+          artist_payload(artist_id: 1, artist_name: 'Silk Sonic'),
+          artist_payload(artist_id: 2, artist_name: 'Thirty Seconds to Mars')
+        ]
+      end
+
+      before do
+        stub_search(itunes_response(artists))
+        result.execute
+      end
+
+      it 'returns nil' do
+        expect(result.artist).to be_nil
+      end
+    end
+
+    context 'when iTunes returns no results' do
+      before do
+        stub_search('results' => [])
+        result.execute
+      end
+
+      it 'returns nil' do
+        expect(result.artist).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/song_importer_edge_cases_spec.rb
+++ b/spec/services/song_importer_edge_cases_spec.rb
@@ -512,6 +512,7 @@ describe SongImporter do
         allow(Broadcaster).to receive(:song_confirmed)
         allow(MusicProfileJob).to receive(:perform_async)
         allow(SongExternalIdsEnrichmentJob).to receive(:perform_async)
+        allow(ArtistExternalIdsEnrichmentJob).to receive(:perform_async)
       end
 
       it 'confirms the existing draft air play' do
@@ -529,6 +530,7 @@ describe SongImporter do
         allow(Broadcaster).to receive(:song_confirmed)
         allow(MusicProfileJob).to receive(:perform_async)
         allow(SongExternalIdsEnrichmentJob).to receive(:perform_async)
+        allow(ArtistExternalIdsEnrichmentJob).to receive(:perform_async)
       end
 
       it 'creates a confirmed air play' do
@@ -552,6 +554,7 @@ describe SongImporter do
         allow(Broadcaster).to receive(:song_draft_created)
         allow(MusicProfileJob).to receive(:perform_async)
         allow(SongExternalIdsEnrichmentJob).to receive(:perform_async)
+        allow(ArtistExternalIdsEnrichmentJob).to receive(:perform_async)
       end
 
       it 'creates a draft air play' do
@@ -569,6 +572,7 @@ describe SongImporter do
       importer.instance_variable_set(:@artists, [artist])
       allow(MusicProfileJob).to receive(:perform_async)
       allow(SongExternalIdsEnrichmentJob).to receive(:perform_async)
+      allow(ArtistExternalIdsEnrichmentJob).to receive(:perform_async)
     end
 
     it 'enqueues MusicProfileJob and SongExternalIdsEnrichmentJob', :aggregate_failures do

--- a/spec/services/tidal/artist_enricher_spec.rb
+++ b/spec/services/tidal/artist_enricher_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Tidal::ArtistEnricher do
+  subject(:enricher) { described_class.new(artist) }
+
+  let(:artist) { create(:artist, name: 'Bruno Mars', id_on_tidal: nil) }
+
+  describe '#enrich' do
+    context 'when artist is blank' do
+      subject(:enricher) { described_class.new(nil) }
+
+      it 'returns nil' do
+        expect(enricher.enrich).to be_nil
+      end
+    end
+
+    context 'when artist already has id_on_tidal' do
+      let(:artist) { create(:artist, name: 'Bruno Mars', id_on_tidal: '12345') }
+
+      before do
+        allow(Tidal::ArtistFinder::Result).to receive(:new)
+      end
+
+      it 'does not fetch from Tidal' do
+        enricher.enrich
+        expect(Tidal::ArtistFinder::Result).not_to have_received(:new)
+      end
+    end
+
+    context 'when Tidal returns a valid match' do
+      let(:tidal_result) do
+        instance_double(
+          Tidal::ArtistFinder::Result,
+          execute: {},
+          valid_match?: true,
+          id: '3658521',
+          tidal_artist_url: 'https://tidal.com/browse/artist/3658521'
+        )
+      end
+
+      before do
+        allow(Tidal::ArtistFinder::Result).to receive(:new).and_return(tidal_result)
+      end
+
+      it 'updates the artist with id_on_tidal and the URL', :aggregate_failures do
+        enricher.enrich
+        artist.reload
+        expect(artist.id_on_tidal).to eq('3658521')
+        expect(artist.tidal_artist_url).to eq('https://tidal.com/browse/artist/3658521')
+      end
+    end
+
+    context 'when Tidal returns no valid match' do
+      let(:tidal_result) do
+        instance_double(Tidal::ArtistFinder::Result, execute: nil, valid_match?: false)
+      end
+
+      before do
+        allow(Tidal::ArtistFinder::Result).to receive(:new).and_return(tidal_result)
+      end
+
+      it 'does not update the artist' do
+        enricher.enrich
+        expect(artist.reload.id_on_tidal).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/tidal/artist_finder/result_spec.rb
+++ b/spec/services/tidal/artist_finder/result_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Tidal::ArtistFinder::Result do
+  subject(:result) { described_class.new(name: name) }
+
+  let(:name) { 'Bruno Mars' }
+
+  before do
+    allow(Tidal::Token).to receive(:new).and_return(instance_double(Tidal::Token, token: 'fake_token'))
+  end
+
+  def search_response(ranked_ids:, included:)
+    {
+      'data' => {
+        'id' => 'q', 'type' => 'searchResults',
+        'attributes' => { 'trackingId' => 'abc' },
+        'relationships' => { 'artists' => { 'data' => ranked_ids.map { |id| { 'id' => id, 'type' => 'artists' } } } }
+      },
+      'included' => included
+    }
+  end
+
+  def stub_search(body)
+    stub_request(:get, %r{openapi\.tidal\.com/v2/searchResults}).to_return(
+      status: 200,
+      body: body.to_json,
+      headers: { 'Content-Type' => 'application/vnd.api+json' }
+    )
+  end
+
+  def artist_resource(id:, name:, popularity: 0.5)
+    {
+      'id' => id, 'type' => 'artists',
+      'attributes' => { 'name' => name, 'popularity' => popularity }
+    }
+  end
+
+  describe '#execute' do
+    context 'when the top-ranked artist matches the search name' do
+      let(:included) do
+        [
+          artist_resource(id: '11002332', name: 'Bruno Mari', popularity: 0.05),
+          artist_resource(id: '3658521', name: 'Bruno Mars', popularity: 0.97),
+          artist_resource(id: '1565', name: 'Maroon 5', popularity: 0.92)
+        ]
+      end
+
+      before do
+        stub_search(search_response(ranked_ids: %w[3658521 11002332 1565], included: included))
+        result.execute
+      end
+
+      it 'picks the top-ranked artist whose name passes the threshold' do
+        expect(result.id).to eq('3658521')
+      end
+
+      it 'exposes the matched artist name' do
+        expect(result.name).to eq('Bruno Mars')
+      end
+
+      it 'builds the canonical artist URL from the id' do
+        expect(result.tidal_artist_url).to eq('https://tidal.com/browse/artist/3658521')
+      end
+
+      it 'is a valid match' do
+        expect(result.valid_match?).to be true
+      end
+    end
+
+    context 'when the top-ranked artist fails the threshold but a later one passes' do
+      let(:included) do
+        [
+          artist_resource(id: '1565', name: 'Maroon 5', popularity: 0.92),
+          artist_resource(id: '3658521', name: 'Bruno Mars', popularity: 0.97)
+        ]
+      end
+
+      before do
+        stub_search(search_response(ranked_ids: %w[1565 3658521], included: included))
+        result.execute
+      end
+
+      it 'walks past the low-similarity top result and picks the next valid one' do
+        expect(result.id).to eq('3658521')
+      end
+    end
+
+    context 'when no candidate passes the name threshold' do
+      let(:included) do
+        [
+          artist_resource(id: 'wrong-1', name: 'Completely Different', popularity: 0.5),
+          artist_resource(id: 'wrong-2', name: 'Another Mismatch', popularity: 0.3)
+        ]
+      end
+
+      before do
+        stub_search(search_response(ranked_ids: %w[wrong-1 wrong-2], included: included))
+        result.execute
+      end
+
+      it 'returns nil for artist' do
+        expect(result.artist).to be_nil
+      end
+
+      it 'is not a valid match' do
+        expect(result.valid_match?).to be false
+      end
+    end
+
+    context 'when search returns no artists' do
+      before do
+        stub_search('data' => { 'id' => 'q', 'type' => 'searchResults', 'attributes' => {} }, 'included' => [])
+        result.execute
+      end
+
+      it 'returns nil for id' do
+        expect(result.id).to be_nil
+      end
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -76,6 +76,13 @@ RSpec.configure do |config|
                   lastfm_listeners: { type: :integer, nullable: true },
                   lastfm_playcount: { type: :integer, nullable: true },
                   lastfm_tags: { type: :array, items: { type: :string }, nullable: true },
+                  id_on_tidal: { type: :string, nullable: true },
+                  tidal_artist_url: { type: :string, nullable: true },
+                  id_on_deezer: { type: :string, nullable: true },
+                  deezer_artist_url: { type: :string, nullable: true },
+                  deezer_artwork_url: { type: :string, nullable: true },
+                  id_on_itunes: { type: :string, nullable: true },
+                  itunes_artist_url: { type: :string, nullable: true },
                   counter: { type: :integer, nullable: true }
                 }
               }

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -3593,6 +3593,27 @@ components:
               items:
                 type: string
               nullable: true
+            id_on_tidal:
+              type: string
+              nullable: true
+            tidal_artist_url:
+              type: string
+              nullable: true
+            id_on_deezer:
+              type: string
+              nullable: true
+            deezer_artist_url:
+              type: string
+              nullable: true
+            deezer_artwork_url:
+              type: string
+              nullable: true
+            id_on_itunes:
+              type: string
+              nullable: true
+            itunes_artist_url:
+              type: string
+              nullable: true
             counter:
               type: integer
               nullable: true


### PR DESCRIPTION
## Summary
- Adds `id_on_tidal`/`id_on_deezer`/`id_on_itunes` (+ provider URLs and Deezer artwork) to `artists`, mirroring the existing song-side external ID enrichment.
- Three new `ArtistFinder::Result` services (name search + Jaro-Winkler validation, threshold 80) and matching `ArtistEnricher` services.
- New `ArtistExternalIdsEnrichmentJob` orchestrates all three providers, enqueued at the end of every song import for the song's artists. Backfill rake: `enrichment:backfill_artist_external_ids`.

## Notes
- Tidal `/v2/searchResults?include=artists` returns search ranking only via `data.relationships.artists.data` — `included` is unordered. The finder walks the ranked list and resolves each ID from `included` (documented inline).
- Endpoints were live-tested against all three APIs before any parsing was written; smoke-tested end-to-end against a real Artist record (Spin Doctors → Tidal/Deezer/iTunes IDs all resolved).
- `Artist.most_played`, `ArtistSerializer`, and the `Artist` swagger schema were updated to expose the new fields; `swagger/v1/swagger.yaml` regenerated.

## Test plan
- [ ] CI passes (rspec, rubocop, brakeman, bundler-audit, swagger drift check)
- [ ] After merge: run `bundle exec rake enrichment:backfill_artist_external_ids` to backfill existing artists
- [ ] Spot-check a few enriched artists in the API response to confirm the new fields appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)