### PR TITLE
Source artist country from MusicBrainz instead of Wikipedia

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ bundle exec rake lyrics:backfill                               # Enqueue lyrics 
 
 # Enrichment
 bundle exec rake enrichment:backfill_artist_aka_names          # Fetch alternative artist names from MusicBrainz
+bundle exec rake enrichment:backfill_artist_country            # Fetch artist country (ISO code + name) from MusicBrainz
 
 # Slugs
 bundle exec rake slug:backfill_songs                           # Backfill slugs for songs without one
@@ -84,7 +85,7 @@ The app uses service objects extensively in `app/services/`:
 - `TrackExtractor/` - Extracts artist/song info and finds tracks via `SpotifyTrackFinder`, `DeezerTrackFinder`, `ItunesTrackFinder`. Both `SpotifyTrackFinder` and `SongExtractor` use fuzzy search fallbacks with JaroWinkler title validation (>= 70%) to prevent matching different songs by the same artist.
 - `Spotify/` - External API integration with two track-finding paths: search-based (`best_match`) and ID-based (`fetch_spotify_track`). Both compute JaroWinkler match scores for `valid_match?` validation (artist >= 80, title >= 70)
 - `Youtube/` - YouTube API integration
-- `Lastfm/` and `Wikipedia/` - Artist bio/info enrichment (Last.fm listeners/playcount/tags, Wikipedia nationality via Wikidata)
+- `Lastfm/` and `Wikipedia/` - Artist bio/info enrichment (Last.fm listeners/playcount/tags, Wikipedia bio/summary). Country of origin comes from `MusicBrainz::ArtistCountryFinder` (ISO 3166-1 alpha-2 stored as `country_code`, full name derived via the `countries` gem and stored as `country_of_origin`).
 - `Deezer/` and `Itunes/` - Additional enrichment sources (duration_ms, release_date backfill)
 - `ClientTokenGenerator` - Generates short-lived JWT tokens (10-minute expiry) for frontend client authentication
 - `MusicBrainz/` - ISRCs enrichment for songs and `ArtistAliasFetcher` for populating `Artist#aka_names` (legal names, stylization variants like P!nk/Pink, former names via `artist rename` relations)
@@ -237,7 +238,7 @@ The score is calculated automatically by `MusicProfileJob` after creating a musi
 ### Key Models
 
 - `Song` - Core entity with Spotify/YouTube IDs, enrichment fields (`album_name`, `popularity`, `explicit`, `duration_ms`, `release_date`, `isrcs` array, `lastfm_listeners`, `lastfm_playcount`, `lastfm_tags`, `hit_potential_score`), `slug` for SEO-friendly URLs
-- `Artist` - Core entity with enrichment fields (`genres` array, `country_of_origin` array, `spotify_popularity`, `spotify_followers_count`, `lastfm_listeners`, `lastfm_playcount`, `lastfm_tags`, `aka_names` array, `id_on_musicbrainz`), `slug` for SEO-friendly URLs
+- `Artist` - Core entity with enrichment fields (`genres` array, `country_of_origin` array, `country_code` (ISO 3166-1 alpha-2), `spotify_popularity`, `spotify_followers_count`, `lastfm_listeners`, `lastfm_playcount`, `lastfm_tags`, `aka_names` array, `id_on_musicbrainz`), `slug` for SEO-friendly URLs
 - `AirPlay` - Song play events (unique per station/song/time, `broadcasted_at` presence validated)
 - `RadioStation` - Station metadata with last 12 airplay IDs (JSONB), `is_currently_playing` flag on last_played_songs endpoint, `slug` for SEO-friendly URLs
 - `ChartPosition` - Polymorphic rankings (can be Song or Artist), with popularity boost tiebreaker

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby '4.0.2'
 gem 'babosa', '~> 2.0'
 gem 'bootsnap', require: false
 gem 'charlock_holmes', '~> 0.7.7'
+gem 'countries', '~> 7.1'
 gem 'csv', '~> 3.3', '>= 3.3.2'
 gem 'devise'
 gem 'devise-jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,8 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
