### PR TITLE
Add lyric theme to song faceted and LLM search

### DIFF
--- a/app/controllers/api/v1/songs_controller.rb
+++ b/app/controllers/api/v1/songs_controller.rb
@@ -47,6 +47,8 @@ module Api
       #   - artist (optional): Filter by artist name (fuzzy match)
       #   - title (optional): Filter by song title (fuzzy match)
       #   - album (optional): Filter by album name (fuzzy match)
+      #   - theme (optional): Filter by lyric theme (e.g. "love", "freedom", "drugs"). See
+      #     `GET /search_suggestions?field=theme` for the canonical theme vocabulary
       #   - year_from (optional): Filter songs released in or after this year
       #   - year_to (optional): Filter songs released in or before this year
       #   - limit (optional, default: 10): Maximum number of results (max: 20)
@@ -82,12 +84,30 @@ module Api
                        .to_json
       end
 
+      # GET /api/v1/songs/natural_language_examples
+      #
+      # Returns example natural language queries the frontend can show as suggestions
+      # (e.g. "Try: songs about freedom"). Each example is bilingual.
+      #
+      # Response:
+      # {
+      #   "examples": [
+      #     { "en": "songs about freedom", "nl": "nummers over vrijheid", "category": "theme" },
+      #     ...
+      #   ]
+      # }
+      def natural_language_examples
+        render json: { examples: Llm::SearchExamples.list }
+      end
+
       # GET /api/v1/songs/search_suggestions
       #
       # Returns autocomplete suggestions for a specific search field.
       #
       # Parameters:
-      #   - field (required): Field to suggest values for (artist, title, album, year)
+      #   - field (required): Field to suggest values for (artist, title, album, year, theme).
+      #     The `theme` field returns canonical English lyric themes (love, freedom, drugs, etc.)
+      #     suitable for the `/search?theme=` facet.
       #   - q (optional): Partial input to filter suggestions
       #   - limit (optional, default: 5): Maximum suggestions (max: 10)
       def search_suggestions
@@ -401,6 +421,7 @@ module Api
           artist: params[:artist],
           title: params[:title],
           album: params[:album],
+          theme: params[:theme],
           year_from: params[:year_from],
           year_to: params[:year_to],
           sort_by: params[:sort_by],

--- a/app/models/concerns/song_search_concern.rb
+++ b/app/models/concerns/song_search_concern.rb
@@ -3,7 +3,7 @@
 module SongSearchConcern
   extend ActiveSupport::Concern
 
-  SEARCH_FIELDS = %w[artist title album year_from year_to].freeze
+  SEARCH_FIELDS = %w[artist title album year_from year_to theme].freeze
 
   # Minimum pg_trgm similarity for a fuzzy match. The default `%` operator uses
   # pg_trgm.similarity_limit (0.3) which is too permissive for search; 0.5
@@ -47,6 +47,12 @@ module SongSearchConcern
 
       where(arel_table[:album_name].matches("%#{sanitize_sql_like(album)}%"))
     }
