### PR TITLE
Stop SongImportLog rows from getting stuck in pending

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ bundle exec rake data_repair:find_contaminated_isrcs[limit]    # Dry run: find s
 bundle exec rake data_repair:fix_contaminated_isrcs[limit]     # Fix songs with cross-contaminated ISRCs
 bundle exec rake data_repair:rollback_import_log[log_id]       # Dry run: preview rollback of a single SongImportLog
 bundle exec rake data_repair:rollback_import_log[log_id,apply] # Apply: destroy airplay, destroy song if orphaned, mark log failed
+bundle exec rake data_repair:find_stuck_pending_logs[limit]    # Dry run: detect SongImportLogs stuck in pending status
+bundle exec rake data_repair:fix_stuck_pending_logs[limit]     # Recover stuck pending logs by linking/creating airplays
 bundle exec rake optimization:vacuum                           # PostgreSQL VACUUM FULL ANALYZE
 
 # Hit Potential
@@ -90,6 +92,7 @@ The app uses service objects extensively in `app/services/`:
 - `DuplicateSongMerger` - Finds and merges duplicate songs via Spotify ID or fuzzy title matching (Jaro-Winkler, threshold: 92)
 - `MismatchedAirplayRepair` - Detects and fixes airplays linked to wrong songs via two detectors: (1) title mismatch — import log title vs linked song title (Jaro-Winkler < 70%); (2) spotify_track_id mismatch — the log's Spotify ID points to a different canonical song than the one linked. Reassigns airplays to the canonical song (found by Spotify track ID, exact match, or newly created).
 - `SongImportLogRollback` - Rolls back a single `SongImportLog`: destroys the linked airplay, destroys the linked song if no other airplays reference it, marks the log `failed` with a rollback reason. Guards against orphaning charts (skips song deletion if chart positions exist) and preserves songs played on other stations.
+- `StuckPendingLogRecovery` - Recovers `SongImportLog` rows stuck in `pending` status (jobs killed mid-flight before reaching a terminal status). For each stuck log with a `spotify_track_id`: resolves the canonical Song (by Spotify ID, then exact artist+title, then create), reuses an existing AirPlay at `(radio_station, song, broadcasted_at)` if one was created before the interruption, otherwise creates one, and marks the log `success`. Skips logs without `spotify_track_id` and logs younger than `min_age` (default 10 minutes).
 - `HitPotentialCalculator` - Predicts song hit potential (0-100) using multi-signal scoring: audio features (50%), artist popularity (20%), engagement metrics (15%), release recency (15%)
 - `SoundProfileGenerator` - Generates per-station sound profiles with audio feature averages, top genres/tags, release decade distribution, and bilingual descriptions (EN/NL). Uses song-count-weighted percentiles and peak decade detection (≥15% threshold) for accurate era descriptions instead of naive min/max year ranges
 - `NaturalLanguageSearch` - Translates free-text queries (e.g., "upbeat Dutch songs on Radio 538 last week") into structured filters via `Llm::QueryTranslator`, then applies faceted search. Supports mood-based filtering using Spotify audio feature ranges, result limiting ("top 3 songs", "most popular song" → `.limit()`), and lyrics-based song identification

--- a/app/services/song_import_logger.rb
+++ b/app/services/song_import_logger.rb
@@ -127,6 +127,21 @@ class SongImportLogger
     )
   end
 
+  # Safety net for the SongImporter ensure block: if the import was interrupted
+  # before it could call complete_log/fail_log/skip_log (process kill, double
+  # timeout, exception inside the rescue handler), the row would otherwise stay
+  # `pending` forever. Flip it to `failed` so we don't lose track of the import.
+  def fail_log_if_pending(reason:)
+    return unless @log
+
+    @log.reload
+    return unless @log.pending?
+
+    @log.update(status: :failed, failure_reason: sanitize_reason(reason))
+  rescue ActiveRecord::RecordNotFound
+    nil
+  end
+
   private
 
   def sanitize_reason(reason)

