### PR TITLE
Split lyrics endpoint into stats and text

### DIFF
--- a/app/controllers/api/v1/songs_controller.rb
+++ b/app/controllers/api/v1/songs_controller.rb
@@ -4,7 +4,7 @@ module Api
   module V1
     class SongsController < ApiController
       skip_before_action :authenticate_client!, only: :widget
-      before_action :song, only: %i[show graph_data chart_positions time_analytics air_plays info lyrics music_profile widget]
+      before_action :song, only: %i[show graph_data chart_positions time_analytics air_plays info lyrics lyrics_text music_profile widget]
 
       def index
         render json: SongSerializer.new(songs)
@@ -209,8 +209,10 @@ module Api
 
       # GET /api/v1/songs/:id/lyrics
       #
-      # Returns the stored lyric metadata for a song. Full lyrics text is fetched
-      # on-demand from LRCLIB (not stored locally for licensing reasons).
+      # Returns the stored lyric metadata for a song (sentiment, themes, language).
+      # This endpoint is DB-only and fast. The full lyrics text is served by a
+      # separate endpoint (`GET /api/v1/songs/:id/lyrics/text`) so clients can
+      # render statistics without waiting on the external LRCLIB fetch.
       #
       # Response when the song has been analyzed:
       # {
@@ -220,15 +222,33 @@ module Api
       #     "language": "en",
       #     "source": "lrclib",
       #     "source_url": "https://lrclib.net/api/get/12345",
-      #     "enriched_at": "2026-04-20T14:33:11Z",
-      #     "lyrics": "..."
+      #     "enriched_at": "2026-04-20T14:33:11Z"
       #   }
       # }
       #
-      # Response when no Lyric record exists yet, or the song is instrumental
-      # (LRCLIB has no plain lyrics): the same shape with `data: null`.
+      # Response when no Lyric record exists yet: the same shape with `data: null`.
       def lyrics
-        render json: { data: lyric_data }.to_json
+        render json: { data: lyric_stats }.to_json
+      end
+
+      # GET /api/v1/songs/:id/lyrics/text
+      #
+      # Returns the plain lyrics text fetched on-demand from LRCLIB
+      # (not stored locally for licensing reasons). Cached for 24 hours.
+      #
+      # Response:
+      # {
+      #   "data": {
+      #     "lyrics": "...",
+      #     "source": "lrclib",
+      #     "source_url": "https://lrclib.net/api/get/12345"
+      #   }
+      # }
+      #
+      # Response when no Lyric record exists, or the song is instrumental
+      # (LRCLIB has no plain lyrics): the same shape with `data: null`.
+      def lyrics_text
+        render json: { data: lyric_text }.to_json
       end
 
       # GET /api/v1/songs/:id/music_profile
@@ -271,7 +291,7 @@ module Api
 
       private
 
-      def lyric_data
+      def lyric_stats
         lyric = song.lyric
         return nil if lyric.blank?
 
@@ -281,8 +301,21 @@ module Api
           language: lyric.language,
           source: lyric.source,
           source_url: lyric.source_url,
-          enriched_at: lyric.enriched_at,
-          lyrics: lyric.plain_lyrics
+          enriched_at: lyric.enriched_at
+        }
+      end
+
+      def lyric_text
+        lyric = song.lyric
+        return nil if lyric.blank?
+
+        plain = lyric.plain_lyrics
+        return nil if plain.blank?
+
+        {
+          lyrics: plain,
+          source: lyric.source,
+          source_url: lyric.source_url
         }
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
         get :air_plays, on: :member
         get :info, on: :member
         get :lyrics, on: :member
+        get 'lyrics/text', on: :member, action: :lyrics_text, as: :lyrics_text
         get :music_profile, on: :member
         get :widget, on: :member
       end

--- a/spec/requests/api/v1/songs_spec.rb
+++ b/spec/requests/api/v1/songs_spec.rb
@@ -651,11 +651,12 @@ RSpec.describe 'Songs API', type: :request do
   end
 
   path '/api/v1/songs/{id}/lyrics' do