+    scope :filter_by_theme, lambda { |theme|
+      return all if theme.blank?
+
+      normalized = theme.to_s.downcase.strip
+      joins(:lyric).where('lyrics.themes @> ARRAY[?]::varchar[]', normalized)
+    }
     scope :filter_by_year_range, lambda { |year_from: nil, year_to: nil|
       scope = all
       scope = scope.where(release_date: Date.new(year_from.to_i)..) if year_from.present?
@@ -77,19 +83,10 @@ module SongSearchConcern
       scope = scope.filter_by_artist(filters[:artist])
                 .filter_by_title(filters[:title])
                 .filter_by_album(filters[:album])
+                .filter_by_theme(filters[:theme])
                 .filter_by_year_range(year_from: filters[:year_from], year_to: filters[:year_to])
                 .limit(filters.fetch(:limit, 10))
       apply_faceted_sort(scope, filters[:sort_by])
-    end
-
-    def suggest(field:, query: nil, limit: 5)
-      case field
-      when 'artist' then suggest_artists(query, limit)
-      when 'title' then suggest_titles(query, limit)
-      when 'album' then suggest_albums(query, limit)
-      when 'year' then suggest_years(limit)
-      else SEARCH_FIELDS
-      end
     end
 
     private
@@ -100,36 +97,6 @@ module SongSearchConcern
       when 'newest' then scope.order(Arel.sql('songs.release_date DESC NULLS LAST'))
       else scope.order(popularity: :desc)
       end
-    end
-
-    def suggest_artists(query, limit)
-      scope = if query.present?
-                Artist.where(SongSearchConcern.trigram_or_ilike(Artist, :name, query))
-                  .order(*SongSearchConcern.relevance_order('artists.name', query), spotify_popularity: :desc)
-              else
-                Artist.order(spotify_popularity: :desc)
-              end
-      scope.limit(limit).pluck(:name).uniq
-    end
-
-    def suggest_titles(query, limit)
-      scope = if query.present?
-                where(SongSearchConcern.trigram_or_ilike(self, :title, query))
-                  .order(*SongSearchConcern.relevance_order('songs.title', query), popularity: :desc)
-              else
-                order(popularity: :desc)
-              end
-      scope.limit(limit).pluck(:title).uniq
-    end
-
-    def suggest_albums(query, limit)
-      scope = where.not(album_name: [nil, ''])
-      scope = scope.where(arel_table[:album_name].matches("%#{sanitize_sql_like(query)}%")) if query.present?
-      scope.distinct.order(:album_name).limit(limit).pluck(:album_name)
-    end
-
-    def suggest_years(limit)
-      distinct_years(limit).map(&:year)
     end
   end
 end

--- a/app/models/concerns/song_suggestion_concern.rb
+++ b/app/models/concerns/song_suggestion_concern.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module SongSuggestionConcern
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def suggest(field:, query: nil, limit: 5)
+      case field
+      when 'artist' then suggest_artists(query, limit)
+      when 'title' then suggest_titles(query, limit)
+      when 'album' then suggest_albums(query, limit)
+      when 'year' then suggest_years(limit)
+      when 'theme' then suggest_themes(query, limit)
+      else SongSearchConcern::SEARCH_FIELDS
+      end
+    end
+
+    private
+
+    def suggest_artists(query, limit)
+      scope = if query.present?
+                Artist.where(SongSearchConcern.trigram_or_ilike(Artist, :name, query))
+                  .order(*SongSearchConcern.relevance_order('artists.name', query), spotify_popularity: :desc)
+              else
+                Artist.order(spotify_popularity: :desc)
+              end
+      scope.limit(limit).pluck(:name).uniq
+    end
+
+    def suggest_titles(query, limit)
+      scope = if query.present?
+                where(SongSearchConcern.trigram_or_ilike(self, :title, query))
+                  .order(*SongSearchConcern.relevance_order('songs.title', query), popularity: :desc)
+              else
+                order(popularity: :desc)
+              end
+      scope.limit(limit).pluck(:title).uniq
+    end
+
+    def suggest_albums(query, limit)
+      scope = where.not(album_name: [nil, ''])
+      scope = scope.where(arel_table[:album_name].matches("%#{sanitize_sql_like(query)}%")) if query.present?
+      scope.distinct.order(:album_name).limit(limit).pluck(:album_name)
+    end
+
+    def suggest_years(limit)
+      distinct_years(limit).map(&:year)
+    end
+
+    def suggest_themes(query, limit)
+      themes = Lyrics::ThemeTranslator::EN_TO_NL.keys
+      themes = themes.select { |t| t.start_with?(query.downcase.strip) } if query.present?
+      themes.first(limit)
+    end
+  end
+end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -63,6 +63,7 @@ class Song < ApplicationRecord
   include ChartConcern
   include TimeAnalyticsConcern
   include SongSearchConcern
+  include SongSuggestionConcern
   include Sluggable
   include TitleNormalizable
   include ExternalEnrichmentConcern

--- a/app/services/llm/query_translator.rb
+++ b/app/services/llm/query_translator.rb
@@ -18,7 +18,7 @@ module Llm
 
     SORT_OPTIONS = %w[most_played newest popularity].freeze
     SEARCH_TYPES = %w[songs artists].freeze
-    STRING_FILTERS = %w[text_search artist title album genre radio_station period lyrics].freeze
+    STRING_FILTERS = %w[text_search artist title album genre radio_station period lyrics theme].freeze
     MAX_STRING_LENGTH = 200
     COUNTRY_CODE_PATTERN = /\A[A-Z]{2,3}\z/
 
@@ -57,6 +57,7 @@ module Llm
         - "sort_by": one of: most_played, newest, popularity (default: most_played)
         - "limit": max results to return (integer, default: 20, max: 50). Use when the user asks for "top N", "most popular", "number 1", etc. For example, "top 3" → limit: 3, "the most popular song" → limit: 1.
         - "lyrics": the lyrics or text snippet the user is searching by (string, for display purposes only)
+        - "theme": a single lyric theme tag the user is searching by. Use this when the user asks for songs *about* a topic (e.g. "songs about freedom", "nummers over liefde"). Pick exactly one English lower-case tag from this controlled vocabulary: #{lyric_themes_vocabulary}. Map synonyms to the closest tag (e.g. "broken heart" → "heartbreak", "vrijheid" → "freedom", "verdriet" → "loss", "verliefd" → "love"). Skip the field if no tag fits.
 
         Rules:
         - Return ONLY valid JSON, no explanation or markdown.
@@ -67,6 +68,14 @@ module Llm
         - "Hits" or "popular" implies sort_by "popularity".
         - Understand both English and Dutch queries.
         - When the user mentions lyrics, song text, or quotes part of a song, try to identify the song. If you recognize the lyrics, set "artist" and "title" to the correct song. Always set "lyrics" to the quoted/mentioned lyrics so the user can see what was matched. If you cannot identify the song, set "text_search" to the most distinctive words from the lyrics and still set "lyrics".
+
+        Example translations:
+        - "songs about freedom" -> {"theme": "freedom"}
+        - "nummers over liefde" -> {"theme": "love"}
+        - "heartbreak songs from the 90s" -> {"theme": "heartbreak", "year_from": 1990, "year_to": 1999}
+        - "songs about drugs by Dutch artists" -> {"theme": "drugs", "country": "NL"}
+        - "party songs about dancing" -> {"theme": "dance", "mood": "party"}
+        - "top 5 songs about hope this month" -> {"theme": "hope", "period": "month", "sort_by": "most_played", "limit": 5}
       PROMPT
     end
 
@@ -74,6 +83,10 @@ module Llm
       Rails.cache.fetch('llm:radio_station_names', expires_in: 1.hour) do
         RadioStation.pluck(:name)
       end
+    end
+
+    def lyric_themes_vocabulary
+      Lyrics::ThemeTranslator::EN_TO_NL.keys.join(', ')
     end
 
     def parse_response(response)

--- a/app/services/llm/search_examples.rb
+++ b/app/services/llm/search_examples.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Static catalogue of example natural language queries the frontend can render as
+# clickable suggestions next to the search bar. Bilingual (EN/NL) so the UI can
+# pick the right label for the active locale, and tagged by `category` so the
+# frontend can group them or sample one per category.
+#
+# These doubles as ad-hoc documentation of which phrasings the LLM is expected
+# to handle: any query here that doesn't translate cleanly via
+# `Llm::QueryTranslator` is a prompt regression worth investigating.
+module Llm
+  module SearchExamples
+    EXAMPLES = [
+      { en: 'songs about freedom', nl: 'nummers over vrijheid', category: 'theme' },
+      { en: 'love songs from the 90s', nl: 'liefdesnummers uit de jaren 90', category: 'theme' },
+      { en: 'songs about heartbreak by Adele', nl: 'liefdesverdriet nummers van Adele', category: 'theme' },
+      { en: 'party songs about dancing', nl: 'feestnummers over dansen', category: 'theme' },
+      { en: 'songs about drugs and addiction', nl: 'nummers over drugs en verslaving', category: 'theme' },
+      { en: 'songs about hope and the future', nl: 'nummers over hoop en de toekomst', category: 'theme' },
+      { en: 'upbeat Dutch songs played on Radio 538 last week', nl: 'vrolijke Nederlandse nummers op Radio 538 van afgelopen week',
+        category: 'mood' },
+      { en: 'sad acoustic songs', nl: 'droevige akoestische nummers', category: 'mood' },
+      { en: 'top 3 most played songs this month', nl: 'top 3 meest gedraaide nummers deze maand', category: 'chart' },
+      { en: 'British rock songs from the 80s', nl: 'Britse rocknummers uit de jaren 80', category: 'genre' }
+    ].freeze
+
+    def self.list
+      EXAMPLES.map(&:dup)
+    end
+  end
+end

--- a/app/services/natural_language_search.rb
+++ b/app/services/natural_language_search.rb
@@ -61,6 +61,7 @@ class NaturalLanguageSearch
     scope = apply_song_text_facets(scope)
     scope = apply_genre_filter(scope) if filters[:genre].present?
     scope = apply_country_filter(scope) if filters[:country].present?
+    scope = scope.filter_by_theme(filters[:theme]) if filters[:theme].present?
     scope
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
         get :autocomplete, on: :collection
         get :search, on: :collection
         get :natural_language_search, on: :collection
+        get :natural_language_examples, on: :collection
         get :search_suggestions, on: :collection
         get :graph_data, on: :member
         get :chart_positions, on: :member

--- a/spec/models/song_spec.rb
+++ b/spec/models/song_spec.rb
@@ -305,6 +305,25 @@ describe Song do
       expect(results).to contain_exactly(rolling)
     end
 
+    context 'with a theme filter' do
+      before do
+        create(:lyric, song: hotline, themes: %w[party dance])
+        create(:lyric, song: rolling, themes: %w[heartbreak loss])
+      end
+
+      it 'filters by lyric theme', :aggregate_failures do
+        results = Song.faceted_search(theme: 'heartbreak')
+        expect(results).to include(rolling)
+        expect(results).not_to include(hotline)
+      end
+
+      it 'normalizes the theme value', :aggregate_failures do
+        results = Song.faceted_search(theme: ' Heartbreak ')
+        expect(results).to include(rolling)
+        expect(results).not_to include(hotline)
+      end
+    end
+
     it 'returns all songs when no filters given' do
       results = Song.faceted_search
       expect(results).to include(hotline, rolling)
@@ -351,8 +370,16 @@ describe Song do
       expect(Song.suggest(field: 'year')).to include(2016)
     end
 
+    it 'suggests lyric themes from the canonical vocabulary' do
+      expect(Song.suggest(field: 'theme', limit: 10)).to include('love', 'freedom')
+    end
+
+    it 'filters theme suggestions by query prefix' do
+      expect(Song.suggest(field: 'theme', query: 'free')).to include('freedom')
+    end
+
     it 'returns available field names for unknown field' do
-      expect(Song.suggest(field: nil)).to eq(%w[artist title album year_from year_to])
+      expect(Song.suggest(field: nil)).to eq(%w[artist title album year_from year_to theme])
     end
   end
 

--- a/spec/requests/api/v1/songs_spec.rb
+++ b/spec/requests/api/v1/songs_spec.rb
@@ -171,6 +171,9 @@ RSpec.describe 'Songs API', type: :request do
                 description: 'Filter by song title (fuzzy match)'
       parameter name: :album, in: :query, type: :string, required: false,
                 description: 'Filter by album name'
+      parameter name: :theme, in: :query, type: :string, required: false,
+                description: 'Filter by lyric theme (e.g. love, freedom, drugs). Use ' \
+                             '/search_suggestions?field=theme for the canonical vocabulary.'
       parameter name: :year_from, in: :query, type: :integer, required: false,
                 description: 'Filter songs released in or after this year'
       parameter name: :year_to, in: :query, type: :integer, required: false,
@@ -239,6 +242,65 @@ RSpec.describe 'Songs API', type: :request do
           end
         end
       end
+
+      context 'with a theme filter' do
+        response '200', 'Filters by lyric theme' do
+          let!(:freedom_song) { create(:song, title: 'Free Bird') }
+          let!(:love_song) { create(:song, title: 'Love Story') }
+          let(:theme) { 'freedom' }
+
+          before do
+            create(:lyric, song: freedom_song, themes: %w[freedom rebellion])
+            create(:lyric, song: love_song, themes: %w[love romance])
+          end
+
+          run_test! do |response|
+            data = JSON.parse(response.body)
+            titles = data['data'].map { |d| d['attributes']['title'] }
+            expect(titles).to include('Free Bird')
+            expect(titles).not_to include('Love Story')
+          end
+        end
+      end
+    end
+  end
+
+  path '/api/v1/songs/natural_language_examples' do
+    get 'Example natural language search queries' do
+      tags 'Songs'
+      produces 'application/json'
+      description 'Returns example bilingual (EN/NL) natural language queries the frontend can ' \
+                  'show as suggestions next to the search bar (e.g. "Try: songs about freedom").'
+
+      response '200', 'Examples returned' do
+        example 'application/json', :examples, {
+          examples: [
+            { en: 'songs about freedom', nl: 'nummers over vrijheid', category: 'theme' },
+            { en: 'love songs from the 90s', nl: 'liefdesnummers uit de jaren 90', category: 'theme' }
+          ]
+        }
+
+        schema type: :object, properties: {
+          examples: {
+            type: :array,
+            items: {
+              type: :object,
+              properties: {
+                en: { type: :string },
+                nl: { type: :string },
+                category: { type: :string }
+              },
+              required: %w[en nl category]
+            }
+          }
+        }, required: ['examples']
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['examples']).to be_an(Array)
+          expect(data['examples']).not_to be_empty
+        end
+      end
     end
   end
 