--- a/app/services/song_importer.rb
+++ b/app/services/song_importer.rb
@@ -33,11 +33,11 @@ class SongImporter
 
     create_air_play
   rescue StandardError => e
-    ExceptionNotifier.notify(e)
-    Broadcaster.error_during_import(error_message: e.message, radio_station_name: @radio_station.name)
     @import_logger.fail_log(reason: e.message)
+    notify_import_error(e)
     nil
   ensure
+    safely_resolve_pending_log
     clear_instance_variables
   end
 
@@ -142,6 +142,21 @@ class SongImporter
     @import_logger.start_log
   rescue StandardError => e
     Rails.logger.error("Failed to create song import log: #{e.message}")
+  end
+
+  # Side-effects that must not block fail_log: if Sentry is rate-limiting or
+  # ActionCable is wedged, we still want the log row marked failed.
+  def notify_import_error(error)
+    ExceptionNotifier.notify(error)
+    Broadcaster.error_during_import(error_message: error.message, radio_station_name: @radio_station.name)
+  rescue StandardError => e
+    Rails.logger.error("Failed to notify import error: #{e.message}")
+  end
+
+  def safely_resolve_pending_log
+    @import_logger.fail_log_if_pending(reason: 'Import interrupted before completion')
+  rescue StandardError => e
+    Rails.logger.error("Failed to resolve song import log status: #{e.message}")
   end
 
   def clear_instance_variables