+    countries (7.1.1)
+      unaccent (~> 0.3)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -526,6 +528,7 @@ GEM
     tsort (0.2.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unaccent (0.4.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
@@ -583,6 +586,7 @@ DEPENDENCIES
   circuitbox (~> 2.0)
   concurrent-ruby
   connection_pool
+  countries (~> 7.1)
   csv (~> 3.3, >= 3.3.2)
   database_cleaner
   devise

--- a/app/jobs/artist_enrichment_job.rb
+++ b/app/jobs/artist_enrichment_job.rb
@@ -1,12 +1,10 @@
 # frozen_string_literal: true
 
 class ArtistEnrichmentJob
-  # Wikipedia allows 500 requests/hour without a token.
-  # Each job makes ~2 Wikipedia API calls (summary + full content),
-  # so max 250 jobs/hour → 3600 / 250 ≈ 15 seconds between jobs.
-  WIKIPEDIA_RATE_LIMIT_PER_HOUR = 500
-  WIKIPEDIA_REQUESTS_PER_JOB = 2
-  THROTTLE_INTERVAL = (3600.0 / (WIKIPEDIA_RATE_LIMIT_PER_HOUR / WIKIPEDIA_REQUESTS_PER_JOB)).ceil
+  # MusicBrainz asks clients to keep below 1 req/sec; the country finder
+  # makes up to 2 sequential calls per artist (search + lookup), each with
+  # a 1-second sleep, so a 3-second spacing between jobs leaves headroom.
+  THROTTLE_INTERVAL = 3
   RECHECK_AFTER = 90.days
 
   include Sidekiq::Job
@@ -15,7 +13,7 @@ class ArtistEnrichmentJob
   def self.enqueue_all
     stale_threshold = RECHECK_AFTER.ago
     scope = Artist
-              .where(country_of_origin: [])
+              .where(country_code: nil)
               .where('country_of_origin_checked_at IS NULL OR country_of_origin_checked_at < ?', stale_threshold)
 
     scope.find_each.with_index do |artist, index|
@@ -26,7 +24,7 @@ class ArtistEnrichmentJob
   def perform(artist_id)
     artist = Artist.find_by(id: artist_id)
     return if artist.blank?
-    return if artist.country_of_origin.present?
+    return if artist.country_code.present?
     return if artist.country_of_origin_checked_at.present? && artist.country_of_origin_checked_at > RECHECK_AFTER.ago
 
     enrich_country_of_origin(artist)
@@ -37,14 +35,15 @@ class ArtistEnrichmentJob
   private
 
   def enrich_country_of_origin(artist)
-    return if artist.country_of_origin.present?
+    return if artist.country_code.present?
 
-    info = Wikipedia::ArtistFinder.new.get_info(artist.name)
-    return if info.blank?
+    iso_code = MusicBrainz::ArtistCountryFinder.new(artist).()
+    return if iso_code.blank?
 
-    nationality = info.dig('general_info', 'nationality')
-    artist.update(country_of_origin: nationality) if nationality.present?
-    artist.cache_wikipedia_url(info['url'])
+    country = ISO3166::Country.new(iso_code)
+    return if country.nil?
+
+    artist.update(country_code: iso_code, country_of_origin: [country.common_name || country.iso_short_name])
   end
 
   def enrich_spotify_metrics(artist)

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -82,7 +82,7 @@ class Artist < ApplicationRecord
     id_on_tidal tidal_artist_url
     id_on_deezer deezer_artist_url deezer_artwork_url
     id_on_itunes itunes_artist_url
-    instagram_url website_url genres country_of_origin
+    instagram_url website_url genres country_of_origin country_code
     lastfm_listeners lastfm_playcount lastfm_tags
   ].map { |c| "artists.#{c}" }.freeze
 

--- a/app/serializers/artist_serializer.rb
+++ b/app/serializers/artist_serializer.rb
@@ -50,7 +50,7 @@ class ArtistSerializer
   include FastJsonapi::ObjectSerializer
 
   attributes :id, :name, :slug, :spotify_artist_url, :spotify_artwork_url, :instagram_url, :website_url, :genres,
-             :spotify_popularity, :spotify_followers_count, :country_of_origin,
+             :spotify_popularity, :spotify_followers_count, :country_of_origin, :country_code,
              :lastfm_listeners, :lastfm_playcount, :lastfm_tags,
              :id_on_tidal, :tidal_artist_url,
              :id_on_deezer, :deezer_artist_url, :deezer_artwork_url,

--- a/app/services/music_brainz/artist_country_finder.rb
+++ b/app/services/music_brainz/artist_country_finder.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module MusicBrainz
+  class ArtistCountryFinder
+    SEARCH_ENDPOINT = 'https://musicbrainz.org/ws/2/artist'
+    LOOKUP_ENDPOINT = 'https://musicbrainz.org/ws/2/artist'
+    USER_AGENT = 'Airplays/1.0.0 (https://airplays.nl)'
+    RATE_LIMIT_DELAY = 1.0
+    SEARCH_SCORE_THRESHOLD = 90
+    NAME_SIMILARITY_THRESHOLD = 90
+
+    def initialize(artist)
+      @artist = artist
+    end
+
+    def call
+      mbid = @artist.id_on_musicbrainz.presence || lookup_mbid
+      return nil if mbid.blank?
+
+      data = fetch_artist(mbid)
+      return nil if data.blank?
+
+      @artist.update(id_on_musicbrainz: mbid) if @artist.id_on_musicbrainz.blank?
+      extract_country_code(data)
+    end
+
+    private
+
+    def lookup_mbid
+      data = search_by_name
+      return nil if data.blank?
+
+      candidate = data['artists']&.first
+      return nil if candidate.blank?
+      return nil if candidate['score'].to_i < SEARCH_SCORE_THRESHOLD
+      return nil unless name_matches?(candidate['name'])
+
+      candidate['id']
+    end
+
+    def search_by_name
+      sleep(RATE_LIMIT_DELAY)
+      uri = URI(SEARCH_ENDPOINT)
+      uri.query = URI.encode_www_form(query: "artist:\"#{@artist.name}\"", fmt: 'json', limit: 1)
+
+      response = make_request(uri)
+      return nil unless response.is_a?(Net::HTTPSuccess)
+
+      JSON.parse(response.body)
+    rescue JSON::ParserError => e
+      Rails.logger.error "MusicBrainz::ArtistCountryFinder: Invalid JSON in search: #{e.message}"
+      nil
+    rescue StandardError => e
+      Rails.logger.error "MusicBrainz::ArtistCountryFinder: Search error: #{e.message}"
+      nil
+    end
+
+    def name_matches?(candidate_name)
+      score = (JaroWinkler.similarity(candidate_name.to_s.downcase, @artist.name.to_s.downcase) * 100).to_i
+      score >= NAME_SIMILARITY_THRESHOLD
+    end
+
+    def fetch_artist(mbid)
+      sleep(RATE_LIMIT_DELAY)
+      uri = URI("#{LOOKUP_ENDPOINT}/#{mbid}")
+      uri.query = URI.encode_www_form(fmt: 'json')
+
+      response = make_request(uri)
+      return nil unless response.is_a?(Net::HTTPSuccess)
+
+      JSON.parse(response.body)
+    rescue JSON::ParserError => e
+      Rails.logger.error "MusicBrainz::ArtistCountryFinder: Invalid JSON in lookup: #{e.message}"
+      nil
+    rescue StandardError => e
+      Rails.logger.error "MusicBrainz::ArtistCountryFinder: Lookup error: #{e.message}"
+      nil
+    end
+
+    def extract_country_code(data)
+      data['country'].presence || data.dig('area', 'iso-3166-1-codes')&.first
+    end
+
+    def make_request(uri)
+      https = Net::HTTP.new(uri.host, uri.port)
+      https.use_ssl = true
+      https.open_timeout = 10
+      https.read_timeout = 10
+
+      request = Net::HTTP::Get.new(uri)
+      request['User-Agent'] = USER_AGENT
+      request['Accept'] = 'application/json'
+
+      https.request(request)
+    end
+  end
+end

--- a/db/migrate/20260506082251_add_country_code_to_artists.rb
+++ b/db/migrate/20260506082251_add_country_code_to_artists.rb
@@ -1,0 +1,5 @@
+class AddCountryCodeToArtists < ActiveRecord::Migration[8.1]
+  def change
+    add_column :artists, :country_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_06_080343) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_06_082251) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -87,6 +87,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_080343) do
   create_table "artists", force: :cascade do |t|
     t.string "aka_names", default: [], array: true
     t.datetime "aka_names_checked_at"
