### PR TITLE
Normalized-title dedupe column on songs (defense in depth for #2106)

### DIFF
--- a/app/models/concerns/title_normalizable.rb
+++ b/app/models/concerns/title_normalizable.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Adds a `normalized_title` mirror of `title`: lowercased, diacritic-stripped,
+# and reduced to alphanumerics only. Used by the import dedupe path so spacing,
+# case, and punctuation variants of the same title (e.g., "Zo Maar" vs
+# "Zomaar", "Don't" vs "Dont") collapse to the same key.
+module TitleNormalizable
+  extend ActiveSupport::Concern
+
+  included do
+    before_save :set_normalized_title, if: :will_save_change_to_title?
+  end
+
+  class_methods do
+    def normalize_title(raw_title)
+      return nil if raw_title.blank?
+
+      raw_title.unicode_normalize(:nfkd).gsub(/\p{Mn}/, '').downcase.gsub(/[^a-z0-9]/, '').presence
+    end
+  end
+
+  private
+
+  def set_normalized_title
+    self.normalized_title = self.class.normalize_title(title)
+  end
+end

--- a/app/models/concerns/title_normalizable.rb
+++ b/app/models/concerns/title_normalizable.rb
@@ -11,17 +11,21 @@ module TitleNormalizable
     before_save :set_normalized_title, if: :will_save_change_to_title?
   end
 
-  class_methods do
-    def normalize_title(raw_title)
-      return nil if raw_title.blank?
+  def self.normalize(raw_title)
+    return nil if raw_title.blank?
 
-      raw_title.unicode_normalize(:nfkd).gsub(/\p{Mn}/, '').downcase.gsub(/[^a-z0-9]/, '').presence
-    end
+    raw_title.unicode_normalize(:nfkd).gsub(/\p{Mn}/, '')
+      .downcase.gsub(/[^a-z0-9]/, '')
+      .presence
   end
 
   private
 
   def set_normalized_title
-    self.normalized_title = self.class.normalize_title(title)
+    self.normalized_title = normalize_title
+  end
+
+  def normalize_title
+    TitleNormalizable.normalize(title)
   end
 end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -27,6 +27,7 @@
 #  lastfm_listeners       :bigint
 #  lastfm_playcount       :bigint
 #  lastfm_tags            :string           default([]), is an Array
+#  normalized_title       :string
 #  popularity             :integer
 #  release_date           :date
 #  release_date_precision :string
@@ -48,6 +49,7 @@
 #  index_songs_on_id_on_deezer           (id_on_deezer)
 #  index_songs_on_id_on_itunes           (id_on_itunes)
 #  index_songs_on_id_on_tidal            (id_on_tidal)
+#  index_songs_on_normalized_title       (normalized_title)
 #  index_songs_on_release_date           (release_date)
 #  index_songs_on_search_text_trgm       (search_text) USING gin
 #  index_songs_on_slug                   (slug) UNIQUE
@@ -61,6 +63,7 @@ class Song < ApplicationRecord
   include TimeAnalyticsConcern
   include SongSearchConcern
   include Sluggable
+  include TitleNormalizable
 
   pg_search_scope :search_by_text,
                   against: :search_text,

--- a/app/serializers/song_serializer.rb
+++ b/app/serializers/song_serializer.rb
@@ -27,6 +27,7 @@
 #  lastfm_listeners       :bigint
 #  lastfm_playcount       :bigint
 #  lastfm_tags            :string           default([]), is an Array
+#  normalized_title       :string
 #  popularity             :integer
 #  release_date           :date
 #  release_date_precision :string
@@ -48,6 +49,7 @@
 #  index_songs_on_id_on_deezer           (id_on_deezer)
 #  index_songs_on_id_on_itunes           (id_on_itunes)
 #  index_songs_on_id_on_tidal            (id_on_tidal)
+#  index_songs_on_normalized_title       (normalized_title)
 #  index_songs_on_release_date           (release_date)
 #  index_songs_on_search_text_trgm       (search_text) USING gin
 #  index_songs_on_slug                   (slug) UNIQUE

--- a/app/services/track_extractor/song_extractor.rb
+++ b/app/services/track_extractor/song_extractor.rb
@@ -85,6 +85,8 @@ class TrackExtractor::SongExtractor < TrackExtractor
   def find_or_create_by_title
     result = if song_by_artists_and_title.present?
                song_by_artists_and_title
+             elsif song_by_artists_and_normalized_title.present?
+               song_by_artists_and_normalized_title
              elsif find_by_fuzzy_search.present?
                find_by_fuzzy_search
              elsif @artists.blank?
@@ -102,6 +104,17 @@ class TrackExtractor::SongExtractor < TrackExtractor
     @song_by_artists_and_title ||= Song.joins(:artists)
                                      .where(artists: @artists)
                                      .where('lower(title) LIKE ?', title.downcase)
+  end
+
+  # Indexed equality lookup against `normalized_title` (whitespace-, case-, and
+  # diacritic-insensitive). Catches scrape variants the exact match misses,
+  # e.g., "Ik Bel Je Zo Maar Even Op" vs "Ik Bel Je Zomaar Even Op", before
+  # falling through to the more expensive trigram fuzzy search.
+  def song_by_artists_and_normalized_title
+    @song_by_artists_and_normalized_title ||= begin
+      key = Song.normalize_title(title)
+      key.present? ? Song.joins(:artists).where(artists: @artists).where(normalized_title: key) : Song.none
+    end
   end
 
   def find_by_fuzzy_search

--- a/app/services/track_extractor/song_extractor.rb
+++ b/app/services/track_extractor/song_extractor.rb
@@ -112,7 +112,7 @@ class TrackExtractor::SongExtractor < TrackExtractor
   # falling through to the more expensive trigram fuzzy search.
   def song_by_artists_and_normalized_title
     @song_by_artists_and_normalized_title ||= begin
-      key = Song.normalize_title(title)
+      key = TitleNormalizable.normalize(title)
       key.present? ? Song.joins(:artists).where(artists: @artists).where(normalized_title: key) : Song.none
     end
   end

--- a/db/migrate/20260504200000_add_normalized_title_to_songs.rb
+++ b/db/migrate/20260504200000_add_normalized_title_to_songs.rb
@@ -1,0 +1,6 @@
+class AddNormalizedTitleToSongs < ActiveRecord::Migration[8.1]
+  def change
+    add_column :songs, :normalized_title, :string
+    add_index :songs, :normalized_title
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_03_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_04_200000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -268,6 +268,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_03_200000) do
     t.bigint "lastfm_listeners"
     t.bigint "lastfm_playcount"
     t.string "lastfm_tags", default: [], array: true