--- a/app/services/stuck_pending_log_recovery.rb
+++ b/app/services/stuck_pending_log_recovery.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+# Recovers SongImportLogs that got stuck in `pending` status — typically because
+# the import job was killed mid-flight (OOM, double Timeout::Error, exception
+# inside the rescue's notification side-effects) before reaching a terminal
+# status.
+#
+# For each stuck log with a confirmed Spotify track:
+#  1. Resolve the canonical Song by spotify_track_id (preferred) or by
+#     artist+title; fall back to creating one from the logged Spotify data.
+#  2. Find an existing AirPlay at (radio_station, song, broadcasted_at). If one
+#     already exists (the original import created it but never updated the log),
+#     reuse it. Otherwise create a new AirPlay.
+#  3. Mark the log `success` linked to the song and air_play.
+#
+# Logs without a spotify_track_id are skipped — too risky to back-fill from
+# scraped/recognized data without an authoritative identity. Logs younger than
+# `min_age` are skipped to avoid racing in-flight imports.
+class StuckPendingLogRecovery
+  DEFAULT_MIN_AGE = 10.minutes
+
+  attr_reader :results
+
+  def initialize(dry_run: true, limit: 500, min_age: DEFAULT_MIN_AGE)
+    @dry_run = dry_run
+    @limit = limit
+    @min_age = min_age
+    @results = {
+      checked: 0, recovered: 0, reused_air_play: 0, created_air_play: 0,
+      skipped: 0, errors: []
+    }
+  end
+
+  def run
+    stuck_logs.find_each do |log|
+      @results[:checked] += 1
+      process_log(log)
+    end
+
+    @results
+  end
+
+  private
+
+  def stuck_logs
+    SongImportLog.includes(:radio_station)
+      .where(status: :pending)
+      .where.not(spotify_track_id: nil)
+      .where(created_at: ...@min_age.ago)
+      .order(created_at: :desc)
+      .limit(@limit)
+  end
+
+  def process_log(log)
+    song = find_or_create_song(log)
+    if song.blank?
+      @results[:skipped] += 1
+      log_skip(log, 'could not resolve song from log data')
+      return
+    end
+
+    existing_air_play = find_existing_air_play(log, song)
+    log_recovery(log, song, existing_air_play)
+    return if @dry_run
+
+    air_play = existing_air_play || AirPlay.create!(air_play_attributes(log, song))
+    log.update!(status: :success, song: song, air_play: air_play)
+    @results[:recovered] += 1
+    @results[existing_air_play ? :reused_air_play : :created_air_play] += 1
+  rescue StandardError => e
+    @results[:errors] << { log_id: log.id, error: e.message }
+  end
+
+  def find_or_create_song(log)
+    song = Song.find_by(id_on_spotify: log.spotify_track_id)
+    return song if song.present?
+
+    title = import_title_for(log)
+    artist_name = import_artist_for(log)
+    return nil if title.blank? || artist_name.blank?
+
+    artists = find_artists(artist_name)
+    if artists.present?
+      existing = Song.joins(:artists)
+                   .where(artists: { id: artists.map(&:id) })
+                   .where('LOWER(songs.title) = ?', title.downcase)
+                   .first
+      return existing if existing.present?
+    end
+
+    return nil if @dry_run
+
+    create_song_from_log(log, title, artists)
+  end
+
+  def import_title_for(log)
+    log.spotify_title.presence || log.recognized_title.presence || log.scraped_title.presence
+  end
+
+  def import_artist_for(log)
+    log.spotify_artist.presence || log.recognized_artist.presence || log.scraped_artist.presence
+  end
+
+  def find_artists(artist_name)
+    regex = Regexp.new(Song::MULTIPLE_ARTIST_REGEX, Regexp::IGNORECASE)
+    names = if artist_name.match?(regex)
+              artist_name.split(regex).map(&:strip).reject(&:blank?)
+            else
+              [artist_name]
+            end
+
+    names.filter_map { |name| Artist.find_by('LOWER(name) = ?', name.downcase) }
+  end
+
+  def create_song_from_log(log, title, artists)
+    song = Song.new(
+      title: title,
+      id_on_spotify: log.spotify_track_id,
+      spotify_song_url: "https://open.spotify.com/track/#{log.spotify_track_id}",
+      isrcs: [log.spotify_isrc].compact
+    )
+    artists.each { |artist| song.artists << artist } if artists.present?
+    song.save!
+    song
+  end
+
+  def find_existing_air_play(log, song)
+    return nil if log.broadcasted_at.blank?
+
+    AirPlay.find_by(
+      radio_station_id: log.radio_station_id,
+      song_id: song.id,
+      broadcasted_at: log.broadcasted_at
+    )
+  end
+
+  def air_play_attributes(log, song)
+    {
+      radio_station: log.radio_station,
+      song: song,
+      broadcasted_at: log.broadcasted_at,
+      scraper_import: log.import_source == 'scraping',
+      status: :confirmed
+    }
+  end
+
+  def log_recovery(log, song, existing_air_play)
+    action = if existing_air_play
+               @dry_run ? 'would attach existing air_play' : 'attaching existing air_play'
+             else
+               @dry_run ? 'would create air_play' : 'creating air_play'
+             end
+    $stdout.puts "  Log ##{log.id} | Station #{log.radio_station_id} | " \
+                 "#{log.broadcasted_at&.strftime('%Y-%m-%d %H:%M')} | " \
+                 "#{import_artist_for(log)} - #{import_title_for(log)} | " \
+                 "song ##{song.id} | #{action}" \
+                 "#{existing_air_play ? " ##{existing_air_play.id}" : ''}"
+  end
+
+  def log_skip(log, reason)
+    $stdout.puts "  Log ##{log.id} | skipped: #{reason}"
+  end
+end

--- a/lib/tasks/data_repair.rake
+++ b/lib/tasks/data_repair.rake
@@ -1339,6 +1339,41 @@ namespace :data_repair do
     results[:errors].each { |e| puts "  Song ##{e[:song_id]}: #{e[:error]}" }
   end
 