+    t.string "country_code"
     t.string "country_of_origin", default: [], array: true
     t.datetime "country_of_origin_checked_at"
     t.datetime "created_at", precision: nil, null: false

--- a/lib/tasks/enrichment.rake
+++ b/lib/tasks/enrichment.rake
@@ -27,9 +27,9 @@ namespace :enrichment do
     puts 'Done.'
   end
 
-  desc 'Backfill artist nationality from Wikidata'
-  task backfill_artist_nationality: :environment do
-    puts 'Enqueueing artists for nationality backfill...'
+  desc 'Backfill artist country (ISO code + name) from MusicBrainz'
+  task backfill_artist_country: :environment do
+    puts 'Enqueueing artists for country backfill...'
     ArtistEnrichmentJob.enqueue_all
     puts 'Done.'
   end
@@ -75,7 +75,7 @@ namespace :enrichment do
     %w[
       enrichment:backfill_album_names
       enrichment:backfill_artist_spotify_metrics
-      enrichment:backfill_artist_nationality
+      enrichment:backfill_artist_country
       enrichment:backfill_lastfm
     ].each do |task|
       puts "Running #{task}..."

--- a/spec/jobs/artist_enrichment_job_spec.rb
+++ b/spec/jobs/artist_enrichment_job_spec.rb
@@ -4,30 +4,27 @@ require 'rails_helper'
 
 RSpec.describe ArtistEnrichmentJob do
   describe '#perform' do
