### PR TITLE
Remove AMBIGUOUS_PUNCTUATION check from SongImporter

### DIFF
--- a/app/services/song_importer.rb
+++ b/app/services/song_importer.rb
@@ -6,9 +6,6 @@ class SongImporter
   ].freeze
 
   AD_MARKERS = /(reklame|reclame|nieuws|pingel)/i
-  # Punctuation patterns that appear in legit titles (e.g. "...Baby One More Time") but also in noisy scraped data.
-  # Only reject when Spotify can't match the track either.
-  AMBIGUOUS_PUNCTUATION = /'{2,}|\.{2,}/
 
   include SongImporter::Concerns::AudioRecognition
   include SongImporter::Concerns::TrackFinding
@@ -92,9 +89,7 @@ class SongImporter
   end
 
   def illegal_word_in_title
-    return true if title.match?(AD_MARKERS)
-
-    title.match?(AMBIGUOUS_PUNCTUATION) && track.blank?
+    title.match?(AD_MARKERS)
   end
 
   def recently_imported?

--- a/spec/services/song_importer_edge_cases_spec.rb
+++ b/spec/services/song_importer_edge_cases_spec.rb
@@ -416,55 +416,20 @@ describe SongImporter do
       end
     end
 
-    context 'with ambiguous punctuation and no Spotify match' do
-      before { allow(importer).to receive(:track).and_return(nil) }
-
-      {
-        "title with ''" => true,
-        "title with '''" => true,
-        'title with ..' => true,
-        'title with ...' => true
-      }.each do |title_text, expected|
-        context "with title '#{title_text}'" do
-          let(:title_text) { title_text }
-
-          it "returns #{expected}" do
-            expect(importer.send(:illegal_word_in_title)).to eq(expected)
-          end
-        end
-      end
-    end
-
-    context 'with ambiguous punctuation but Spotify matched the track' do
-      before { allow(importer).to receive(:track).and_return(Object.new) }
-
-      [
-        "title with ''",
-        "title with '''",
-        'title with ..',
-        '...Baby One More Time'
-      ].each do |title_text|
-        context "with title '#{title_text}'" do
-          let(:title_text) { title_text }
-
-          it 'returns false' do
-            expect(importer.send(:illegal_word_in_title)).to be false
-          end
-        end
-      end
-    end
-
     context 'with a clean title' do
       {
         'Normal Song Title' => false,
         "It's a normal title" => false,
         '3.14 is pi' => false,
-        "Song with 'quotes'" => false
+        "Song with 'quotes'" => false,
+        '...Baby One More Time' => false,
+        "title with ''" => false,
+        'title with ..' => false
       }.each do |title_text, expected|
         context "with title '#{title_text}'" do
           let(:title_text) { title_text }
 
-          it "returns #{expected} without consulting Spotify" do
+          it "returns #{expected}" do
             expect(importer.send(:illegal_word_in_title)).to eq(expected)
           end
         end


### PR DESCRIPTION
Closes #2060

## Summary
- Drops the `AMBIGUOUS_PUNCTUATION` regex and its constant from `SongImporter`. The Spotify/iTunes/Deezer match pipeline (with `valid_match?` and JaroWinkler thresholds) plus the LLM fallbacks now do this job — and they do it more accurately than a regex over scraped title noise.
- `illegal_word_in_title` collapses to a single `match?(AD_MARKERS)` call. Ad keywords stay because they're the cheapest and most reliable signal.
- Edge-case specs covering ambiguous punctuation are folded into the existing clean-title coverage (e.g. `...Baby One More Time`, `Song with 'quotes'` now pass through).

## Test plan
- [x] `bundle exec rspec spec/services/song_importer_edge_cases_spec.rb spec/services/song_importer_spec.rb` — 106 examples, 0 failures
- [x] `bundle exec rubocop app/services/song_importer.rb spec/services/song_importer_edge_cases_spec.rb` — no offenses
- [ ] Watch production logs after merge for any uptick in garbage imports that would have previously been caught by the punctuation regex

🤖 Generated with [Claude Code](https://claude.com/claude-code)