+  desc 'Dry run: Show SongImportLogs stuck in pending status that can be recovered. ' \
+       'Usage: rake data_repair:find_stuck_pending_logs[500]'
+  task :find_stuck_pending_logs, [:limit] => :environment do |_t, args|
+    limit = (args[:limit] || 500).to_i
+    puts "Scanning up to #{limit} pending import logs (dry run)..."
+    puts '=' * 80
+
+    recovery = StuckPendingLogRecovery.new(dry_run: true, limit: limit)
+    results = recovery.run
+
+    puts '=' * 80
+    puts "Checked: #{results[:checked]}, Skipped: #{results[:skipped]}"
+    puts "Would attach existing air_play: #{results[:reused_air_play]}, " \
+         "Would create air_play: #{results[:created_air_play]}"
+    puts "Errors: #{results[:errors].count}" if results[:errors].any?
+    results[:errors].each { |e| puts "  Log ##{e[:log_id]}: #{e[:error]}" }
+  end
+
+  desc 'Recover SongImportLogs stuck in pending status by linking or creating airplays. ' \
+       'Usage: rake data_repair:fix_stuck_pending_logs[500]'
+  task :fix_stuck_pending_logs, [:limit] => :environment do |_t, args|
+    limit = (args[:limit] || 500).to_i
+    puts "Recovering up to #{limit} pending import logs..."
+    puts '=' * 80
+
+    recovery = StuckPendingLogRecovery.new(dry_run: false, limit: limit)
+    results = recovery.run
+
+    puts '=' * 80
+    puts "Checked: #{results[:checked]}, Recovered: #{results[:recovered]}, Skipped: #{results[:skipped]}"
+    puts "Reused air_play: #{results[:reused_air_play]}, Created air_play: #{results[:created_air_play]}"
+    puts "Errors: #{results[:errors].count}" if results[:errors].any?
+    results[:errors].each { |e| puts "  Log ##{e[:log_id]}: #{e[:error]}" }
+  end
+
   desc 'Roll back a single SongImportLog: destroy airplay, destroy song if orphaned, mark log failed. ' \
        'Dry run by default. Usage: rake data_repair:rollback_import_log[2765957] or [2765957,apply]'
   task :rollback_import_log, %i[log_id mode] => :environment do |_t, args|

--- a/spec/services/song_import_logger_spec.rb
+++ b/spec/services/song_import_logger_spec.rb
@@ -388,4 +388,38 @@ describe SongImportLogger do
       expect(logger.log.failure_reason).to eq('No artist found')
     end
   end
+
+  describe '#fail_log_if_pending' do
+    before { logger.start_log }
+
+    context 'when log is still pending' do
+      it 'flips status to failed', :aggregate_failures do
+        logger.fail_log_if_pending(reason: 'Import interrupted before completion')
+        expect(logger.log.status).to eq('failed')
+        expect(logger.log.failure_reason).to eq('Import interrupted before completion')
+      end
+    end
+
+    context 'when log has already reached a terminal status' do
+      before { logger.complete_log(song: create(:song), air_play: create(:air_play)) }
+
+      it 'does not overwrite the existing status' do
+        logger.fail_log_if_pending(reason: 'Import interrupted before completion')
+        expect(logger.log.reload.status).to eq('success')
+      end
+    end
+
+    context 'when the log row has been deleted' do
+      before { logger.log.destroy }
+
+      it 'swallows the missing-record error' do
+        expect { logger.fail_log_if_pending(reason: 'Import interrupted before completion') }.not_to raise_error
+      end
+    end
+
+    it 'does nothing when no log was started' do
+      new_logger = described_class.new(radio_station:)
+      expect { new_logger.fail_log_if_pending(reason: 'whatever') }.not_to raise_error
+    end
+  end
 end

--- a/spec/services/song_importer_edge_cases_spec.rb
+++ b/spec/services/song_importer_edge_cases_spec.rb
@@ -7,7 +7,8 @@ describe SongImporter do
   let(:import_logger) do
     instance_double(SongImportLogger, start_log: nil, log_scraping: nil, skip_log: nil,
                                       complete_log: nil, log_recognition: nil, log_acoustid: nil,
-                                      fail_log: nil, log_spotify: nil, log_deezer: nil, log_itunes: nil,
+                                      fail_log: nil, fail_log_if_pending: nil,
+                                      log_spotify: nil, log_deezer: nil, log_itunes: nil,
                                       log_llm: nil)
   end
 