-    get 'Get song lyrics metadata and on-demand text' do
+    get 'Get song lyrics metadata' do
       tags 'Songs'
       produces 'application/json'
-      description 'Returns the stored lyric metadata for a song. Full lyrics text is fetched on-demand from LRCLIB ' \
-                  '(not stored locally for licensing reasons). Returns data: null when no Lyric record exists.'
+      description 'Returns stored lyric metadata for a song (sentiment, themes, language). DB-only and fast; ' \
+                  'the full lyrics text is served by GET /api/v1/songs/{id}/lyrics/text. ' \
+                  'Returns data: null when no Lyric record exists.'
       parameter name: :id, in: :path, type: :integer, required: true, description: 'Song ID or slug'
 
       response '200', 'Lyrics metadata retrieved successfully' do
@@ -666,8 +667,7 @@ RSpec.describe 'Songs API', type: :request do
             language: 'en',
             source: 'lrclib',
             source_url: 'https://lrclib.net/api/get/12345',
-            enriched_at: '2026-04-20T14:33:11Z',
-            lyrics: "Verse 1\nVerse 2\n..."
+            enriched_at: '2026-04-20T14:33:11Z'
           }
         }
 
@@ -682,8 +682,7 @@ RSpec.describe 'Songs API', type: :request do
                      language: { type: :string, nullable: true },
                      source: { type: :string },
                      source_url: { type: :string, nullable: true },
-                     enriched_at: { type: :string, format: 'date-time', nullable: true },
-                     lyrics: { type: :string, nullable: true }
+                     enriched_at: { type: :string, format: 'date-time', nullable: true }
                    }
                  }
                }
@@ -694,6 +693,64 @@ RSpec.describe 'Songs API', type: :request do
                          source: 'lrclib', source_id: '12345',
                          source_url: 'https://lrclib.net/api/get/12345',
                          enriched_at: Time.zone.parse('2026-04-20T14:33:11Z'))
+        end
+        let(:id) { song.id }
+
+        run_test!
+      end
+
+      response '200', 'Returns null data when no lyric record exists' do
+        let(:song) { create(:song) }
+        let(:id) { song.id }
+
+        run_test! do |response|
+          body = JSON.parse(response.body)
+          expect(body['data']).to be_nil
+        end
+      end
+
+      response '404', 'Song not found' do
+        let(:id) { 0 }
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v1/songs/{id}/lyrics/text' do
+    get 'Get song lyrics plain text' do
+      tags 'Songs'
+      produces 'application/json'
+      description 'Returns the plain lyrics text fetched on-demand from LRCLIB (not stored locally for licensing ' \
+                  'reasons). Cached for 24 hours. Returns data: null when no Lyric record exists or the song is ' \
+                  'instrumental (LRCLIB has no plain lyrics).'
+      parameter name: :id, in: :path, type: :integer, required: true, description: 'Song ID or slug'
+
+      response '200', 'Lyrics text retrieved successfully' do
+        example 'application/json', :example, {
+          data: {
+            lyrics: "Verse 1\nVerse 2\n...",
+            source: 'lrclib',
+            source_url: 'https://lrclib.net/api/get/12345'
+          }
+        }
+
+        schema type: :object,
+               properties: {
+                 data: {
+                   type: :object,
+                   nullable: true,
+                   properties: {
+                     lyrics: { type: :string },
+                     source: { type: :string },
+                     source_url: { type: :string, nullable: true }
+                   }
+                 }
+               }
+
+        let(:song) { create(:song) }
+        let!(:lyric) do
+          create(:lyric, song: song, source: 'lrclib', source_id: '12345',
+                         source_url: 'https://lrclib.net/api/get/12345')
         end
         let(:id) { song.id }
 
@@ -708,6 +765,24 @@ RSpec.describe 'Songs API', type: :request do
       response '200', 'Returns null data when no lyric record exists' do
         let(:song) { create(:song) }
         let(:id) { song.id }