@@ -288,13 +350,13 @@ RSpec.describe 'Songs API', type: :request do
 
       response '200', 'Available fields when no field specified' do
         example 'application/json', :available_fields, {
-          suggestions: %w[artist title album year_from year_to],
+          suggestions: %w[artist title album year_from year_to theme],
           field: nil
         }
 
         run_test! do |response|
           data = JSON.parse(response.body)
-          expect(data['suggestions']).to eq(%w[artist title album year_from year_to])
+          expect(data['suggestions']).to eq(%w[artist title album year_from year_to theme])
         end
       end
     end

--- a/spec/services/llm/query_translator_spec.rb
+++ b/spec/services/llm/query_translator_spec.rb
@@ -192,6 +192,20 @@ RSpec.describe Llm::QueryTranslator, type: :service do
       end
     end
 
+    context 'when the query asks for songs about a theme' do
+      let(:llm_response) do
+        { theme: 'freedom', period: 'all' }.to_json
+      end
+
+      before do
+        allow(translator).to receive(:chat).and_return(llm_response)
+      end
+
+      it 'returns the theme filter' do
+        expect(translate[:theme]).to eq('freedom')
+      end
+    end
+
     context 'when the query asks for a limited number of results' do
       let(:llm_response) do
         {

--- a/spec/services/natural_language_search_spec.rb
+++ b/spec/services/natural_language_search_spec.rb
@@ -211,6 +211,25 @@ RSpec.describe NaturalLanguageSearch, type: :service do
       end
     end
 
+    context 'when filtering songs by lyric theme' do
+      let(:freedom_song) { create(:song, title: 'Free Bird') }
+      let(:love_song) { create(:song, title: 'Love Story') }
+
+      before do
+        create(:lyric, song: freedom_song, themes: %w[freedom rebellion])
+        create(:lyric, song: love_song, themes: %w[love romance])
+        create(:air_play, song: freedom_song, radio_station: radio_station, broadcasted_at: 1.day.ago, status: :confirmed)
+        create(:air_play, song: love_song, radio_station: radio_station, broadcasted_at: 1.day.ago, status: :confirmed)
+        allow(translator).to receive(:translate).and_return(theme: 'freedom', period: 'all')
+      end
+
+      it 'returns only songs whose lyrics include the theme', :aggregate_failures do
+        result_ids = search.map(&:id)
+        expect(result_ids).to include(freedom_song.id)
+        expect(result_ids).not_to include(love_song.id)
+      end
+    end
+
     context 'when the query specifies a limit' do
       let(:songs) { create_list(:song, 5) }
 

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -2904,6 +2904,13 @@ paths:
         description: Filter by album name
         schema:
           type: string
+      - name: theme
+        in: query
+        required: false
+        description: Filter by lyric theme (e.g. love, freedom, drugs). Use /search_suggestions?field=theme
+          for the canonical vocabulary.
+        schema:
+          type: string
       - name: year_from
         in: query
         required: false
@@ -2936,7 +2943,7 @@ paths:
           type: integer
       responses:
         '200':
-          description: Returns songs ordered by popularity
+          description: Filters by lyric theme
           content:
             application/json:
               examples:
@@ -2952,6 +2959,49 @@ paths:
                         artists:
                         - id: 1
                           name: Drake
+  "/api/v1/songs/natural_language_examples":
+    get:
+      summary: Example natural language search queries
+      tags:
+      - Songs
+      description: 'Returns example bilingual (EN/NL) natural language queries the
+        frontend can show as suggestions next to the search bar (e.g. "Try: songs
+        about freedom").'
+      responses:
+        '200':
+          description: Examples returned
+          content:
+            application/json:
+              examples:
+                examples:
+                  value:
+                    examples:
+                    - en: songs about freedom
+                      nl: nummers over vrijheid
+                      category: theme
+                    - en: love songs from the 90s
+                      nl: liefdesnummers uit de jaren 90
+                      category: theme
+              schema:
+                type: object
+                properties:
+                  examples:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        en:
+                          type: string
+                        nl:
+                          type: string
+                        category:
+                          type: string
+                      required:
+                      - en
+                      - nl
+                      - category
+                required:
+                - examples
   "/api/v1/songs/search_suggestions":
     get:
       summary: Get search suggestions for a field
@@ -3004,6 +3054,7 @@ paths:
                     - album
                     - year_from
                     - year_to
+                    - theme
                     field:
   "/api/v1/songs/{id}":
     get:


### PR DESCRIPTION
## Summary
- Filter songs by lyric theme via `GET /api/v1/songs/search?theme=<tag>` (uses the existing GIN index on `lyrics.themes`).
- Surface the canonical theme vocabulary through `GET /api/v1/songs/search_suggestions?field=theme`.
- Teach `Llm::QueryTranslator` to map natural-language "songs about X" queries (EN+NL) to a `theme` filter, with the controlled vocabulary inlined into the system prompt and worked examples.
- Add `GET /api/v1/songs/natural_language_examples` returning bilingual example queries the frontend can show next to the search bar.
- Extract `SongSuggestionConcern` from `SongSearchConcern` to keep both within rubocop length limits.

## Test plan
- [x] `bundle exec rspec` (1894 examples, 0 failures)
- [x] `bundle exec rubocop` on changed files
- [x] `bundle exec rake rswag:specs:swaggerize` (swagger.yaml updated)
- [ ] Verify on the frontend: theme facet on `/songs/search`, theme appears in `search_suggestions?field=theme`, NL search e.g. "songs about freedom" routes through `theme: "freedom"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)