--- a/spec/services/song_importer_spec.rb
+++ b/spec/services/song_importer_spec.rb
@@ -26,7 +26,8 @@ describe SongImporter do
       allow(SongImportLogger).to receive(:new).and_return(
         instance_double(SongImportLogger, start_log: nil, log_scraping: nil, skip_log: nil,
                                           complete_log: nil, log_recognition: nil, log_acoustid: nil,
-                                          fail_log: nil, log_spotify: nil, log_deezer: nil, log_itunes: nil)
+                                          fail_log: nil, fail_log_if_pending: nil,
+                                          log_spotify: nil, log_deezer: nil, log_itunes: nil)
       )
     end
 
@@ -79,7 +80,8 @@ describe SongImporter do
       let(:import_logger) do
         instance_double(SongImportLogger, start_log: nil, log_scraping: nil, skip_log: nil,
                                           complete_log: nil, log_recognition: nil, log_acoustid: nil,
-                                          fail_log: nil, log_spotify: nil, log_deezer: nil, log_itunes: nil)
+                                          fail_log: nil, fail_log_if_pending: nil,
+                                          log_spotify: nil, log_deezer: nil, log_itunes: nil)
       end
 
       before do
@@ -100,6 +102,51 @@ describe SongImporter do
         importer.import
         expect(import_logger).to have_received(:skip_log).with(reason: 'No song scraped or recognized')
         expect(import_logger).not_to have_received(:fail_log)
+      end
+    end
+
+    context 'when the import flow raises and the error notifier itself fails' do
+      let(:import_logger) do
+        instance_double(SongImportLogger, start_log: nil, log_scraping: nil, skip_log: nil,
+                                          complete_log: nil, log_recognition: nil, log_acoustid: nil,
+                                          fail_log: nil, fail_log_if_pending: nil,
+                                          log_spotify: nil, log_deezer: nil, log_itunes: nil)
+      end
+
+      before do
+        allow(SongImportLogger).to receive(:new).and_return(import_logger)
+        allow(TrackScraper::NpoApiProcessor).to receive(:new).and_return(scraper)
+        allow(importer).to receive_messages(artists: [artist], song: song, deezer_track: nil, itunes_track: nil)
+        allow(importer).to receive(:create_air_play).and_raise(StandardError, 'boom')
+        allow(ExceptionNotifier).to receive(:notify).and_raise(StandardError, 'sentry down')
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it 'still marks the log as failed before notification side-effects', :aggregate_failures do
+        expect { importer.import }.not_to raise_error
+        expect(import_logger).to have_received(:fail_log).with(reason: 'boom')
+      end
+    end
+
+    context 'when the import flow is interrupted and the log is still pending' do
+      let(:import_logger) do
+        instance_double(SongImportLogger, start_log: nil, log_scraping: nil, skip_log: nil,
+                                          complete_log: nil, log_recognition: nil, log_acoustid: nil,
+                                          fail_log: nil, fail_log_if_pending: nil,
+                                          log_spotify: nil, log_deezer: nil, log_itunes: nil)
+      end
+
+      before do
+        allow(SongImportLogger).to receive(:new).and_return(import_logger)
+        allow(TrackScraper::NpoApiProcessor).to receive(:new).and_return(scraper)
+        allow(importer).to receive_messages(artists: [artist], song: song, deezer_track: nil, itunes_track: nil,
+                                            create_air_play: true)
+      end
+
+      it 'runs the pending-log safety net in the ensure block' do
+        importer.import
+        expect(import_logger).to have_received(:fail_log_if_pending)
+                                   .with(reason: 'Import interrupted before completion')
       end
     end
   end

