### PR TITLE
Add Wikipedia::UrlFinder service

### DIFF
--- a/app/services/wikipedia/url_finder.rb
+++ b/app/services/wikipedia/url_finder.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Wikipedia
+  class UrlFinder < Base
+    SIMILARITY_THRESHOLD = 92
+    MUSICBRAINZ_HOST = 'https://musicbrainz.org'
+    MUSICBRAINZ_USER_AGENT = 'Airplays/1.0.0 (https://airplays.nl)'
+    MUSICBRAINZ_RATE_LIMIT_DELAY = 1.0
+
+    def find_for_artist(artist)
+      return nil if artist.blank?
+
+      from_musicbrainz(artist.id_on_musicbrainz) || from_opensearch(artist.name, hint: 'musician')
+    end
+
+    def find_for_name(name, hint: nil)
+      return nil if name.blank?
+
+      from_opensearch(name, hint: hint)
+    end
+
+    private
+
+    def from_musicbrainz(mbid)
+      return nil if mbid.blank?
+
+      data = fetch_musicbrainz_artist(mbid)
+      relations = data.is_a?(Hash) ? data['relations'].to_a : []
+      wiki_relations = relations.select { |rel| rel['type'] == 'wikipedia' && rel.dig('url', 'resource').present? }
+      return nil if wiki_relations.empty?
+
+      preferred = wiki_relations.find { |rel| rel.dig('url', 'resource').include?("//#{language}.wikipedia.org/") }
+      (preferred || wiki_relations.first).dig('url', 'resource')
+    end
+
+    def from_opensearch(name, hint: nil)
+      query = hint.present? ? "#{name} #{hint}" : name
+      response = make_mediawiki_request(action: 'opensearch', search: query, limit: 1)
+      return nil unless response.is_a?(Array)
+
+      title = response[1]&.first
+      url = response[3]&.first
+      return nil if title.blank? || url.blank?
+      return nil unless title_matches?(title, name)
+
+      url
+    end
+
+    def title_matches?(title, name)
+      cleaned = title.sub(/\s*\(.*?\)\s*\z/, '')
+      score = (JaroWinkler.similarity(cleaned.downcase, name.to_s.downcase) * 100).to_i
+      score >= SIMILARITY_THRESHOLD
+    end
+
+    def fetch_musicbrainz_artist(mbid)
+      Rails.cache.fetch("wikipedia_url_finder:mb_artist:#{mbid}", expires_in: 24.hours) do
+        sleep(MUSICBRAINZ_RATE_LIMIT_DELAY)
+        response = musicbrainz_connection.get("/ws/2/artist/#{mbid}", { inc: 'url-rels', fmt: 'json' })
+        response.success? ? response.body : nil
+      end
+    rescue StandardError => e
+      ExceptionNotifier.notify(e)
+      Rails.logger.error("Wikipedia::UrlFinder MusicBrainz error: #{e.message}")
+      nil
+    end
+
+    def musicbrainz_connection
+      @musicbrainz_connection ||= Faraday.new(url: MUSICBRAINZ_HOST) do |conn|
+        conn.options.timeout = 10
+        conn.options.open_timeout = 5
+        conn.headers['User-Agent'] = MUSICBRAINZ_USER_AGENT
+        conn.headers['Accept'] = 'application/json'
+        conn.response :json
+      end
+    end
+  end
+end