-    let(:artist) { create(:artist, id_on_spotify: 'spotify_123', country_of_origin: []) }
+    let(:artist) { create(:artist, id_on_spotify: 'spotify_123', country_code: nil) }
     let(:job) { described_class.new }
-
-    let(:wikipedia_info) do
-      {
-        'url' => 'https://en.wikipedia.org/wiki/Adele',
-        'general_info' => {
-          'nationality' => ['United Kingdom']
-        }
-      }
-    end
 
     let(:spotify_artist_response) do
       { 'popularity' => 85, 'followers' => { 'total' => 500_000 } }
     end
 
     before do
-      allow_any_instance_of(Wikipedia::ArtistFinder).to receive(:get_info).and_return(wikipedia_info) # rubocop:disable RSpec/AnyInstance
+      country_finder = instance_double(MusicBrainz::ArtistCountryFinder, call: 'GB')
+      allow(MusicBrainz::ArtistCountryFinder).to receive(:new).and_return(country_finder)
       artist_finder = instance_double(Spotify::ArtistFinder, info: spotify_artist_response)
       allow(Spotify::ArtistFinder).to receive(:new).and_return(artist_finder)
     end
 
-    context 'when artist has empty country_of_origin and Spotify ID' do
-      it 'stores country_of_origin from Wikipedia' do
+    context 'when artist has no country_code and a Spotify ID' do
+      it 'stores country_code from MusicBrainz' do
+        job.perform(artist.id)
+        expect(artist.reload.country_code).to eq('GB')
+      end
+
+      it 'stores country_of_origin derived from the ISO code' do
         job.perform(artist.id)
         expect(artist.reload.country_of_origin).to eq(['United Kingdom'])
       end
@@ -41,19 +38,19 @@ RSpec.describe ArtistEnrichmentJob do
         job.perform(artist.id)
         expect(artist.reload.spotify_followers_count).to eq(500_000)
       end