--- a/spec/services/stuck_pending_log_recovery_spec.rb
+++ b/spec/services/stuck_pending_log_recovery_spec.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe StuckPendingLogRecovery do
+  let(:radio_station) { create(:radio_station) }
+  let(:artist) { create(:artist, name: 'Luke Combs') }
+  let(:broadcasted_at) { 30.minutes.ago }
+
+  before do
+    allow($stdout).to receive(:puts)
+  end
+
+  def stuck_log(overrides = {})
+    log = create(:song_import_log,
+                 radio_station: radio_station,
+                 status: :pending,
+                 broadcasted_at: broadcasted_at,
+                 spotify_track_id: '1Lo0QY9cvc8sUB2vnIOxDT',
+                 spotify_artist: 'Luke Combs',
+                 spotify_title: 'Fast Car',
+                 spotify_isrc: 'US6XF2200436',
+                 recognized_artist: 'Luke Combs',
+                 recognized_title: 'Fast Car',
+                 import_source: :recognition,
+                 **overrides)
+    log.update_columns(created_at: 30.minutes.ago) # rubocop:disable Rails/SkipsModelValidations
+    log
+  end
+
+  describe '#run' do
+    context 'when the canonical Song already exists with the logged spotify_track_id' do
+      let!(:song) { create(:song, title: 'Fast Car', id_on_spotify: '1Lo0QY9cvc8sUB2vnIOxDT', artists: [artist]) }
+      let!(:log) { stuck_log }
+
+      it 'creates an AirPlay and links it to the log', :aggregate_failures do
+        results = described_class.new(dry_run: false).run
+
+        log.reload
+        expect(log.status).to eq('success')
+        expect(log.song_id).to eq(song.id)
+        expect(log.air_play_id).to be_present
+        expect(log.air_play.song_id).to eq(song.id)
+        expect(log.air_play.broadcasted_at).to be_within(1.second).of(broadcasted_at)
+        expect(results).to include(checked: 1, recovered: 1, created_air_play: 1, reused_air_play: 0)
+      end
+    end
+
+    context 'when an AirPlay was already created by the original interrupted import' do
+      let!(:song) { create(:song, title: 'Fast Car', id_on_spotify: '1Lo0QY9cvc8sUB2vnIOxDT', artists: [artist]) }
+      let!(:existing_air_play) do
+        create(:air_play, song: song, radio_station: radio_station, broadcasted_at: broadcasted_at)
+      end
+      let!(:log) { stuck_log }
+
+      it 'reuses the existing AirPlay instead of creating a duplicate', :aggregate_failures do
+        results = described_class.new(dry_run: false).run
+
+        log.reload
+        expect(log.air_play_id).to eq(existing_air_play.id)
+        expect(log.status).to eq('success')
+        expect(AirPlay.where(song: song, radio_station: radio_station, broadcasted_at: broadcasted_at).count).to eq(1)
+        expect(results).to include(recovered: 1, reused_air_play: 1, created_air_play: 0)
+      end
+    end
+
+    context 'when no Song with the spotify_track_id exists yet' do
+      let!(:log) { stuck_log }
+
+      it 'creates the Song from log data and links the airplay', :aggregate_failures do
+        artist
+        results = described_class.new(dry_run: false).run
+
+        log.reload
+        expect(log.song.id_on_spotify).to eq('1Lo0QY9cvc8sUB2vnIOxDT')
+        expect(log.song.title).to eq('Fast Car')
+        expect(log.song.isrcs).to eq(['US6XF2200436'])
+        expect(log.air_play.song_id).to eq(log.song_id)
+        expect(results).to include(recovered: 1, created_air_play: 1)
+      end
+    end
+
+    context 'when the log has no spotify_track_id' do
+      let!(:log) { stuck_log(spotify_track_id: nil, spotify_artist: nil, spotify_title: nil, spotify_isrc: nil) }
+
+      it 'leaves the log alone', :aggregate_failures do
+        results = described_class.new(dry_run: false).run
+
+        log.reload
+        expect(log.status).to eq('pending')
+        expect(results).to include(checked: 0)
+      end
+    end
+
+    context 'when the log is younger than min_age' do
+      let!(:log) do
+        create(:song, title: 'Fast Car', id_on_spotify: '1Lo0QY9cvc8sUB2vnIOxDT', artists: [artist])
+        log = stuck_log
+        log.update_columns(created_at: 1.minute.ago) # rubocop:disable Rails/SkipsModelValidations
+        log
+      end
+
+      it 'is excluded from recovery', :aggregate_failures do
+        results = described_class.new(dry_run: false).run
+
+        expect(log.reload.status).to eq('pending')
+        expect(results).to include(checked: 0)
+      end
+    end
+
+    context 'with dry_run: true' do
+      let(:song) { create(:song, title: 'Fast Car', id_on_spotify: '1Lo0QY9cvc8sUB2vnIOxDT', artists: [artist]) }
+      let!(:log) do
+        song
+        stuck_log
+      end
+
+      it 'reports what would happen without mutating', :aggregate_failures do
+        results = described_class.new(dry_run: true).run
+
+        log.reload
+        expect(log.status).to eq('pending')
+        expect(log.air_play_id).to be_nil
+        expect(AirPlay.where(song: song).count).to eq(0)
+        expect(results).to include(checked: 1, created_air_play: 0, recovered: 0)
+      end
+    end
+
+    context 'when AirPlay creation fails (e.g., missing broadcasted_at)' do
+      let!(:log) do
+        create(:song, title: 'Fast Car', id_on_spotify: '1Lo0QY9cvc8sUB2vnIOxDT', artists: [artist])
+        stuck_log(broadcasted_at: nil)
+      end
+
+      it 'records the error and leaves the log pending', :aggregate_failures do
+        results = described_class.new(dry_run: false).run
+
+        log.reload
+        expect(log.status).to eq('pending')
+        expect(results[:errors].count).to eq(1)
+        expect(results[:errors].first[:log_id]).to eq(log.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Today's export of Jumbo Radio import logs showed 13 of 35 recognition imports stuck at `status: pending` (Fast Car, Pure Shores, USHER, etc.) — no `failure_reason`, no linked `air_play`, never finalized.
- Root cause: `SongImporter#import`'s rescue called `fail_log` **last**, after `ExceptionNotifier.notify` and `Broadcaster.error_during_import`. If either re-raised (Sentry hiccup, double `Timeout::Error` firing inside the rescue, OOM mid-notification), the exception escaped to `ImportSongJob`'s outer rescue and the log row was never updated.
- Fix forward: call `fail_log` first, isolate the notification side-effects behind their own rescue, and add an ensure-block safety net (`fail_log_if_pending`) that flips any still-pending log to failed regardless of how the import was interrupted.
- Recovery for already-stuck rows: new `StuckPendingLogRecovery` service + `data_repair:find_stuck_pending_logs[limit]` / `data_repair:fix_stuck_pending_logs[limit]` tasks. For pending logs older than 10 minutes with a `spotify_track_id`, resolve the canonical Song, reuse an AirPlay at `(radio_station, song, broadcasted_at)` if the original interrupted import managed to create one (we observed this with Madonna 06:17 — subsequent attempt was *skipped* as a duplicate, proving an AirPlay existed), otherwise create one, and mark the log `success`.

## Test plan
- [x] `bundle exec rspec spec/services/song_import_logger_spec.rb spec/services/song_importer_spec.rb spec/services/song_importer_edge_cases_spec.rb spec/services/stuck_pending_log_recovery_spec.rb` — 166 examples, 0 failures
- [x] `bundle exec rubocop` on the changed files — clean
- [x] `bundle exec rake -T data_repair` — new tasks registered
- [ ] After deploy: run `bundle exec rake data_repair:find_stuck_pending_logs[500]` in production, review the dry-run output, then run `data_repair:fix_stuck_pending_logs[500]` to clean up historical rows
- [ ] Re-export Jumbo Radio import logs and confirm the pending count stays low going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)