+
+        run_test! do |response|
+          body = JSON.parse(response.body)
+          expect(body['data']).to be_nil
+        end
+      end
+
+      response '200', 'Returns null data when LRCLIB has no plain lyrics (instrumental)' do
+        let(:song) { create(:song) }
+        let!(:lyric) do
+          create(:lyric, song: song, source: 'lrclib', source_id: '99999')
+        end
+        let(:id) { song.id }
+
+        before do # rubocop:disable RSpec/ScatteredSetup
+          allow_any_instance_of(Lyrics::LrclibFinder).to receive(:fetch_by_id) # rubocop:disable RSpec/AnyInstance
+                                                           .with('99999').and_return(nil)
+        end
 
         run_test! do |response|
           body = JSON.parse(response.body)

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -3412,11 +3412,11 @@ paths:
                     error: Not Found
   "/api/v1/songs/{id}/lyrics":
     get:
-      summary: Get song lyrics metadata and on-demand text
+      summary: Get song lyrics metadata
       tags:
       - Songs
-      description: 'Returns the stored lyric metadata for a song. Full lyrics text
-        is fetched on-demand from LRCLIB (not stored locally for licensing reasons).
+      description: 'Returns stored lyric metadata for a song (sentiment, themes, language).
+        DB-only and fast; the full lyrics text is served by GET /api/v1/songs/{id}/lyrics/text.
         Returns data: null when no Lyric record exists.'
       parameters:
       - name: id
@@ -3442,10 +3442,6 @@ paths:
                       source: lrclib
                       source_url: https://lrclib.net/api/get/12345
                       enriched_at: '2026-04-20T14:33:11Z'
-                      lyrics: |-
-                        Verse 1
-                        Verse 2
-                        ...
               schema:
                 type: object
                 properties:
@@ -3473,7 +3469,51 @@ paths:
                         type: string
                         format: date-time
                         nullable: true
+        '404':
+          description: Song not found
+  "/api/v1/songs/{id}/lyrics/text":
+    get:
+      summary: Get song lyrics plain text
+      tags:
+      - Songs
+      description: 'Returns the plain lyrics text fetched on-demand from LRCLIB (not
+        stored locally for licensing reasons). Cached for 24 hours. Returns data:
+        null when no Lyric record exists or the song is instrumental (LRCLIB has no
+        plain lyrics).'
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: Song ID or slug
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: Returns null data when LRCLIB has no plain lyrics (instrumental)
+          content:
+            application/json:
+              examples:
+                example:
+                  value:
+                    data:
+                      lyrics: |-
+                        Verse 1
+                        Verse 2
+                        ...
+                      source: lrclib
+                      source_url: https://lrclib.net/api/get/12345
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    nullable: true
+                    properties:
                       lyrics:
+                        type: string
+                      source:
+                        type: string
+                      source_url:
                         type: string
                         nullable: true
         '404':


### PR DESCRIPTION
## Summary

- `GET /api/v1/songs/:id/lyrics` now returns DB-only metadata (sentiment, themes, language, source). The slow LRCLIB roundtrip is no longer on this path.
- New `GET /api/v1/songs/:id/lyrics/text` returns the plain lyrics text from LRCLIB (still cached 24h via `Lyric#plain_lyrics`).
- Lets clients render lyrics statistics immediately and stream the body in afterwards. The frontend change that consumes this lives in playlists-interface `lyrics-tab`.

## Test plan

- [x] `bundle exec rspec spec/requests/api/v1/songs_spec.rb -e 'lyrics'` (7 examples, 0 failures)
- [x] `bundle exec rake rswag:specs:swaggerize` regenerated `swagger/v1/swagger.yaml`
- [x] `bundle exec rubocop` clean on touched files
- [ ] Smoke test against staging once deployed: `/lyrics` returns no `lyrics` field; `/lyrics/text` returns body or null for instrumentals

🤖 Generated with [Claude Code](https://claude.com/claude-code)