+    t.string "normalized_title"
     t.integer "popularity"
     t.date "release_date"
     t.string "release_date_precision"
@@ -285,6 +286,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_03_200000) do
     t.index ["id_on_deezer"], name: "index_songs_on_id_on_deezer"
     t.index ["id_on_itunes"], name: "index_songs_on_id_on_itunes"
     t.index ["id_on_tidal"], name: "index_songs_on_id_on_tidal"
+    t.index ["normalized_title"], name: "index_songs_on_normalized_title"
     t.index ["release_date"], name: "index_songs_on_release_date"
     t.index ["search_text"], name: "index_songs_on_search_text_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["slug"], name: "index_songs_on_slug", unique: true

--- a/lib/tasks/normalized_title_backfill.rake
+++ b/lib/tasks/normalized_title_backfill.rake
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+namespace :normalized_title do
+  desc 'Backfill normalized_title for all songs without one'
+  task backfill: :environment do
+    scope = Song.where(normalized_title: nil).where.not(title: [nil, ''])
+    total = scope.count
+    puts "Backfilling normalized_title for #{total} songs..."
+
+    processed = 0
+    scope.find_each(batch_size: 1000) do |song|
+      song.update_column(:normalized_title, Song.normalize_title(song.title)) # rubocop:disable Rails/SkipsModelValidations
+      processed += 1
+      print "\rProcessed #{processed}/#{total}..." if (processed % 1000).zero?
+    end
+
+    puts "\nDone! Backfilled #{processed} song normalized_titles."
+  end
+end

--- a/lib/tasks/normalized_title_backfill.rake
+++ b/lib/tasks/normalized_title_backfill.rake
@@ -9,7 +9,7 @@ namespace :normalized_title do
 
     processed = 0
     scope.find_each(batch_size: 1000) do |song|
-      song.update_column(:normalized_title, Song.normalize_title(song.title)) # rubocop:disable Rails/SkipsModelValidations
+      song.update_column(:normalized_title, TitleNormalizable.normalize(song.title)) # rubocop:disable Rails/SkipsModelValidations
       processed += 1
       print "\rProcessed #{processed}/#{total}..." if (processed % 1000).zero?
     end

