### PR TITLE
Add lyrics sentiment analysis enrichment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,9 @@ bundle exec rake optimization:vacuum                           # PostgreSQL VACU
 # Hit Potential
 bundle exec rake hit_potential:backfill                        # Backfill hit_potential_score for songs with music profiles
 
+# Lyrics Sentiment
+bundle exec rake lyrics:backfill                               # Enqueue lyrics sentiment enrichment for recently-played songs (requires LYRICS_ENRICHMENT_ENABLED=true)
+
 # Enrichment
 bundle exec rake enrichment:backfill_artist_aka_names          # Fetch alternative artist names from MusicBrainz
 
@@ -93,7 +96,10 @@ The app uses service objects extensively in `app/services/`:
 - `MismatchedAirplayRepair` - Detects and fixes airplays linked to wrong songs via two detectors: (1) title mismatch — import log title vs linked song title (Jaro-Winkler < 70%); (2) spotify_track_id mismatch — the log's Spotify ID points to a different canonical song than the one linked. Reassigns airplays to the canonical song (found by Spotify track ID, exact match, or newly created).
 - `SongImportLogRollback` - Rolls back a single `SongImportLog`: destroys the linked airplay, destroys the linked song if no other airplays reference it, marks the log `failed` with a rollback reason. Guards against orphaning charts (skips song deletion if chart positions exist) and preserves songs played on other stations.
 - `StuckPendingLogRecovery` - Recovers `SongImportLog` rows stuck in `pending` status (jobs killed mid-flight before reaching a terminal status). For each stuck log with a `spotify_track_id`: resolves the canonical Song (by Spotify ID, then exact artist+title, then create), reuses an existing AirPlay at `(radio_station, song, broadcasted_at)` if one was created before the interruption, otherwise creates one, and marks the log `success`. Skips logs without `spotify_track_id` and logs younger than `min_age` (default 10 minutes).
-- `HitPotentialCalculator` - Predicts song hit potential (0-100) using multi-signal scoring: audio features (50%), artist popularity (20%), engagement metrics (15%), release recency (15%)
+- `HitPotentialCalculator` - Predicts song hit potential (0-100) using multi-signal scoring: audio features (45%), artist popularity (20%), engagement metrics (15%), release recency (10%), lyrics sentiment (10%). Songs without analyzed lyrics receive a neutral 0.5 lyrics score
+- `Lyrics/` - LRCLIB lyrics fetching (`LrclibFinder`). Free, public-domain-leaning corpus, no auth. Stores only sentiment + metadata + LRCLIB URL on the `Lyric` model — full lyrics text is refetched on demand to avoid licensing concerns.
+- `Llm::LyricsSentimentAnalyzer` - Analyzes lyrics with GPT-4.1-mini and returns `{sentiment: -1..1, themes: [...], language, confidence}`. Multilingual (Dutch + English + others)
+- `LyricsSentimentTrendCalculator` - Time-bucketed average lyrics sentiment for a station's airplays. Granularity follows the period: hour for days, day for weeks/months, month for years, year for "all"
 - `SoundProfileGenerator` - Generates per-station sound profiles with audio feature averages, top genres/tags, release decade distribution, and bilingual descriptions (EN/NL). Uses song-count-weighted percentiles and peak decade detection (≥15% threshold) for accurate era descriptions instead of naive min/max year ranges
 - `NaturalLanguageSearch` - Translates free-text queries (e.g., "upbeat Dutch songs on Radio 538 last week") into structured filters via `Llm::QueryTranslator`, then applies faceted search. Supports mood-based filtering using Spotify audio feature ranges, result limiting ("top 3 songs", "most popular song" → `.limit()`), and lyrics-based song identification
 - `Llm::Base` - OpenAI GPT-4.1-mini integration with 1-hour response caching, circuit breaker, and exponential backoff
@@ -125,6 +131,7 @@ Sidekiq jobs in `app/jobs/` run on schedules defined in `config/sidekiq.yml`:
 - `AvgSongGapCalculationJob` (`compute`) - Daily at 5am, calculates per-station average song gaps
 - `ArtistEnrichmentBatchJob` (`enrichment`) - Weekly Sunday 3am, batch enqueues artist enrichment
 - `LastfmEnrichmentBatchJob` (`enrichment`) - Weekly Sunday 4am, batch enqueues Last.fm enrichment for songs/artists
+- `LyricsEnrichmentBatchJob` (`enrichment`) - Weekly Sunday 5am, batch enqueues lyrics-sentiment enrichment for recently-played songs (gated by `LYRICS_ENRICHMENT_ENABLED`)
 
 On-demand enrichment jobs (triggered by import flow, not scheduled — all on the `enrichment` queue):
 - `SongExternalIdsEnrichmentJob` - Enriches songs with Deezer, iTunes, and MusicBrainz IDs after import
@@ -213,14 +220,15 @@ Formula: `(weekly_airplay * 100) + (popularity_boost * 50)`. Artists default to 
 
 ### Hit Potential Score
 
-`HitPotentialCalculator` predicts how likely a song is to be a hit (0-100), combining four signal categories based on academic research:
+`HitPotentialCalculator` predicts how likely a song is to be a hit (0-100), combining five signal categories based on academic research:
 
 | Signal | Weight | Data Source | Research Basis |
 |--------|--------|-------------|----------------|
-| Audio features | 50% | `MusicProfile` (danceability, energy, loudness, etc.) | Rusconi 2024, ~80-89% accuracy |
+| Audio features | 45% | `MusicProfile` (danceability, energy, loudness, etc.) | Rusconi 2024, ~80-89% accuracy |
 | Artist popularity | 20% | `Artist#spotify_popularity`, `spotify_followers_count`, `lastfm_listeners` | Interiano 2018: +15% accuracy |
 | Engagement metrics | 15% | `Song#popularity`, `lastfm_listeners`, `lastfm_playcount` | Mountzouris 2025 |
-| Release recency | 15% | `Song#release_date` (exponential decay, 5-year half-life) | SpotiPred 2022 |
+| Release recency | 10% | `Song#release_date` (exponential decay, 5-year half-life) | SpotiPred 2022 |
+| Lyrics sentiment | 10% | `Lyric#sentiment` (linear -1..1 → 0..1; neutral 0.5 when missing) | Lyrics for Success, ACL 2024 |
 
 Audio features use Gaussian scoring against optimal ranges for popular songs (e.g., danceability center=0.64, loudness center=-6.0 dB), with per-feature weights from Random Forest feature importance. Engagement and follower counts are log-normalized.
 
@@ -330,6 +338,8 @@ Songs, artists, and radio stations support lookup by slug in addition to numeric
 **Important:** `Song.most_played` and `Artist.most_played` use explicit `.select()` lists. When adding new serialized attributes, they must also be added to these select clauses to avoid `ActiveModel::MissingAttributeError`.
 - Sound profile endpoint (public, no auth required):
   - `GET /api/v1/radio_stations/:id/sound_profile` — audio feature averages, top genres/tags, release decade distribution, bilingual descriptions (`description_en`/`description_nl`), era analysis with weighted percentiles (`release_year_range.era_description_en`/`era_description_nl`, `peak_decades`, `median_year`)
+- Sentiment trend endpoint (public, no auth required):
+  - `GET /api/v1/radio_stations/:id/sentiment_trend?period=4_weeks` — time-bucketed average lyrics sentiment per station. Granularity follows the period (hour for days, day for weeks/months, month for years, year for "all"). Songs without analyzed lyrics are excluded from the average
 - Widget endpoints (public, no auth required):
   - `GET /api/v1/songs/:id/widget` — total plays, station count, release date, duration
   - `GET /api/v1/artists/:id/widget` — total plays, song count, station count, country of origin

--- a/app/controllers/api/v1/radio_stations_controller.rb
+++ b/app/controllers/api/v1/radio_stations_controller.rb
@@ -8,7 +8,7 @@ module Api
       rate_limit to: 5, within: 1.minute, by: -> { request.remote_ip }, only: :stream_proxy, name: 'stream-proxy',
                  with: -> { render json: { error: 'Rate limit exceeded' }, status: :too_many_requests }
 
-      skip_before_action :authenticate_client!, only: %i[stream_proxy widget sound_profile sentiment_trend]
+      skip_before_action :authenticate_client!, only: %i[stream_proxy widget sound_profile]
       before_action :set_radio_station, only: %i[show status data classifiers stream_proxy bar_chart_race
                                                  widget sound_profile sentiment_trend diversity_metrics exposure_saturation]
 