-
-      it 'stores wikipedia_url' do
-        job.perform(artist.id)
-        expect(artist.reload.wikipedia_url).to eq('https://en.wikipedia.org/wiki/Adele')
-      end
     end
 
-    context 'when artist already has country_of_origin' do
-      let(:artist) { create(:artist, id_on_spotify: 'spotify_123', country_of_origin: ['Netherlands']) }
+    context 'when artist already has country_code' do
+      let(:artist) { create(:artist, id_on_spotify: 'spotify_123', country_code: 'NL', country_of_origin: ['Netherlands']) }
 
-      it 'does not overwrite country_of_origin' do
+      it 'does not overwrite country_code' do
         job.perform(artist.id)
-        expect(artist.reload.country_of_origin).to eq(['Netherlands'])
+        expect(artist.reload.country_code).to eq('NL')
+      end
+
+      it 'does not call MusicBrainz' do
+        job.perform(artist.id)
+        expect(MusicBrainz::ArtistCountryFinder).not_to have_received(:new)
       end
 
       it 'does not call Spotify' do
@@ -62,9 +59,15 @@ RSpec.describe ArtistEnrichmentJob do
       end
     end
 
-    context 'when Wikipedia returns no data' do
+    context 'when MusicBrainz returns no country' do
       before do
-        allow_any_instance_of(Wikipedia::ArtistFinder).to receive(:get_info).and_return(nil) # rubocop:disable RSpec/AnyInstance
+        country_finder = instance_double(MusicBrainz::ArtistCountryFinder, call: nil)
+        allow(MusicBrainz::ArtistCountryFinder).to receive(:new).and_return(country_finder)
+      end
+
+      it 'does not update country_code' do
+        job.perform(artist.id)
+        expect(artist.reload.country_code).to be_nil
       end
 
       it 'does not update country_of_origin' do
@@ -78,13 +81,27 @@ RSpec.describe ArtistEnrichmentJob do
 
         job.perform(artist.id)
 
-        expect(artist.reload.country_of_origin).to eq([])
+        expect(artist.reload.country_code).to be_nil
         expect(artist.country_of_origin_checked_at).to be_within(1.second).of(freeze_time)
       end
     end
 
+    context 'when MusicBrainz returns an unknown ISO code' do
+      before do
+        country_finder = instance_double(MusicBrainz::ArtistCountryFinder, call: 'ZZ')
+        allow(MusicBrainz::ArtistCountryFinder).to receive(:new).and_return(country_finder)
+      end
+
+      it 'does not update country_code or country_of_origin', :aggregate_failures do
+        job.perform(artist.id)
+        artist.reload
+        expect(artist.country_code).to be_nil
+        expect(artist.country_of_origin).to eq([])
+      end
+    end
+
     context 'when artist has no Spotify ID' do
-      let(:artist) { create(:artist, id_on_spotify: nil, country_of_origin: []) }
+      let(:artist) { create(:artist, id_on_spotify: nil, country_code: nil) }
 
       it 'does not update Spotify metrics' do
         job.perform(artist.id)
@@ -98,56 +115,52 @@ RSpec.describe ArtistEnrichmentJob do
       end
     end
 
-    context 'when artist was checked recently and Wikipedia had no nationality' do
+    context 'when artist was checked recently and MusicBrainz had no country' do
       let(:artist) do
-        create(:artist, id_on_spotify: 'spotify_123', country_of_origin: [], country_of_origin_checked_at: 2.days.ago)
+        create(:artist, id_on_spotify: 'spotify_123', country_code: nil, country_of_origin_checked_at: 2.days.ago)
       end
 
-      it 'does not call Wikipedia again' do
-        wikipedia_finder = instance_double(Wikipedia::ArtistFinder)
-        allow(Wikipedia::ArtistFinder).to receive(:new).and_return(wikipedia_finder)
-
+      it 'does not call MusicBrainz again' do
         job.perform(artist.id)
-
-        expect(Wikipedia::ArtistFinder).not_to have_received(:new)
+        expect(MusicBrainz::ArtistCountryFinder).not_to have_received(:new)
       end
     end
 