--- a/spec/services/wikipedia/url_finder_spec.rb
+++ b/spec/services/wikipedia/url_finder_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Wikipedia::UrlFinder, type: :service do
+  let(:url_finder) { described_class.new }
+  let(:artist) { create(:artist, name: 'Coldplay') }
+  let(:mbid) { 'cc197bad-dc9c-440d-a5b5-d52ba2e14234' }
+
+  before { allow(url_finder).to receive(:sleep) }
+
+  describe '#find_for_artist' do
+    context 'when artist has a MusicBrainz ID with a wikipedia url-relation' do
+      let(:mb_response) do
+        {
+          'id' => mbid,
+          'relations' => [
+            { 'type' => 'wikidata', 'url' => { 'resource' => 'https://www.wikidata.org/wiki/Q45188' } },
+            { 'type' => 'wikipedia', 'url' => { 'resource' => 'https://en.wikipedia.org/wiki/Coldplay' } }
+          ]
+        }
+      end
+
+      before do
+        artist.update!(id_on_musicbrainz: mbid)
+        stub_request(:get, %r{musicbrainz.org/ws/2/artist/#{mbid}})
+          .to_return(status: 200, body: mb_response.to_json, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns the wikipedia URL from the MusicBrainz relation' do
+        expect(url_finder.find_for_artist(artist)).to eq('https://en.wikipedia.org/wiki/Coldplay')
+      end
+    end
+
+    context 'when MusicBrainz returns multiple wikipedia urls in different languages' do
+      let(:mb_response) do
+        {
+          'id' => mbid,
+          'relations' => [
+            { 'type' => 'wikipedia', 'url' => { 'resource' => 'https://en.wikipedia.org/wiki/Coldplay' } },
+            { 'type' => 'wikipedia', 'url' => { 'resource' => 'https://nl.wikipedia.org/wiki/Coldplay' } }
+          ]
+        }
+      end
+
+      before do
+        artist.update!(id_on_musicbrainz: mbid)
+        stub_request(:get, %r{musicbrainz.org/ws/2/artist/#{mbid}})
+          .to_return(status: 200, body: mb_response.to_json, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'prefers the URL matching the configured language' do
+        finder = described_class.new(language: 'nl')
+        allow(finder).to receive(:sleep)
+        expect(finder.find_for_artist(artist)).to eq('https://nl.wikipedia.org/wiki/Coldplay')
+      end
+    end
+
+    context 'when artist has no MusicBrainz ID and OpenSearch returns a matching title' do
+      before do
+        stub_request(:get, %r{en.wikipedia.org/w/api.php}).to_return(
+          status: 200,
+          body: ['Coldplay musician', ['Coldplay'], [''], ['https://en.wikipedia.org/wiki/Coldplay']].to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+
+      it 'returns the URL from the OpenSearch top result' do
+        expect(url_finder.find_for_artist(artist)).to eq('https://en.wikipedia.org/wiki/Coldplay')
+      end
+    end
+
+    context 'when artist has a MusicBrainz ID without wikipedia url-rels' do
+      before do
+        artist.update!(id_on_musicbrainz: mbid)
+        stub_request(:get, %r{musicbrainz.org/ws/2/artist/#{mbid}}).to_return(
+          status: 200,
+          body: { 'id' => mbid, 'relations' => [] }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+        stub_request(:get, %r{en.wikipedia.org/w/api.php}).to_return(
+          status: 200,
+          body: ['Coldplay musician', ['Coldplay'], [''], ['https://en.wikipedia.org/wiki/Coldplay']].to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+
+      it 'falls back to OpenSearch' do
+        expect(url_finder.find_for_artist(artist)).to eq('https://en.wikipedia.org/wiki/Coldplay')
+      end
+    end
+
+    context 'when OpenSearch returns a title that is not similar enough' do
+      let(:artist) { create(:artist, name: 'Pink') }
+
+      before do
+        stub_request(:get, %r{en.wikipedia.org/w/api.php}).to_return(
+          status: 200,
+          body: ['Pink musician', ['Pink Floyd'], [''], ['https://en.wikipedia.org/wiki/Pink_Floyd']].to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+
+      it 'rejects the result' do
+        expect(url_finder.find_for_artist(artist)).to be_nil
+      end
+    end
+
+    context 'when OpenSearch returns a title with a parenthetical disambiguation suffix' do
+      let(:artist) { create(:artist, name: 'Taylor Swift') }
+
+      before do
+        stub_request(:get, %r{en.wikipedia.org/w/api.php}).to_return(
+          status: 200,
+          body: [
+            'Taylor Swift musician',
+            ['Taylor Swift (singer)'],
+            [''],
+            ['https://en.wikipedia.org/wiki/Taylor_Swift_(singer)']
+          ].to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+
+      it 'strips the suffix before comparing and accepts the match' do
+        expect(url_finder.find_for_artist(artist)).to eq('https://en.wikipedia.org/wiki/Taylor_Swift_(singer)')
+      end
+    end
+
+    context 'when artist is nil' do
+      it 'returns nil' do
+        expect(url_finder.find_for_artist(nil)).to be_nil
+      end
+    end
+
+    context 'when the MusicBrainz request errors' do
+      before do
+        artist.update!(id_on_musicbrainz: mbid)
+        stub_request(:get, %r{musicbrainz.org/ws/2/artist/#{mbid}}).to_return(status: 503, body: 'Service Unavailable')
+        stub_request(:get, %r{en.wikipedia.org/w/api.php}).to_return(
+          status: 200,
+          body: ['Coldplay musician', ['Coldplay'], [''], ['https://en.wikipedia.org/wiki/Coldplay']].to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+
+      it 'falls back to OpenSearch' do
+        expect(url_finder.find_for_artist(artist)).to eq('https://en.wikipedia.org/wiki/Coldplay')
+      end
+    end
+  end
+
+  describe '#find_for_name' do
+    context 'when a hint is provided' do
+      before do
+        stub_request(:get, %r{en.wikipedia.org/w/api.php}).with(query: hash_including(search: 'Coldplay band')).to_return(
+          status: 200,
+          body: ['Coldplay band', ['Coldplay'], [''], ['https://en.wikipedia.org/wiki/Coldplay']].to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+
+      it 'appends the hint to the search query' do
+        expect(url_finder.find_for_name('Coldplay', hint: 'band')).to eq('https://en.wikipedia.org/wiki/Coldplay')
+      end
+    end
+
+    context 'when name is blank' do
+      it 'returns nil' do
+        expect(url_finder.find_for_name('')).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- New `Wikipedia::UrlFinder` resolves Wikipedia URLs for artists, preferring the authoritative MusicBrainz `url-rels` relation when `Artist#id_on_musicbrainz` is set, and falling back to Wikipedia's OpenSearch API otherwise.
- OpenSearch results are validated with a JaroWinkler title check (>= 92, after stripping `(disambiguation)` suffixes) to reject mismatches like `"Pink"` -> `"Pink Floyd"` while accepting `"Taylor Swift"` -> `"Taylor Swift (singer)"`.
- MusicBrainz lookups respect the 1 req/sec rate limit and are cached in Rails.cache for 24 hours, mirroring `MusicBrainz::ArtistAliasFetcher`. Inherits language support, circuit breaker, and OpenSearch caching from `Wikipedia::Base`.

## Test plan

- [x] `bundle exec rspec spec/services/wikipedia/url_finder_spec.rb` (10 examples, 0 failures)
- [x] `bundle exec rubocop app/services/wikipedia/url_finder.rb spec/services/wikipedia/url_finder_spec.rb` (no offenses)
- [ ] Wire into a caller (e.g. an enrichment job) in a follow-up PR — this PR adds the service in isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)