--- a/spec/models/song_spec.rb
+++ b/spec/models/song_spec.rb
@@ -27,6 +27,7 @@
 #  lastfm_listeners       :bigint
 #  lastfm_playcount       :bigint
 #  lastfm_tags            :string           default([]), is an Array
+#  normalized_title       :string
 #  popularity             :integer
 #  release_date           :date
 #  release_date_precision :string
@@ -48,6 +49,7 @@
 #  index_songs_on_id_on_deezer           (id_on_deezer)
 #  index_songs_on_id_on_itunes           (id_on_itunes)
 #  index_songs_on_id_on_tidal            (id_on_tidal)
+#  index_songs_on_normalized_title       (normalized_title)
 #  index_songs_on_release_date           (release_date)
 #  index_songs_on_search_text_trgm       (search_text) USING gin
 #  index_songs_on_slug                   (slug) UNIQUE
@@ -454,6 +456,62 @@ describe Song do
 
     it 'updates search_text before song creation' do
       expect(song.reload.search_text).to eq('Ed Sheeran Shape of You')
+    end
+  end
+
+  describe '.normalize_title' do
+    it 'returns nil for blank input' do
+      expect(Song.normalize_title('')).to be_nil
+    end
+
+    it 'returns nil for nil input' do
+      expect(Song.normalize_title(nil)).to be_nil
+    end
+
+    it 'collapses spacing variants to the same key' do
+      expect(Song.normalize_title('Ik Bel Je Zo Maar Even Op'))
+        .to eq(Song.normalize_title('Ik Bel Je Zomaar Even Op'))
+    end
+
+    it 'is case-insensitive' do
+      expect(Song.normalize_title('Hello World')).to eq(Song.normalize_title('HELLO world'))
+    end
+
+    it 'strips diacritics' do
+      expect(Song.normalize_title('Beyoncé')).to eq(Song.normalize_title('Beyonce'))
+    end
+
+    it 'strips punctuation so smart-quote variants collapse', :aggregate_failures do
+      expect(Song.normalize_title("Don't Stop Me Now")).to eq('dontstopmenow')
+      expect(Song.normalize_title('Don’t Stop Me Now')).to eq('dontstopmenow')
+    end
+
+    it 'preserves digits' do
+      expect(Song.normalize_title('99 Luftballons')).to eq('99luftballons')
+    end
+
+    it 'returns nil when the input contains only punctuation/whitespace' do
+      expect(Song.normalize_title('  --!!  ')).to be_nil
+    end
+  end
+
+  describe '#set_normalized_title callback' do
+    let(:artist) { create(:artist, name: 'Gordon') }
+
+    it 'populates normalized_title on create' do
+      song = create(:song, title: 'Ik Bel Je Zomaar Even Op', artists: [artist])
+      expect(song.reload.normalized_title).to eq('ikbeljezomaarevenop')
+    end
+
+    it 'recomputes normalized_title when the title changes' do
+      song = create(:song, title: 'Ik Bel Je Zomaar Even Op', artists: [artist])
+      song.update!(title: 'Ik Bel Je Zo Maar Even Op')
+      expect(song.reload.normalized_title).to eq('ikbeljezomaarevenop')
+    end
+
+    it 'leaves normalized_title untouched when an unrelated attribute changes' do
+      song = create(:song, title: 'Hello World', artists: [artist])
+      expect { song.update!(popularity: 50) }.not_to(change { song.reload.normalized_title })
     end
   end
 

--- a/spec/models/song_spec.rb
+++ b/spec/models/song_spec.rb
@@ -459,39 +459,39 @@ describe Song do
     end
   end
 
-  describe '.normalize_title' do
+  describe TitleNormalizable, '.normalize' do
     it 'returns nil for blank input' do
-      expect(Song.normalize_title('')).to be_nil
+      expect(TitleNormalizable.normalize('')).to be_nil
     end
 
     it 'returns nil for nil input' do
-      expect(Song.normalize_title(nil)).to be_nil
+      expect(TitleNormalizable.normalize(nil)).to be_nil
     end
 
     it 'collapses spacing variants to the same key' do
-      expect(Song.normalize_title('Ik Bel Je Zo Maar Even Op'))
-        .to eq(Song.normalize_title('Ik Bel Je Zomaar Even Op'))
+      expect(TitleNormalizable.normalize('Ik Bel Je Zo Maar Even Op'))
+        .to eq(TitleNormalizable.normalize('Ik Bel Je Zomaar Even Op'))
     end
 
     it 'is case-insensitive' do