-    context 'when artist was checked long ago and country is still empty' do
+    context 'when artist was checked long ago and country is still missing' do
       let(:artist) do
-        create(:artist, id_on_spotify: 'spotify_123', country_of_origin: [],
+        create(:artist, id_on_spotify: 'spotify_123', country_code: nil,
                         country_of_origin_checked_at: (described_class::RECHECK_AFTER + 1.day).ago)
       end
 
-      it 'rechecks Wikipedia' do
+      it 'rechecks MusicBrainz' do
         job.perform(artist.id)
-        expect(artist.reload.country_of_origin).to eq(['United Kingdom'])
+        expect(artist.reload.country_code).to eq('GB')
       end
     end
   end
 
   describe '.enqueue_all' do
-    let!(:artist_without_country) { create(:artist, country_of_origin: []) }
-    let!(:artist_with_country) { create(:artist, country_of_origin: ['Netherlands']) }
+    let!(:artist_without_country) { create(:artist, country_code: nil) }
+    let!(:artist_with_country) { create(:artist, country_code: 'NL', country_of_origin: ['Netherlands']) }
     let!(:artist_recently_checked) do
-      create(:artist, country_of_origin: [], country_of_origin_checked_at: 1.day.ago)
+      create(:artist, country_code: nil, country_of_origin_checked_at: 1.day.ago)
     end
     let!(:artist_stale_check) do
-      create(:artist, country_of_origin: [], country_of_origin_checked_at: (described_class::RECHECK_AFTER + 1.day).ago)
+      create(:artist, country_code: nil, country_of_origin_checked_at: (described_class::RECHECK_AFTER + 1.day).ago)
     end
 
     before do
       allow(described_class).to receive(:perform_in)
     end
 
-    it 'enqueues jobs for artists without country_of_origin' do
+    it 'enqueues jobs for artists without country_code' do
       described_class.enqueue_all
       expect(described_class).to have_received(:perform_in).with(
         anything, artist_without_country.id
       )
     end
 
-    it 'does not enqueue jobs for artists with country_of_origin' do
+    it 'does not enqueue jobs for artists with country_code' do
       described_class.enqueue_all
       expect(described_class).not_to have_received(:perform_in).with(anything, artist_with_country.id)
     end

--- a/spec/services/music_brainz/artist_country_finder_spec.rb
+++ b/spec/services/music_brainz/artist_country_finder_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe MusicBrainz::ArtistCountryFinder, type: :service do
+  let(:artist) { create(:artist, name: 'Adele') }
+  let(:mbid) { 'cc2c9c3c-b7bc-4b8b-84d8-4fbd8779e493' }
+  let(:finder) { described_class.new(artist) }
+
+  before { allow(finder).to receive(:sleep) }
+
+  describe '#call' do
+    context 'when artist already has id_on_musicbrainz and lookup returns a country code' do
+      before do
+        artist.update!(id_on_musicbrainz: mbid)
+        stub_request(:get, %r{musicbrainz.org/ws/2/artist/#{mbid}})
+          .to_return(status: 200, body: { 'id' => mbid, 'country' => 'GB' }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns the ISO 3166-1 alpha-2 code' do
+        expect(finder.()).to eq('GB')
+      end
+    end
+
+    context 'when the lookup omits country but includes area iso codes' do
+      before do
+        artist.update!(id_on_musicbrainz: mbid)
+        stub_request(:get, %r{musicbrainz.org/ws/2/artist/#{mbid}})
+          .to_return(status: 200,
+                     body: { 'id' => mbid, 'country' => nil, 'area' => { 'iso-3166-1-codes' => ['NL'] } }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'falls back to the area code' do
+        expect(finder.()).to eq('NL')
+      end
+    end
+
+    context 'when the artist has no MBID and the search top match passes validation' do
+      before do
+        stub_request(:get, %r{musicbrainz.org/ws/2/artist\?}).to_return(
+          status: 200,
+          body: { 'artists' => [{ 'id' => mbid, 'name' => 'Adele', 'score' => 100 }] }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+        stub_request(:get, %r{musicbrainz.org/ws/2/artist/#{mbid}}).to_return(
+          status: 200, body: { 'id' => mbid, 'country' => 'GB' }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+
+      it 'persists the discovered MBID and returns the country code', :aggregate_failures do
+        result = finder.()
+        expect(result).to eq('GB')
+        expect(artist.reload.id_on_musicbrainz).to eq(mbid)
+      end
+    end
+
+    context 'when the search top match score is below threshold' do
+      before do
+        stub_request(:get, %r{musicbrainz.org/ws/2/artist\?}).to_return(
+          status: 200,
+          body: { 'artists' => [{ 'id' => mbid, 'name' => 'Adele', 'score' => 80 }] }.to_json,
+          headers: { 'Content-Type' => 'application/json' }
+        )
+      end
+
+      it 'returns nil', :aggregate_failures do
+        expect(finder.()).to be_nil
+        expect(artist.reload.id_on_musicbrainz).to be_nil
+      end
+    end
+
+    context 'when the lookup returns no country at all' do
+      before do
+        artist.update!(id_on_musicbrainz: mbid)
+        stub_request(:get, %r{musicbrainz.org/ws/2/artist/#{mbid}})
+          .to_return(status: 200, body: { 'id' => mbid, 'country' => nil }.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'returns nil' do
+        expect(finder.()).to be_nil
+      end
+    end
+
+    context 'when the lookup endpoint returns an HTTP error' do
+      before do
+        artist.update!(id_on_musicbrainz: mbid)
+        stub_request(:get, %r{musicbrainz.org/ws/2/artist/#{mbid}}).to_return(status: 503)
+      end
+
+      it 'returns nil' do
+        expect(finder.()).to be_nil
+      end
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -89,6 +89,7 @@ RSpec.configure do |config|
                   spotify_popularity: { type: :integer, nullable: true },
                   spotify_followers_count: { type: :integer, nullable: true },
                   country_of_origin: { type: :array, items: { type: :string }, nullable: true },
+                  country_code: { type: :string, nullable: true },
                   lastfm_listeners: { type: :integer, nullable: true },
                   lastfm_playcount: { type: :integer, nullable: true },
                   lastfm_tags: { type: :array, items: { type: :string }, nullable: true },

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -3684,6 +3684,9 @@ components:
               items:
                 type: string
               nullable: true
+            country_code:
+              type: string
+              nullable: true
             lastfm_listeners:
               type: integer
               nullable: true


### PR DESCRIPTION
## Summary
- Replace Wikidata-based artist nationality lookup with `MusicBrainz::ArtistCountryFinder`. Stores the ISO 3166-1 alpha-2 in a new `country_code` column and derives the human-readable name via the `countries` gem.
- Restructure `ArtistEnrichmentJob` so the gate is `country_code.present?` (instead of `country_of_origin.present?`) — artists with Wikipedia-derived names get re-enriched once at the 90-day recheck cadence. `country_of_origin` is only overwritten when MusicBrainz returns a country, so artists without an MB match keep their Wikipedia value.
- Drop the Wikipedia rate-limit constants and pace `enqueue_all` at 3s/job to fit MusicBrainz's 1 req/sec budget.
- Expose `country_code` on `ArtistSerializer`, `MOST_PLAYED_COLUMNS`, and the swagger schema.
- Rename `enrichment:backfill_artist_nationality` → `enrichment:backfill_artist_country` (updated in `backfill_all`).

## Test plan
- [x] `bundle exec rspec` — 1877 examples, 0 failures
- [x] `bundle exec rubocop` — clean
- [x] `bundle exec brakeman -i config/brakeman.ignore` — no warnings
- [x] `bundle exec bundle-audit check --update` — no vulnerabilities
- [x] `bundle exec rake rswag:specs:swaggerize` — committed
- [ ] Spot-check `MusicBrainz::ArtistCountryFinder` against a few real artists in console after merge
- [ ] Run `bundle exec rake enrichment:backfill_artist_country` in production and confirm jobs progress without 503s from MusicBrainz

🤖 Generated with [Claude Code](https://claude.com/claude-code)