--- a/app/controllers/api/v1/radio_stations_controller.rb
+++ b/app/controllers/api/v1/radio_stations_controller.rb
@@ -8,9 +8,9 @@ module Api
       rate_limit to: 5, within: 1.minute, by: -> { request.remote_ip }, only: :stream_proxy, name: 'stream-proxy',
                  with: -> { render json: { error: 'Rate limit exceeded' }, status: :too_many_requests }
 
-      skip_before_action :authenticate_client!, only: %i[stream_proxy widget sound_profile]
+      skip_before_action :authenticate_client!, only: %i[stream_proxy widget sound_profile sentiment_trend]
       before_action :set_radio_station, only: %i[show status data classifiers stream_proxy bar_chart_race
-                                                 widget sound_profile diversity_metrics exposure_saturation]
+                                                 widget sound_profile sentiment_trend diversity_metrics exposure_saturation]
 
       def index
         render json: RadioStationSerializer.new(RadioStation.all).serializable_hash.to_json
@@ -97,6 +97,10 @@ module Api
           start_time: parse_time_param(:start_time),
           end_time: parse_time_param(:end_time)
         ) }.to_json
+      end
+
+      def sentiment_trend
+        render json: { data: @radio_station.sentiment_trend(period: params[:period]) }.to_json
       end
 
       def diversity_metrics

--- a/app/jobs/lyrics_enrichment_batch_job.rb
+++ b/app/jobs/lyrics_enrichment_batch_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class LyricsEnrichmentBatchJob
+  include Sidekiq::Job
+  sidekiq_options queue: 'enrichment'
+
+  def perform
+    LyricsEnrichmentJob.enqueue_all
+  end
+end

--- a/app/jobs/lyrics_enrichment_job.rb
+++ b/app/jobs/lyrics_enrichment_job.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+class LyricsEnrichmentJob
+  THROTTLE_INTERVAL = 2 # seconds between jobs
+
+  include Sidekiq::Job
+  sidekiq_options queue: 'enrichment', retry: 2
+
+  def self.enqueue_all
+    return unless enabled?
+
+    index = 0
+    enrichable_songs.find_each do |song|
+      perform_in((index * THROTTLE_INTERVAL).seconds, song.id)
+      index += 1
+    end
+  end
+
+  def self.enabled?
+    ENV['LYRICS_ENRICHMENT_ENABLED'] == 'true'
+  end
+
+  def self.enrichable_songs
+    week_ago = 7.days.ago
+    stale = Lyric::STALE_AFTER.ago
+
+    # Only enrich songs played at least once in the last week, where lyrics are missing or stale.
+    # Cheap MVP scope to keep LLM cost predictable.
+    Song
+      .joins(:air_plays)
+      .where(air_plays: { broadcasted_at: week_ago.. })
+      .left_joins(:lyric)
+      .where('lyrics.id IS NULL OR lyrics.enriched_at IS NULL OR lyrics.enriched_at < ?', stale)
+      .distinct
+  end
+
+  def perform(song_id)
+    return unless self.class.enabled?
+
+    song = Song.find_by(id: song_id)
+    return if song.blank?
+
+    artist_name = song.artists.first&.name
+    return if artist_name.blank?
+
+    lyrics_data = Lyrics::LrclibFinder.new.find(
+      artist_name: artist_name,
+      track_name: song.title,
+      duration: song.duration_ms ? (song.duration_ms / 1000.0).round : nil
+    )
+    return if lyrics_data.blank? || lyrics_data[:plain_lyrics].blank?
+
+    sentiment = Llm::LyricsSentimentAnalyzer.new(lyrics: lyrics_data[:plain_lyrics]).analyze
+    return if sentiment.blank?
+
+    upsert_lyric!(song, lyrics_data, sentiment)
+  end
+
+  private
+
+  def upsert_lyric!(song, lyrics_data, sentiment)
+    lyric = song.lyric || song.build_lyric
+    lyric.assign_attributes(
+      sentiment: sentiment[:sentiment],
+      themes: sentiment[:themes],
+      language: sentiment[:language],
+      source: 'lrclib',
+      source_id: lyrics_data[:id],
+      source_url: lyrics_data[:source_url],
+      enriched_at: Time.current
+    )
+    lyric.save!
+  end
+end

--- a/app/models/concerns/external_enrichment_concern.rb
+++ b/app/models/concerns/external_enrichment_concern.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module ExternalEnrichmentConcern
+  extend ActiveSupport::Concern
+
+  def enrich_with_external_services
+    enrich_with_deezer if should_enrich_with_deezer?
+    enrich_with_itunes if should_enrich_with_itunes?
+    enrich_with_tidal if should_enrich_with_tidal?
+    enrich_with_music_brainz if should_enrich_with_music_brainz?
+  end
+
+  def needs_external_ids_enrichment?
+    should_enrich_with_deezer? || should_enrich_with_itunes? ||
+      should_enrich_with_tidal? || should_enrich_with_music_brainz?
+  end
+
+  private
+
+  def should_enrich_with_deezer?
+    (id_on_deezer.blank? || duration_ms.blank?) && (isrcs.present? || title.present?)
+  end
+
+  def should_enrich_with_itunes?
+    (id_on_itunes.blank? || duration_ms.blank?) && title.present?
+  end
+
+  def should_enrich_with_tidal?
+    id_on_tidal.blank? && title.present?
+  end
+
+  def should_enrich_with_music_brainz?
+    isrcs.size == 1
+  end
+end

--- a/app/models/lyric.rb
+++ b/app/models/lyric.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: lyrics
+#
+#  id          :bigint           not null, primary key
+#  enriched_at :datetime
+#  language    :string(8)
+#  sentiment   :decimal(3, 2)
+#  source      :string           default("lrclib"), not null
+#  source_url  :string
+#  themes      :string           default([]), is an Array
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  song_id     :bigint           not null
+#  source_id   :string
+#
+# Indexes
+#
+#  index_lyrics_on_enriched_at  (enriched_at)
+#  index_lyrics_on_sentiment    (sentiment)
+#  index_lyrics_on_song_id      (song_id) UNIQUE
+#  index_lyrics_on_themes       (themes) USING gin
+#
+# Foreign Keys
+#
+#  fk_rails_...  (song_id => songs.id)
+#
+class Lyric < ApplicationRecord
+  STALE_AFTER = 90.days
+
+  belongs_to :song
+
+  validates :song_id, uniqueness: true
+  validates :sentiment, numericality: { greater_than_or_equal_to: -1, less_than_or_equal_to: 1, allow_nil: true }
+
+  scope :stale, -> { where(enriched_at: nil).or(where(enriched_at: ...STALE_AFTER.ago)) }
+
+  def stale?
+    enriched_at.nil? || enriched_at < STALE_AFTER.ago
+  end
+end

--- a/app/models/radio_station.rb
+++ b/app/models/radio_station.rb
@@ -148,6 +148,10 @@ class RadioStation < ActiveRecord::Base
     SoundProfileGenerator.new(radio_station: self, start_time: start_time, end_time: end_time).generate
   end
 
+  def sentiment_trend(period: '4_weeks')
+    LyricsSentimentTrendCalculator.new(radio_station: self, period: period).calculate
+  end
+
   def widget_data
     day_range = 1.day.ago..Time.zone.now
     week_range = 1.week.ago..Time.zone.now

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -64,6 +64,7 @@ class Song < ApplicationRecord
   include SongSearchConcern
   include Sluggable
   include TitleNormalizable
+  include ExternalEnrichmentConcern
 
   pg_search_scope :search_by_text,
                   against: :search_text,
@@ -81,6 +82,7 @@ class Song < ApplicationRecord
   has_many :chart_positions, as: :positianable
   has_many :song_import_logs, dependent: :nullify
   has_one :music_profile, dependent: :destroy
+  has_one :lyric, dependent: :destroy
 
   before_create :set_search_text
   before_create :set_slug
@@ -297,17 +299,6 @@ class Song < ApplicationRecord
     }
   end
 
-  def enrich_with_external_services
-    enrich_with_deezer if should_enrich_with_deezer?
-    enrich_with_itunes if should_enrich_with_itunes?
-    enrich_with_tidal if should_enrich_with_tidal?
-    enrich_with_music_brainz if should_enrich_with_music_brainz?
-  end
-
-  def needs_external_ids_enrichment?
-    should_enrich_with_deezer? || should_enrich_with_itunes? || should_enrich_with_tidal? || should_enrich_with_music_brainz?
-  end
-
   private
 
   def update_air_plays_obsolete_songs(songs, most_played_song)
@@ -347,21 +338,5 @@ class Song < ApplicationRecord
 
   def should_update_youtube?
     id_on_youtube.blank? && (id_on_spotify.present? || isrcs.present? || title.present?)