-      expect(Song.normalize_title('Hello World')).to eq(Song.normalize_title('HELLO world'))
+      expect(TitleNormalizable.normalize('Hello World')).to eq(TitleNormalizable.normalize('HELLO world'))
     end
 
     it 'strips diacritics' do
-      expect(Song.normalize_title('Beyoncé')).to eq(Song.normalize_title('Beyonce'))
+      expect(TitleNormalizable.normalize('Beyoncé')).to eq(TitleNormalizable.normalize('Beyonce'))
     end
 
     it 'strips punctuation so smart-quote variants collapse', :aggregate_failures do
-      expect(Song.normalize_title("Don't Stop Me Now")).to eq('dontstopmenow')
-      expect(Song.normalize_title('Don’t Stop Me Now')).to eq('dontstopmenow')
+      expect(TitleNormalizable.normalize("Don't Stop Me Now")).to eq('dontstopmenow')
+      expect(TitleNormalizable.normalize('Don’t Stop Me Now')).to eq('dontstopmenow')
     end
 
     it 'preserves digits' do
-      expect(Song.normalize_title('99 Luftballons')).to eq('99luftballons')
+      expect(TitleNormalizable.normalize('99 Luftballons')).to eq('99luftballons')
     end
 
     it 'returns nil when the input contains only punctuation/whitespace' do
-      expect(Song.normalize_title('  --!!  ')).to be_nil
+      expect(TitleNormalizable.normalize('  --!!  ')).to be_nil
     end
   end
 

--- a/spec/services/track_extractor/song_extractor_spec.rb
+++ b/spec/services/track_extractor/song_extractor_spec.rb
@@ -423,6 +423,33 @@ describe TrackExtractor::SongExtractor do
       end
     end
 
+    context 'when an existing song matches only after title normalization' do
+      let(:track) { nil }
+      let(:played_song) do
+        OpenStruct.new(
+          title: 'Ik Bel Je Zo Maar Even Op',
+          artist_name: artist.name,
+          spotify_url: nil,
+          isrc_code: nil
+        )
+      end
+
+      let!(:existing_song) do
+        create(:song,
+               title: 'Ik Bel Je Zomaar Even Op',
+               id_on_spotify: nil,
+               artists: [artist])
+      end
+
+      it 'finds the existing song instead of creating a duplicate' do
+        expect(song).to eq(existing_song)
+      end
+
+      it 'does not create a new song' do
+        expect { song }.not_to change(Song, :count)
+      end
+    end
+
     context 'when exact title match takes precedence over fuzzy match' do
       let(:track) do
         OpenStruct.new(


### PR DESCRIPTION
## Summary

- Adds an indexed `normalized_title` column on `songs`: lowercased, diacritic-stripped, alphanumerics only. Populated automatically by a `before_save` callback in a new `TitleNormalizable` concern.
- `SongExtractor#find_or_create_by_title` consults it as step 1.5 — between the exact-title match and the trigram fuzzy search — so spacing, case, and punctuation variants of the same title (\"Zo Maar\" vs \"Zomaar\", \"Don't\" vs \"Dont\", \"Beyoncé\" vs \"Beyonce\") collapse to the same key.
- Defense in depth alongside #2107: even when all three external lookups (Spotify / Deezer / iTunes) miss or are unavailable, we recognize an existing song by its normalized form instead of creating a duplicate. Closes the local-dedupe half of #2106.
- Logic lives in `app/models/concerns/title_normalizable.rb` — Song class doesn't grow past its existing rubocop limit.

## Deploy

- Migration `20260504200000_add_normalized_title_to_songs` adds the column + index. Cheap; no backfill in the migration.
- After deploy, run `bundle exec rake normalized_title:backfill` to populate existing rows. Iterates with `find_each(batch_size: 1000)` and uses `update_column` (intentional callback bypass; matches `hit_potential.rake` precedent).
- Existing duplicate songs already in the DB are unaffected by this PR. Manual cleanup of song 197898 from #2106 is still pending and tracked separately.

## Test plan

- [x] `bundle exec rspec spec/models/song_spec.rb spec/services/track_extractor/song_extractor_spec.rb spec/services/song_importer/` — 223 examples, 0 failures
- [x] `bundle exec rubocop` on the 7 changed files — no offenses
- [x] CI green
- [x] After merge: run `rake normalized_title:backfill` in production
- [ ] After backfill: monitor SongImportLog for any imports that hit step 1.5 (existing exact match miss but normalized hit) — should be a handful per day initially, decreasing over time

🤖 Generated with [Claude Code](https://claude.com/claude-code)