-  end
-
-  def should_enrich_with_deezer?
-    (id_on_deezer.blank? || duration_ms.blank?) && (isrcs.present? || title.present?)
-  end
-
-  def should_enrich_with_itunes?
-    (id_on_itunes.blank? || duration_ms.blank?) && title.present?
-  end
-
-  def should_enrich_with_tidal?
-    id_on_tidal.blank? && title.present?
-  end
-
-  def should_enrich_with_music_brainz?
-    isrcs.size == 1
   end
 end

--- a/app/services/circuit_breaker_config.rb
+++ b/app/services/circuit_breaker_config.rb
@@ -56,6 +56,12 @@ class CircuitBreakerConfig
       volume_threshold: 5,
       error_threshold: 50,
       time_window: 60
+    },
+    lrclib: {
+      sleep_window: 60,
+      volume_threshold: 5,
+      error_threshold: 50,
+      time_window: 60
     }
   }.freeze
 

--- a/app/services/hit_potential_calculator.rb
+++ b/app/services/hit_potential_calculator.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-# Calculates a hit potential score (0-100) for a song by combining four signal categories:
+# Calculates a hit potential score (0-100) for a song by combining five signal categories:
 #
-# 1. Audio features (50%) — Gaussian scoring against optimal ranges for popular songs.
+# 1. Audio features (45%) — Gaussian scoring against optimal ranges for popular songs.
 #    Feature weights from Random Forest importance (Rusconi 2024). Each feature is scored
 #    by proximity to its optimal center value using exp(-0.5 * ((value - center) / spread)^2).
 #
@@ -14,9 +14,13 @@
 #    Spotify popularity was found to be the most decisive single predictor (Mountzouris 2025).
 #    Large values are log-normalized to prevent outlier dominance.
 #
-# 4. Release recency (15%) — Exponential decay from release date with a 5-year half-life.
+# 4. Release recency (10%) — Exponential decay from release date with a 5-year half-life.
 #    Recent releases consistently correlate with higher popularity (SpotiPred, Gulmatico 2022).
 #    Songs with no release date receive a neutral 0.5 score.
+#
+# 5. Lyrics sentiment (10%) — Linear mapping of lyrics sentiment (-1..1) to a 0..1 score.
+#    Lyrics embedding features add predictive power for popularity beyond audio features alone
+#    (Lyrics for Success, ACL 2024). Songs without analyzed lyrics receive a neutral 0.5 score.
 #
 # Usage:
 #   score = HitPotentialCalculator.new(song).calculate  # => 0.0..100.0 or nil
@@ -35,10 +39,11 @@ class HitPotentialCalculator
   # - Adding engagement metrics: +10-60% (multi-signal studies)
   # - Release recency correlates with popularity (SpotiPred 2022)
   SIGNAL_WEIGHTS = {
-    audio_features: 0.50,
+    audio_features: 0.45,
     artist_popularity: 0.20,
     engagement: 0.15,
-    release_recency: 0.15
+    release_recency: 0.10,
+    lyrics_sentiment: 0.10
   }.freeze
 
   # Audio feature weights based on Random Forest feature importance from Rusconi (2024).
@@ -85,7 +90,8 @@ class HitPotentialCalculator
     score = audio_features_score * SIGNAL_WEIGHTS[:audio_features] +
             artist_popularity_score * SIGNAL_WEIGHTS[:artist_popularity] +
             engagement_score * SIGNAL_WEIGHTS[:engagement] +
-            release_recency_score * SIGNAL_WEIGHTS[:release_recency]
+            release_recency_score * SIGNAL_WEIGHTS[:release_recency] +
+            lyrics_sentiment_score * SIGNAL_WEIGHTS[:lyrics_sentiment]
 
     (score * 100).round(2).clamp(0.0, 100.0)
   end
@@ -98,6 +104,7 @@ class HitPotentialCalculator
       artist_popularity: (artist_popularity_score * SIGNAL_WEIGHTS[:artist_popularity] * 100).round(2),
       engagement: (engagement_score * SIGNAL_WEIGHTS[:engagement] * 100).round(2),
       release_recency: (release_recency_score * SIGNAL_WEIGHTS[:release_recency] * 100).round(2),
+      lyrics_sentiment: (lyrics_sentiment_score * SIGNAL_WEIGHTS[:lyrics_sentiment] * 100).round(2),
       audio_features_detail: audio_features_breakdown
     }
   end
@@ -160,6 +167,16 @@ class HitPotentialCalculator
 
     decay_years = 5.0
     Math.exp(-days_old / (decay_years * 365.0))
+  end
+
+  # Lyrics sentiment signal (Lyrics for Success, ACL 2024: lyrics embeddings add predictive
+  # power beyond audio features). Linear mapping of -1..1 to 0..1; neutral 0.5 when missing
+  # so songs without analyzed lyrics aren't penalized.
+  def lyrics_sentiment_score
+    sentiment = @song.lyric&.sentiment
+    return 0.5 if sentiment.nil?
+
+    ((sentiment.to_f + 1.0) / 2.0).clamp(0.0, 1.0)
   end
 
   def log_normalize(value, max_exponent)

--- a/app/services/llm/lyrics_sentiment_analyzer.rb
+++ b/app/services/llm/lyrics_sentiment_analyzer.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Llm
+  class LyricsSentimentAnalyzer < Base
+    MAX_LYRICS_CHARS = 4_000
+
+    attr_reader :raw_response
+
+    def initialize(lyrics:)
+      super()
+      @lyrics = lyrics.to_s
+      @raw_response = {}
+    end
+
+    def analyze
+      truncated = truncate_lyrics(@lyrics)
+      return nil if truncated.blank?
+
+      response = chat(system_prompt: system_prompt, user_message: truncated, max_tokens: 256)
+      @raw_response = { request_chars: truncated.length, response: response }
+      return nil if response.blank?
+
+      parse_response(response)
+    end
+
+    private
+
+    def truncate_lyrics(text)
+      text.length > MAX_LYRICS_CHARS ? text[0, MAX_LYRICS_CHARS] : text
+    end
+
+    def system_prompt
+      <<~PROMPT
+        You are a music lyrics analyst. You receive song lyrics in any language (Dutch, English, etc.).
+        Output a JSON object describing the lyrics on these axes:
+
+        - "sentiment": float in [-1.0, 1.0]. -1 = very negative/sad/angry, 0 = neutral/mixed, +1 = very positive/joyful.
+        - "themes": array of 1-5 short lowercase theme tags chosen from this controlled list:
+          love, heartbreak, loss, nostalgia, hope, faith, party, dance, friendship, family,
+          empowerment, rebellion, social, political, money, fame, sex, loneliness, anxiety,
+          anger, peace, nature, travel, summer, winter, christmas, drugs, violence, freedom, work
+        - "language": ISO 639-1 code of the dominant language ("nl", "en", "de", "fr", "es", "it", "tr", "ar", etc.).
+        - "confidence": float in [0.0, 1.0] expressing how confident you are in the sentiment score.
+
+        If the lyrics are too short, garbled, or otherwise unanalyzable, return:
+        {"sentiment": null, "themes": [], "language": null, "confidence": 0.0}
+
+        Return ONLY the JSON object. No explanation, no code fences.
+      PROMPT
+    end
+
+    def parse_response(response)
+      json = extract_json(response)
+      return nil if json.blank?
+
+      parsed = JSON.parse(json)
+      return nil unless parsed.is_a?(Hash)
+
+      {
+        sentiment: clamp_float(parsed['sentiment'], -1.0, 1.0),
+        themes: extract_themes(parsed['themes']),
+        language: parsed['language'].presence,
+        confidence: clamp_float(parsed['confidence'], 0.0, 1.0)
+      }
+    rescue JSON::ParserError => e
+      Rails.logger.warn("[LLM::LyricsSentimentAnalyzer] Failed to parse JSON: #{e.message}")
+      nil
+    end
+
+    def clamp_float(value, min, max)
+      return nil if value.nil?
+
+      value.to_f.clamp(min, max)
+    end
+
+    def extract_themes(themes)
+      return [] unless themes.is_a?(Array)
+
+      themes.filter_map { |t| t.to_s.downcase.strip.presence }.uniq.first(5)
+    end
+  end
+end

--- a/app/services/lyrics/base.rb
+++ b/app/services/lyrics/base.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Lyrics
+  class Base
+    BASE_URL = 'https://lrclib.net/api/'
+    USER_AGENT = 'Airplays/1.0 (https://github.com/samuelvaneck/airplays)'
+
+    include CircuitBreakable
+
+    circuit_breaker_for :lrclib
+
+    private
+
+    def get(path, params = {})
+      with_circuit_breaker do
+        with_exponential_backoff(max_attempts: 3, base_delay: 1) do
+          response = connection.get(path, params)
+          handle_rate_limit_response(response)
+          response.success? ? response.body : nil
+        end
+      end
+    rescue StandardError => e
+      ExceptionNotifier.notify(e)
+      Rails.logger.error("[Lyrics] LRCLIB request failed: #{e.class}: #{e.message}")
+      nil
+    end
+
+    def connection
+      @connection ||= Faraday.new(url: BASE_URL, headers: { 'User-Agent' => USER_AGENT }) do |conn|
+        conn.options.timeout = 10
+        conn.options.open_timeout = 5
+        conn.response :json
+      end
+    end
+  end
+end

--- a/app/services/lyrics/lrclib_finder.rb
+++ b/app/services/lyrics/lrclib_finder.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Lyrics
+  class LrclibFinder < Base
+    def find(artist_name:, track_name:, album_name: nil, duration: nil)
+      body = get('get', {
+        artist_name: artist_name,
+        track_name: track_name,
+        album_name: album_name,
+        duration: duration
+      }.compact)
+      return if body.blank? || body['instrumental']
+
+      normalize(body)
+    end
+
+    def fetch_by_id(id)
+      body = get("get/#{id}")
+      return if body.blank? || body['instrumental']
+
+      normalize(body)
+    end
+
+    private
+
+    def normalize(body)
+      id = body['id']
+      {
+        id: id&.to_s,
+        plain_lyrics: body['plainLyrics'],
+        track_name: body['trackName'],
+        artist_name: body['artistName'],
+        album_name: body['albumName'],
+        duration: body['duration'],
+        source_url: "#{BASE_URL}get/#{id}"
+      }
+    end
+  end
+end

--- a/app/services/lyrics_sentiment_trend_calculator.rb
+++ b/app/services/lyrics_sentiment_trend_calculator.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# Time-bucketed average lyrics sentiment for a radio station's airplays.
+# Returns one row per bucket: { period_start, average_sentiment, play_count }.
+class LyricsSentimentTrendCalculator
+  BUCKET_EXPRESSIONS = {
+    hour: Arel.sql("date_trunc('hour', air_plays.broadcasted_at)"),
+    day: Arel.sql("date_trunc('day', air_plays.broadcasted_at)"),
+    month: Arel.sql("date_trunc('month', air_plays.broadcasted_at)"),
+    year: Arel.sql("date_trunc('year', air_plays.broadcasted_at)")
+  }.freeze
+  AVG_EXPR = Arel.sql('AVG(lyrics.sentiment)::float')
+  COUNT_EXPR = Arel.sql('COUNT(*)')
+
+  def initialize(radio_station:, period: '4_weeks')
+    @radio_station = radio_station
+    @period = period.presence || '4_weeks'
+  end
+
+  def calculate
+    return [] if start_time.nil?
+
+    bucket_expr = BUCKET_EXPRESSIONS.fetch(bucket_granularity)
+
+    rows = AirPlay
+             .where(radio_station: @radio_station, broadcasted_at: start_time..)
+             .joins(song: :lyric)
+             .where.not(lyrics: { sentiment: nil })
+             .group(bucket_expr)
+             .pluck(bucket_expr, AVG_EXPR, COUNT_EXPR)
+
+    rows
+      .map { |bucket_at, avg, count| { period_start: bucket_at, average_sentiment: avg.round(3), play_count: count } }
+      .sort_by { |b| b[:period_start] }
+  end
+
+  private
+
+  def start_time
+    @start_time ||= begin
+      duration = PeriodParser.parse_duration(@period)
+      duration ? duration.ago : @radio_station.air_plays.minimum(:broadcasted_at)
+    end
+  end
+
+  def bucket_granularity
+    return :year if @period == 'all'
+
+    case @period
+    when /year/ then :month
+    when /month/, /week/ then :day
+    when /day/ then :hour
+    else :day
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,6 +56,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
         get :stream_proxy, on: :member
         get :widget, on: :member
         get :sound_profile, on: :member
+        get :sentiment_trend, on: :member
         get :bar_chart_race, on: :member
         get :diversity_metrics, on: :member
         get :exposure_saturation, on: :member

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -47,6 +47,10 @@
         cron: '0 4 * * 0' # weekly Sunday 4am
         queue: enrichment
         enabled: true
+      LyricsEnrichmentBatchJob:
+        cron: '0 5 * * 0' # weekly Sunday 5am
+        queue: enrichment
+        enabled: true
       AvgSongGapCalculationJob:
         cron: '0 5 * * *' # daily at 5am
         queue: compute

--- a/db/migrate/20260506070134_create_lyrics.rb
+++ b/db/migrate/20260506070134_create_lyrics.rb
@@ -1,0 +1,20 @@
+class CreateLyrics < ActiveRecord::Migration[8.1]
+  def change
+    create_table :lyrics do |t|
+      t.references :song, null: false, foreign_key: true, index: { unique: true }
+      t.decimal :sentiment, precision: 3, scale: 2
+      t.string :themes, array: true, default: []
+      t.string :language, limit: 8
+      t.string :source, default: 'lrclib', null: false
+      t.string :source_url
+      t.string :source_id
+      t.datetime :enriched_at
+
+      t.timestamps
+    end
+
+    add_index :lyrics, :themes, using: :gin
+    add_index :lyrics, :sentiment
+    add_index :lyrics, :enriched_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_04_200000) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_06_070134) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -149,6 +149,23 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_200000) do
     t.date "date"
     t.datetime "updated_at", null: false
     t.index ["date"], name: "index_charts_on_date"
+  end
+
+  create_table "lyrics", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "enriched_at"
+    t.string "language", limit: 8
+    t.decimal "sentiment", precision: 3, scale: 2
+    t.bigint "song_id", null: false
+    t.string "source", default: "lrclib", null: false
+    t.string "source_id"
+    t.string "source_url"
+    t.string "themes", default: [], array: true
+    t.datetime "updated_at", null: false
+    t.index ["enriched_at"], name: "index_lyrics_on_enriched_at"
+    t.index ["sentiment"], name: "index_lyrics_on_sentiment"
+    t.index ["song_id"], name: "index_lyrics_on_song_id", unique: true
+    t.index ["themes"], name: "index_lyrics_on_themes", using: :gin
   end
 
   create_table "music_profiles", force: :cascade do |t|
@@ -308,6 +325,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_200000) do
   add_foreign_key "air_plays", "radio_stations"
   add_foreign_key "air_plays", "songs"
   add_foreign_key "chart_positions", "charts"
+  add_foreign_key "lyrics", "songs"
   add_foreign_key "music_profiles", "songs"
   add_foreign_key "radio_station_songs", "radio_stations"
   add_foreign_key "radio_station_songs", "songs"

--- a/lib/tasks/lyrics.rake
+++ b/lib/tasks/lyrics.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+namespace :lyrics do
+  desc 'Enqueue LyricsEnrichmentJob for recently-played songs missing or stale lyrics. ' \
+       'Requires LYRICS_ENRICHMENT_ENABLED=true. Usage: rake lyrics:backfill'
+  task backfill: :environment do
+    unless LyricsEnrichmentJob.enabled?
+      $stdout.puts 'Skipping: LYRICS_ENRICHMENT_ENABLED is not set to true'
+      next
+    end
+
+    count = LyricsEnrichmentJob.enrichable_songs.count
+    $stdout.puts "Enqueuing lyrics enrichment for #{count} songs..."
+    LyricsEnrichmentJob.enqueue_all
+    $stdout.puts 'Done.'
+  end
+end

--- a/spec/factories/lyrics.rb
+++ b/spec/factories/lyrics.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :lyric do
+    song
+    sentiment { 0.42 }
+    themes { %w[love nostalgia] }
+    language { 'en' }
+    source { 'lrclib' }
+    source_id { '390' }
+    source_url { 'https://lrclib.net/api/get/390' }
+    enriched_at { Time.current }
+  end
+end

--- a/spec/fixtures/vcr_cassettes/lyrics/lrclib_finder/_fetch_by_id/when_the_id_resolves_to_a_known_track/returns_normalized_lyrics_data.yml
+++ b/spec/fixtures/vcr_cassettes/lyrics/lrclib_finder/_fetch_by_id/when_the_id_resolves_to_a_known_track/returns_normalized_lyrics_data.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://lrclib.net/api/get/390
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Airplays/1.0 (https://github.com/samuelvaneck/airplays)
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.26.3
+      Date:
+      - Wed, 06 May 2026 07:10:44 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - origin, access-control-request-method, access-control-request-headers
+      Access-Control-Allow-Origin:
+      - "*"
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":390,"name":"Blinding Lights","trackName":"Blinding Lights","artistName":"The
+        Weeknd","albumName":"After Hours","duration":200.0,"instrumental":false,"plainLyrics":"Yeah\n\nI''ve
+        been tryna call\n\nI''ve been on my own for long enough\nMaybe you can show
+        me how to love, maybe\n\nI''m going through withdrawals\n\nYou don''t even
+        have to do too much\nYou can turn me on with just a touch, baby\nI look around
+        and\nSin City''s cold and empty (oh)\nNo one''s around to judge me (oh)\nI
+        can''t see clearly when you''re gone\nI said, ooh, I''m blinded by the lights\nNo,
+        I can''t sleep until I feel your touch\n\nI said, ooh, I''m drowning in the
+        night\nOh, when I''m like this, you''re the one I trust\n(Hey, hey, hey)\n\nI''m
+        running out of time\n\n''Cause I can see the sun light up the sky\nSo I hit
+        the road in overdrive, baby, oh\nThe city''s cold and empty (oh)\nNo one''s
+        around to judge me (oh)\nI can''t see clearly when you''re gone\nI said, ooh,
+        I''m blinded by the lights\nNo, I can''t sleep until I feel your touch\n\nI
+        said, ooh, I''m drowning in the night\nOh, when I''m like this, you''re the
+        one I trust\n\nI''m just walking by to let you know (by to let you know)\nI
+        can never say it on the phone (say it on the phone)\nWill never let you go
+        this time (ooh)\nI said, ooh, I''m blinded by the lights\nNo, I can''t sleep
+        until I feel your touch\n(Hey, hey, hey)\n\n(Hey, hey, hey)\n\nI said, ooh,
+        I''m blinded by the lights\nNo, I can''t sleep until I feel your touch\n\n","syncedLyrics":"[00:13.42]
+        Yeah\n[00:14.81] \n[00:26.95] I''ve been tryna call\n[00:28.56] \n[00:29.83]
+        I''ve been on my own for long enough\n[00:32.62] Maybe you can show me how
+        to love, maybe\n[00:37.42] \n[00:38.24] I''m going through withdrawals\n[00:40.61]
+        \n[00:41.10] You don''t even have to do too much\n[00:43.90] You can turn
+        me on with just a touch, baby\n[00:49.41] I look around and\n[00:50.72] Sin
+        City''s cold and empty (oh)\n[00:53.53] No one''s around to judge me (oh)\n[00:56.29]
+        I can''t see clearly when you''re gone\n[01:00.78] I said, ooh, I''m blinded
+        by the lights\n[01:06.57] No, I can''t sleep until I feel your touch\n[01:11.38]
+        \n[01:11.75] I said, ooh, I''m drowning in the night\n[01:17.90] Oh, when
+        I''m like this, you''re the one I trust\n[01:22.23] (Hey, hey, hey)\n[01:24.83]
+        \n[01:34.24] I''m running out of time\n[01:36.21] \n[01:36.96] ''Cause I can
+        see the sun light up the sky\n[01:40.39] So I hit the road in overdrive, baby,
+        oh\n[01:47.08] The city''s cold and empty (oh)\n[01:49.50] No one''s around
+        to judge me (oh)\n[01:52.69] I can''t see clearly when you''re gone\n[01:56.96]
+        I said, ooh, I''m blinded by the lights\n[02:02.84] No, I can''t sleep until
+        I feel your touch\n[02:07.52] \n[02:08.09] I said, ooh, I''m drowning in the
+        night\n[02:13.99] Oh, when I''m like this, you''re the one I trust\n[02:18.85]
+        \n[02:19.33] I''m just walking by to let you know (by to let you know)\n[02:22.20]
+        I can never say it on the phone (say it on the phone)\n[02:25.46] Will never
+        let you go this time (ooh)\n[02:30.59] I said, ooh, I''m blinded by the lights\n[02:36.57]
+        No, I can''t sleep until I feel your touch\n[02:40.79] (Hey, hey, hey)\n[02:43.19]
+        \n[02:51.94] (Hey, hey, hey)\n[02:54.41] \n[03:04.00] I said, ooh, I''m blinded
+        by the lights\n[03:10.01] No, I can''t sleep until I feel your touch\n[03:15.03]
+        \n","lyricsfile":null}'
+  recorded_at: Wed, 06 May 2026 07:10:44 GMT
+recorded_with: VCR 6.4.0

--- a/spec/fixtures/vcr_cassettes/lyrics/lrclib_finder/_find/when_lrclib_cannot_find_the_track/returns_nil.yml
+++ b/spec/fixtures/vcr_cassettes/lyrics/lrclib_finder/_find/when_lrclib_cannot_find_the_track/returns_nil.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://lrclib.net/api/get?artist_name=NonexistentArtistXYZ123&track_name=NonexistentTrackXYZ123
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Airplays/1.0 (https://github.com/samuelvaneck/airplays)
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - nginx/1.26.3
+      Date:
+      - Wed, 06 May 2026 07:10:40 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '84'
+      Connection:
+      - keep-alive
+      Vary:
+      - origin, access-control-request-method, access-control-request-headers
+      Access-Control-Allow-Origin:
+      - "*"
+    body:
+      encoding: UTF-8
+      string: '{"message":"Failed to find specified track","name":"TrackNotFound","statusCode":404}'
+  recorded_at: Wed, 06 May 2026 07:10:40 GMT
+recorded_with: VCR 6.4.0

--- a/spec/fixtures/vcr_cassettes/lyrics/lrclib_finder/_find/when_lrclib_returns_lyrics_for_a_known_track/returns_normalized_lyrics_data.yml
+++ b/spec/fixtures/vcr_cassettes/lyrics/lrclib_finder/_find/when_lrclib_returns_lyrics_for_a_known_track/returns_normalized_lyrics_data.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://lrclib.net/api/get?artist_name=The%20Weeknd&track_name=Blinding%20Lights
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Airplays/1.0 (https://github.com/samuelvaneck/airplays)
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx/1.26.3
+      Date:
+      - Wed, 06 May 2026 07:10:42 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - origin, access-control-request-method, access-control-request-headers
+      Access-Control-Allow-Origin:
+      - "*"
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":390,"name":"Blinding Lights","trackName":"Blinding Lights","artistName":"The
+        Weeknd","albumName":"After Hours","duration":200.0,"instrumental":false,"plainLyrics":"Yeah\n\nI''ve
+        been tryna call\n\nI''ve been on my own for long enough\nMaybe you can show
+        me how to love, maybe\n\nI''m going through withdrawals\n\nYou don''t even
+        have to do too much\nYou can turn me on with just a touch, baby\nI look around
+        and\nSin City''s cold and empty (oh)\nNo one''s around to judge me (oh)\nI
+        can''t see clearly when you''re gone\nI said, ooh, I''m blinded by the lights\nNo,
+        I can''t sleep until I feel your touch\n\nI said, ooh, I''m drowning in the
+        night\nOh, when I''m like this, you''re the one I trust\n(Hey, hey, hey)\n\nI''m
+        running out of time\n\n''Cause I can see the sun light up the sky\nSo I hit
+        the road in overdrive, baby, oh\nThe city''s cold and empty (oh)\nNo one''s
+        around to judge me (oh)\nI can''t see clearly when you''re gone\nI said, ooh,
+        I''m blinded by the lights\nNo, I can''t sleep until I feel your touch\n\nI
+        said, ooh, I''m drowning in the night\nOh, when I''m like this, you''re the
+        one I trust\n\nI''m just walking by to let you know (by to let you know)\nI
+        can never say it on the phone (say it on the phone)\nWill never let you go
+        this time (ooh)\nI said, ooh, I''m blinded by the lights\nNo, I can''t sleep
+        until I feel your touch\n(Hey, hey, hey)\n\n(Hey, hey, hey)\n\nI said, ooh,
+        I''m blinded by the lights\nNo, I can''t sleep until I feel your touch\n\n","syncedLyrics":"[00:13.42]
+        Yeah\n[00:14.81] \n[00:26.95] I''ve been tryna call\n[00:28.56] \n[00:29.83]
+        I''ve been on my own for long enough\n[00:32.62] Maybe you can show me how
+        to love, maybe\n[00:37.42] \n[00:38.24] I''m going through withdrawals\n[00:40.61]
+        \n[00:41.10] You don''t even have to do too much\n[00:43.90] You can turn
+        me on with just a touch, baby\n[00:49.41] I look around and\n[00:50.72] Sin
+        City''s cold and empty (oh)\n[00:53.53] No one''s around to judge me (oh)\n[00:56.29]
+        I can''t see clearly when you''re gone\n[01:00.78] I said, ooh, I''m blinded
+        by the lights\n[01:06.57] No, I can''t sleep until I feel your touch\n[01:11.38]
+        \n[01:11.75] I said, ooh, I''m drowning in the night\n[01:17.90] Oh, when
+        I''m like this, you''re the one I trust\n[01:22.23] (Hey, hey, hey)\n[01:24.83]
+        \n[01:34.24] I''m running out of time\n[01:36.21] \n[01:36.96] ''Cause I can
+        see the sun light up the sky\n[01:40.39] So I hit the road in overdrive, baby,
+        oh\n[01:47.08] The city''s cold and empty (oh)\n[01:49.50] No one''s around
+        to judge me (oh)\n[01:52.69] I can''t see clearly when you''re gone\n[01:56.96]
+        I said, ooh, I''m blinded by the lights\n[02:02.84] No, I can''t sleep until
+        I feel your touch\n[02:07.52] \n[02:08.09] I said, ooh, I''m drowning in the
+        night\n[02:13.99] Oh, when I''m like this, you''re the one I trust\n[02:18.85]
+        \n[02:19.33] I''m just walking by to let you know (by to let you know)\n[02:22.20]
+        I can never say it on the phone (say it on the phone)\n[02:25.46] Will never
+        let you go this time (ooh)\n[02:30.59] I said, ooh, I''m blinded by the lights\n[02:36.57]
+        No, I can''t sleep until I feel your touch\n[02:40.79] (Hey, hey, hey)\n[02:43.19]
+        \n[02:51.94] (Hey, hey, hey)\n[02:54.41] \n[03:04.00] I said, ooh, I''m blinded
+        by the lights\n[03:10.01] No, I can''t sleep until I feel your touch\n[03:15.03]
+        \n","lyricsfile":null}'
+  recorded_at: Wed, 06 May 2026 07:10:42 GMT
+recorded_with: VCR 6.4.0

--- a/spec/jobs/lyrics_enrichment_job_spec.rb
+++ b/spec/jobs/lyrics_enrichment_job_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LyricsEnrichmentJob do
+  let(:job) { described_class.new }
+  let(:artist) { create(:artist, name: 'The Weeknd') }
+  let(:song) { create(:song, title: 'Blinding Lights', duration_ms: 200_000, artists: [artist]) }
+  let(:lrclib_payload) do
+    {
+      id: '390',
+      plain_lyrics: "Yeah\nI've been tryna call",
+      track_name: 'Blinding Lights',
+      artist_name: 'The Weeknd',
+      album_name: 'After Hours',
+      duration: 200.0,
+      source_url: 'https://lrclib.net/api/get/390'
+    }
+  end
+  let(:sentiment_payload) do
+    { sentiment: -0.2, themes: %w[loneliness love], language: 'en', confidence: 0.8 }
+  end
+
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:[]).with('LYRICS_ENRICHMENT_ENABLED').and_return('true')
+  end
+
+  describe '#perform' do
+    before do
+      allow_any_instance_of(Lyrics::LrclibFinder).to receive(:find).and_return(lrclib_payload) # rubocop:disable RSpec/AnyInstance
+      allow_any_instance_of(Llm::LyricsSentimentAnalyzer).to receive(:analyze).and_return(sentiment_payload) # rubocop:disable RSpec/AnyInstance
+    end
+
+    it 'creates a Lyric record with sentiment data' do
+      expect { job.perform(song.id) }.to change(Lyric, :count).by(1)
+    end
+
+    context 'with a song that has no existing lyric' do
+      let(:lyric) do
+        job.perform(song.id)
+        song.reload.lyric
+      end
+      let(:expected_attributes) do
+        { sentiment: -0.2, themes: %w[loneliness love], language: 'en',
+          source: 'lrclib', source_id: '390', source_url: 'https://lrclib.net/api/get/390' }
+      end
+
+      it 'persists the analyzer output and source metadata', :aggregate_failures do
+        expect(lyric).to have_attributes(expected_attributes)
+        expect(lyric.enriched_at).to be_within(5.seconds).of(Time.current)
+      end
+    end
+
+    context 'when LYRICS_ENRICHMENT_ENABLED is not set' do
+      before { allow(ENV).to receive(:[]).with('LYRICS_ENRICHMENT_ENABLED').and_return(nil) }
+
+      it 'does not create a lyric' do
+        expect { job.perform(song.id) }.not_to change(Lyric, :count)
+      end
+    end
+
+    context 'when LRCLIB returns nothing' do
+      before do
+        allow_any_instance_of(Lyrics::LrclibFinder).to receive(:find).and_return(nil) # rubocop:disable RSpec/AnyInstance
+      end
+
+      it 'does not create a lyric' do
+        expect { job.perform(song.id) }.not_to change(Lyric, :count)
+      end
+    end
+
+    context 'when sentiment analyzer returns nil' do
+      before do
+        allow_any_instance_of(Llm::LyricsSentimentAnalyzer).to receive(:analyze).and_return(nil) # rubocop:disable RSpec/AnyInstance
+      end
+
+      it 'does not create a lyric' do
+        expect { job.perform(song.id) }.not_to change(Lyric, :count)
+      end
+    end
+
+    context 'when the song already has a lyric' do
+      let!(:existing) { create(:lyric, song: song, sentiment: 0.5, enriched_at: 1.year.ago) }
+
+      it 'updates the existing record in place', :aggregate_failures do
+        expect { job.perform(song.id) }.not_to change(Lyric, :count)
+        expect(existing.reload.sentiment).to eq(-0.2)
+      end
+    end
+
+    context 'when the song has no artist' do
+      let(:song) { create(:song, title: 'X', duration_ms: nil) }
+
+      before { song.artists.destroy_all }
+
+      it 'does not create a lyric' do
+        expect { job.perform(song.id) }.not_to change(Lyric, :count)
+      end
+    end
+  end
+
+  describe '.enqueue_all' do
+    let!(:radio_station) { create(:radio_station) }
+    let!(:song_played_recently) { create(:song, artists: [artist]) }
+    let!(:song_played_long_ago) { create(:song) }
+    let(:song_with_fresh_lyric) { create(:song, artists: [artist]) }
+
+    before do
+      create(:air_play, song: song_played_recently, radio_station: radio_station, broadcasted_at: 1.day.ago)
+      create(:air_play, song: song_played_long_ago, radio_station: radio_station, broadcasted_at: 30.days.ago)
+      create(:air_play, song: song_with_fresh_lyric, radio_station: radio_station, broadcasted_at: 1.day.ago)
+      create(:lyric, song: song_with_fresh_lyric, enriched_at: 1.day.ago)
+      allow(described_class).to receive(:perform_in)
+    end
+
+    it 'enqueues recently-played songs missing fresh lyrics' do
+      described_class.enqueue_all
+      expect(described_class).to have_received(:perform_in).with(anything, song_played_recently.id)
+    end
+
+    it 'skips songs not played in the last week' do
+      described_class.enqueue_all
+      expect(described_class).not_to have_received(:perform_in).with(anything, song_played_long_ago.id)
+    end
+
+    it 'skips songs with fresh lyrics' do
+      described_class.enqueue_all
+      expect(described_class).not_to have_received(:perform_in).with(anything, song_with_fresh_lyric.id)
+    end
+
+    context 'when LYRICS_ENRICHMENT_ENABLED is not set' do
+      before { allow(ENV).to receive(:[]).with('LYRICS_ENRICHMENT_ENABLED').and_return(nil) }
+
+      it 'does not enqueue anything' do
+        described_class.enqueue_all
+        expect(described_class).not_to have_received(:perform_in)
+      end
+    end
+  end
+end

--- a/spec/models/lyric_spec.rb
+++ b/spec/models/lyric_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Lyric do
+  describe 'associations' do
+    it { is_expected.to belong_to(:song) }
+  end
+
+  describe 'validations' do
+    subject { create(:lyric) }
+
+    it { is_expected.to validate_uniqueness_of(:song_id) }
+
+    it 'rejects sentiment above 1' do
+      lyric = build(:lyric, sentiment: 1.5)
+      expect(lyric).not_to be_valid
+    end
+
+    it 'rejects sentiment below -1' do
+      lyric = build(:lyric, sentiment: -1.5)
+      expect(lyric).not_to be_valid
+    end
+
+    it 'allows nil sentiment' do
+      lyric = build(:lyric, sentiment: nil)
+      expect(lyric).to be_valid
+    end
+  end
+
+  describe '#stale?' do
+    it 'is true when enriched_at is nil' do
+      expect(build(:lyric, enriched_at: nil)).to be_stale
+    end
+
+    it 'is true when enriched_at is older than STALE_AFTER' do
+      expect(build(:lyric, enriched_at: 100.days.ago)).to be_stale
+    end
+
+    it 'is false when enriched_at is recent' do
+      expect(build(:lyric, enriched_at: 1.day.ago)).not_to be_stale
+    end
+  end
+
+  describe '.stale' do
+    let!(:fresh_lyric) { create(:lyric, enriched_at: 1.day.ago) }
+    let!(:stale_lyric) { create(:lyric, enriched_at: 100.days.ago) }
+    let!(:never_lyric) { create(:lyric, enriched_at: nil) }
+
+    it 'includes lyrics older than STALE_AFTER and those never enriched', :aggregate_failures do
+      ids = described_class.stale.pluck(:id)
+      expect(ids).to include(stale_lyric.id, never_lyric.id)
+      expect(ids).not_to include(fresh_lyric.id)
+    end
+  end
+end

--- a/spec/requests/api/v1/radio_stations_spec.rb
+++ b/spec/requests/api/v1/radio_stations_spec.rb
@@ -452,6 +452,47 @@ describe 'RadioStations API', type: :request do
     end
   end
 
+  path '/api/v1/radio_stations/{id}/sentiment_trend' do
+    get 'Get lyrics sentiment trend for a radio station' do
+      tags 'Radio Stations'
+      produces 'application/json'
+      description 'Returns time-bucketed average lyrics sentiment for a radio station\'s airplays. ' \
+                  'Sentiment ranges from -1 (very negative) to +1 (very positive). ' \
+                  'Songs without analyzed lyrics are excluded.'
+      parameter name: :id, in: :path, type: :integer, required: true, description: 'Radio station ID'
+      parameter name: :period, in: :query, type: :string, required: false,
+                description: 'Time range (e.g. 7_days, 4_weeks, 1_year, all). Defaults to 4_weeks. ' \
+                             'Bucket granularity is hour for days, day for weeks/months, month for years, year for all.'
+
+      response '200', 'Sentiment trend retrieved successfully' do
+        example 'application/json', :example, {
+          data: [
+            { period_start: '2026-04-08T00:00:00Z', average_sentiment: 0.32, play_count: 412 },
+            { period_start: '2026-04-15T00:00:00Z', average_sentiment: 0.18, play_count: 398 },
+            { period_start: '2026-04-22T00:00:00Z', average_sentiment: -0.05, play_count: 425 },
+            { period_start: '2026-04-29T00:00:00Z', average_sentiment: 0.21, play_count: 411 }
+          ]
+        }
+
+        let(:radio_station) { create(:radio_station) }
+        let(:id) { radio_station.id }
+
+        run_test!
+      end
+
+      response '404', 'Radio station not found' do
+        example 'application/json', :example, {
+          status: 404,
+          error: 'Not Found'
+        }
+
+        let(:id) { 0 }
+
+        run_test!
+      end
+    end
+  end
+
   path '/api/v1/radio_stations/{id}/diversity_metrics' do
     get 'Get playlist diversity metrics for a radio station' do
       tags 'Radio Stations'

--- a/spec/services/hit_potential_calculator_spec.rb
+++ b/spec/services/hit_potential_calculator_spec.rb
@@ -97,6 +97,24 @@ RSpec.describe HitPotentialCalculator do
 
       expect(described_class.new(song).calculate).to be_between(0.0, 100.0)
     end
+
+    context 'when comparing songs with different lyrics sentiment' do
+      let(:positive_song) { build(:song) }
+      let(:negative_song) { build(:song) }
+      let(:positive_lyric) { build(:lyric, sentiment: 0.9) }
+      let(:negative_lyric) { build(:lyric, sentiment: -0.9) }
+
+      before do
+        allow(positive_song).to receive_messages(music_profile: build(:music_profile, song: positive_song),
+                                                 lyric: positive_lyric)
+        allow(negative_song).to receive_messages(music_profile: build(:music_profile, song: negative_song),
+                                                 lyric: negative_lyric)
+      end
+
+      it 'scores the positive-sentiment song higher' do
+        expect(described_class.new(positive_song).calculate).to be > described_class.new(negative_song).calculate
+      end
+    end
   end
 
   describe '#breakdown' do
@@ -124,13 +142,15 @@ RSpec.describe HitPotentialCalculator do
 
       it 'returns all signal categories', :aggregate_failures do
         result = described_class.new(song).breakdown
-        expect(result).to include(:audio_features, :artist_popularity, :engagement, :release_recency, :audio_features_detail)
+        expect(result).to include(:audio_features, :artist_popularity, :engagement, :release_recency,
+                                  :lyrics_sentiment, :audio_features_detail)
       end
 
       it 'has category contributions that sum to the total score', :aggregate_failures do
         calculator = described_class.new(song)
         result = calculator.breakdown
-        category_sum = result[:audio_features] + result[:artist_popularity] + result[:engagement] + result[:release_recency]
+        category_sum = result[:audio_features] + result[:artist_popularity] + result[:engagement] +
+                       result[:release_recency] + result[:lyrics_sentiment]
         expect(category_sum).to be_within(0.1).of(calculator.calculate)
       end
 

--- a/spec/services/llm/lyrics_sentiment_analyzer_spec.rb
+++ b/spec/services/llm/lyrics_sentiment_analyzer_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Llm::LyricsSentimentAnalyzer, type: :service do
+  let(:service) { described_class.new(lyrics: lyrics) }
+  let(:lyrics) { "I've been tryna call\nI've been on my own for long enough\n" }
+
+  describe '#analyze' do
+    subject(:analyze) { service.analyze }
+
+    context 'when the LLM returns a valid sentiment hash' do
+      let(:llm_response) do
+        '{"sentiment": -0.3, "themes": ["loneliness", "love"], "language": "en", "confidence": 0.82}'
+      end
+
+      before { allow(service).to receive(:chat).and_return(llm_response) }
+
+      it 'returns a parsed sentiment hash', :aggregate_failures do
+        expect(analyze[:sentiment]).to eq(-0.3)
+        expect(analyze[:themes]).to eq(%w[loneliness love])
+        expect(analyze[:language]).to eq('en')
+        expect(analyze[:confidence]).to eq(0.82)
+      end
+    end
+
+    context 'when sentiment is out of range' do
+      let(:llm_response) { '{"sentiment": 2.5, "themes": [], "language": "en", "confidence": 1.5}' }
+
+      before { allow(service).to receive(:chat).and_return(llm_response) }
+
+      it 'clamps to [-1, 1] and confidence to [0, 1]', :aggregate_failures do
+        expect(analyze[:sentiment]).to eq(1.0)
+        expect(analyze[:confidence]).to eq(1.0)
+      end
+    end
+
+    context 'when sentiment is null (unanalyzable lyrics)' do
+      let(:llm_response) { '{"sentiment": null, "themes": [], "language": null, "confidence": 0.0}' }
+
+      before { allow(service).to receive(:chat).and_return(llm_response) }
+
+      it 'returns a hash with nil sentiment', :aggregate_failures do
+        expect(analyze[:sentiment]).to be_nil
+        expect(analyze[:themes]).to eq([])
+      end
+    end
+
+    context 'when themes contains duplicates and blank values' do
+      let(:llm_response) { '{"sentiment": 0, "themes": ["Love", "love", "", "hope"], "language": "en", "confidence": 0.5}' }
+
+      before { allow(service).to receive(:chat).and_return(llm_response) }
+
+      it 'normalizes, dedupes, and caps to 5 themes' do
+        expect(analyze[:themes]).to eq(%w[love hope])
+      end
+    end
+
+    context 'when LLM wraps response in markdown' do
+      let(:llm_response) { "```json\n{\"sentiment\": 0.4, \"themes\": [\"hope\"], \"language\": \"nl\", \"confidence\": 0.7}\n```" }
+
+      before { allow(service).to receive(:chat).and_return(llm_response) }
+
+      it 'extracts the JSON' do
+        expect(analyze[:sentiment]).to eq(0.4)
+      end
+    end
+
+    context 'when lyrics are blank' do
+      let(:lyrics) { '' }
+
+      before { allow(service).to receive(:chat) }
+
+      it 'returns nil without calling the LLM', :aggregate_failures do
+        expect(analyze).to be_nil
+        expect(service).not_to have_received(:chat)
+      end
+    end
+
+    context 'when the LLM returns invalid JSON' do
+      before { allow(service).to receive(:chat).and_return('not json') }
+
+      it 'returns nil' do
+        expect(analyze).to be_nil
+      end
+    end
+
+    context 'when the LLM returns nil' do
+      before { allow(service).to receive(:chat).and_return(nil) }
+
+      it 'returns nil' do
+        expect(analyze).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/lyrics/lrclib_finder_spec.rb
+++ b/spec/services/lyrics/lrclib_finder_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Lyrics::LrclibFinder do
+  subject(:finder) { described_class.new }
+
+  describe '#find' do
+    context 'when LRCLIB returns lyrics for a known track', :use_vcr do
+      it 'returns normalized lyrics data', :aggregate_failures do
+        result = finder.find(artist_name: 'The Weeknd', track_name: 'Blinding Lights')
+        expect(result[:plain_lyrics]).to be_present
+        expect(result[:source_url]).to start_with('https://lrclib.net/api/get/')
+        expect(result[:id]).to be_present
+      end
+    end
+
+    context 'when LRCLIB cannot find the track', :use_vcr do
+      it 'returns nil' do
+        result = finder.find(
+          artist_name: 'NonexistentArtistXYZ123',
+          track_name: 'NonexistentTrackXYZ123'
+        )
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when the request raises' do
+      before do
+        allow_any_instance_of(Faraday::Connection).to receive(:get).and_raise(Faraday::ConnectionFailed.new('boom')) # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(described_class).to receive(:sleep) # rubocop:disable RSpec/AnyInstance
+        allow(ExceptionNotifier).to receive(:notify)
+        allow(Rails.logger).to receive(:error)
+      end
+
+      it 'returns nil and notifies' do
+        expect(finder.find(artist_name: 'X', track_name: 'Y')).to be_nil
+      end
+    end
+  end
+
+  describe '#fetch_by_id' do
+    context 'when the id resolves to a known track', :use_vcr do
+      it 'returns normalized lyrics data', :aggregate_failures do
+        result = finder.fetch_by_id('390')
+        expect(result[:id]).to eq('390')
+        expect(result[:plain_lyrics]).to be_present
+      end
+    end
+  end
+end

--- a/spec/services/lyrics_sentiment_trend_calculator_spec.rb
+++ b/spec/services/lyrics_sentiment_trend_calculator_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe LyricsSentimentTrendCalculator do
+  let(:radio_station) { create(:radio_station) }
+  let(:positive_song) { create(:song) }
+  let(:negative_song) { create(:song) }
+  let(:unanalyzed_song) { create(:song) }
+
+  before do
+    create(:lyric, song: positive_song, sentiment: 0.6)
+    create(:lyric, song: negative_song, sentiment: -0.4)
+    # unanalyzed_song has no lyric — should be excluded from the average
+  end
+
+  describe '#calculate' do
+    let(:calculator) { described_class.new(radio_station: radio_station, period: '7_days') }
+
+    context 'when station has airplays in range with sentiment data' do
+      before do
+        create(:air_play, radio_station: radio_station, song: positive_song, broadcasted_at: 1.day.ago)
+        create(:air_play, radio_station: radio_station, song: negative_song, broadcasted_at: 1.day.ago)
+        create(:air_play, radio_station: radio_station, song: unanalyzed_song, broadcasted_at: 1.day.ago)
+      end
+
+      it 'returns one bucket with the averaged sentiment of songs that have lyrics', :aggregate_failures do
+        result = calculator.calculate
+        expect(result.size).to eq(1)
+        expect(result.first[:average_sentiment]).to be_within(0.001).of(0.1)
+        expect(result.first[:play_count]).to eq(2)
+      end
+    end
+
+    context 'when station has airplays across multiple days' do
+      before do
+        create(:air_play, radio_station: radio_station, song: positive_song, broadcasted_at: 3.days.ago)
+        create(:air_play, radio_station: radio_station, song: negative_song, broadcasted_at: 1.day.ago)
+      end
+
+      it 'returns separate buckets per day, sorted ascending', :aggregate_failures do
+        result = calculator.calculate
+        expect(result.size).to eq(2)
+        expect(result.map { |r| r[:period_start] }).to eq(result.map { |r| r[:period_start] }.sort)
+      end
+    end
+
+    context 'when station has no airplays in range' do
+      it 'returns an empty array' do
+        expect(calculator.calculate).to eq([])
+      end
+    end
+
+    context 'when period is "all"' do
+      let(:calculator) { described_class.new(radio_station: radio_station, period: 'all') }
+
+      before do
+        create(:air_play, radio_station: radio_station, song: positive_song, broadcasted_at: 2.years.ago)
+        create(:air_play, radio_station: radio_station, song: negative_song, broadcasted_at: 1.day.ago)
+      end
+
+      it 'buckets by year' do
+        years = calculator.calculate.map { |r| r[:period_start].year }
+        expect(years.uniq.size).to eq(2)
+      end
+    end
+
+    context 'when no period is provided' do
+      let(:calculator) { described_class.new(radio_station: radio_station, period: nil) }
+
+      before do
+        create(:air_play, radio_station: radio_station, song: positive_song, broadcasted_at: 1.day.ago)
+      end
+
+      it 'defaults to 4 weeks and returns data' do
+        expect(calculator.calculate).not_to be_empty
+      end
+    end
+  end
+end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -2143,6 +2143,59 @@ paths:
                   value:
                     status: 404
                     error: Not Found
+  "/api/v1/radio_stations/{id}/sentiment_trend":
+    get:
+      summary: Get lyrics sentiment trend for a radio station
+      tags:
+      - Radio Stations
+      description: Returns time-bucketed average lyrics sentiment for a radio station's
+        airplays. Sentiment ranges from -1 (very negative) to +1 (very positive).
+        Songs without analyzed lyrics are excluded.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: Radio station ID
+        schema:
+          type: integer
+      - name: period
+        in: query
+        required: false
+        description: Time range (e.g. 7_days, 4_weeks, 1_year, all). Defaults to 4_weeks.
+          Bucket granularity is hour for days, day for weeks/months, month for years,
+          year for all.
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Sentiment trend retrieved successfully
+          content:
+            application/json:
+              examples:
+                example:
+                  value:
+                    data:
+                    - period_start: '2026-04-08T00:00:00Z'
+                      average_sentiment: 0.32
+                      play_count: 412
+                    - period_start: '2026-04-15T00:00:00Z'
+                      average_sentiment: 0.18
+                      play_count: 398
+                    - period_start: '2026-04-22T00:00:00Z'
+                      average_sentiment: -0.05
+                      play_count: 425
+                    - period_start: '2026-04-29T00:00:00Z'
+                      average_sentiment: 0.21
+                      play_count: 411
+        '404':
+          description: Radio station not found
+          content:
+            application/json:
+              examples:
+                example:
+                  value:
+                    status: 404
+                    error: Not Found
   "/api/v1/radio_stations/{id}/diversity_metrics":
     get:
       summary: Get playlist diversity metrics for a radio station


### PR DESCRIPTION
## Summary
- New `Lyric` model + `lyrics` table storing per-song sentiment, themes, language, and the LRCLIB `source_url`/`source_id` (lyrics text is **not** stored — refetched on demand to avoid licensing concerns).
- `Lyrics::LrclibFinder` (free, no-auth corpus) + `Llm::LyricsSentimentAnalyzer` (GPT-4.1-mini, multilingual) drive a `LyricsEnrichmentJob` and a weekly Sunday `LyricsEnrichmentBatchJob`. Gated behind `LYRICS_ENRICHMENT_ENABLED` so cost stays opt-in.
- `HitPotentialCalculator` now blends a 5th signal (lyrics sentiment, 10% weight, neutral fallback so songs without analyzed lyrics aren't penalized).
- New public endpoint `GET /api/v1/radio_stations/:id/sentiment_trend?period=...` returns time-bucketed average sentiment per station, granularity from `PeriodParser`.
- Closes #1990.

Side-effect: extracted Song's external-enrichment helpers into `ExternalEnrichmentConcern` so the class stays under the rubocop length budget after the new `has_one :lyric` association.

## Test plan
- [x] rspec full suite (1867 examples, 0 failures)
- [x] rubocop on changed files
- [x] brakeman (0 warnings; obsolete pre-existing ignore entry untouched)
- [x] rswag:specs:swaggerize regenerated
- [x] LRCLIB cassettes recorded against live API (200 / 404, no secrets)
- [ ] Set `LYRICS_ENRICHMENT_ENABLED=true` in production once staging traffic is verified
- [ ] Confirm OpenAI cost on first batch run before scaling beyond recently-played songs

🤖 Generated with [Claude Code](https://claude.com/claude-code)