### PR TITLE
Add lyric language to song faceted and LLM search

### DIFF
--- a/app/controllers/api/v1/songs_controller.rb
+++ b/app/controllers/api/v1/songs_controller.rb
@@ -49,6 +49,9 @@ module Api
       #   - album (optional): Filter by album name (fuzzy match)
       #   - theme (optional): Filter by lyric theme (e.g. "love", "freedom", "drugs"). See
       #     `GET /search_suggestions?field=theme` for the canonical theme vocabulary
+      #   - lyric_language (optional): Filter by the language the lyrics are written in,
+      #     ISO 639-1 code (e.g. "en", "nl", "es"). See `GET /search_suggestions?field=lyric_language`
+      #     for languages with analyzed songs.
       #   - year_from (optional): Filter songs released in or after this year
       #   - year_to (optional): Filter songs released in or before this year
       #   - limit (optional, default: 10): Maximum number of results (max: 20)
@@ -105,9 +108,10 @@ module Api
       # Returns autocomplete suggestions for a specific search field.
       #
       # Parameters:
-      #   - field (required): Field to suggest values for (artist, title, album, year, theme).
-      #     The `theme` field returns canonical English lyric themes (love, freedom, drugs, etc.)
-      #     suitable for the `/search?theme=` facet.
+      #   - field (required): Field to suggest values for (artist, title, album, year, theme,
+      #     lyric_language). The `theme` field returns canonical English lyric themes (love,
+      #     freedom, drugs, etc.); `lyric_language` returns ISO 639-1 codes for languages with
+      #     at least one analyzed song.
       #   - q (optional): Partial input to filter suggestions
       #   - limit (optional, default: 5): Maximum suggestions (max: 10)
       def search_suggestions
@@ -422,6 +426,7 @@ module Api
           title: params[:title],
           album: params[:album],
           theme: params[:theme],
+          lyric_language: params[:lyric_language],
           year_from: params[:year_from],
           year_to: params[:year_to],
           sort_by: params[:sort_by],

--- a/app/models/concerns/song_search_concern.rb
+++ b/app/models/concerns/song_search_concern.rb
@@ -3,7 +3,7 @@
 module SongSearchConcern
   extend ActiveSupport::Concern
 
-  SEARCH_FIELDS = %w[artist title album year_from year_to theme].freeze
+  SEARCH_FIELDS = %w[artist title album year_from year_to theme lyric_language].freeze
 
   # Minimum pg_trgm similarity for a fuzzy match. The default `%` operator uses
   # pg_trgm.similarity_limit (0.3) which is too permissive for search; 0.5
@@ -53,6 +53,11 @@ module SongSearchConcern
       normalized = theme.to_s.downcase.strip
       joins(:lyric).where('lyrics.themes @> ARRAY[?]::varchar[]', normalized)
     }
+    scope :filter_by_lyric_language, lambda { |code|
+      return all if code.blank?
+
+      joins(:lyric).where(lyrics: { language: code.to_s.downcase.strip })
+    }
     scope :filter_by_year_range, lambda { |year_from: nil, year_to: nil|
       scope = all
       scope = scope.where(release_date: Date.new(year_from.to_i)..) if year_from.present?
@@ -84,6 +89,7 @@ module SongSearchConcern
                 .filter_by_title(filters[:title])
                 .filter_by_album(filters[:album])
                 .filter_by_theme(filters[:theme])
+                .filter_by_lyric_language(filters[:lyric_language])
                 .filter_by_year_range(year_from: filters[:year_from], year_to: filters[:year_to])
                 .limit(filters.fetch(:limit, 10))
       apply_faceted_sort(scope, filters[:sort_by])

--- a/app/models/concerns/song_suggestion_concern.rb
+++ b/app/models/concerns/song_suggestion_concern.rb
@@ -11,6 +11,7 @@ module SongSuggestionConcern
       when 'album' then suggest_albums(query, limit)
       when 'year' then suggest_years(limit)
       when 'theme' then suggest_themes(query, limit)
+      when 'lyric_language' then suggest_lyric_languages(query, limit)
       else SongSearchConcern::SEARCH_FIELDS
       end
     end
@@ -51,6 +52,12 @@ module SongSuggestionConcern
       themes = Lyrics::ThemeTranslator::EN_TO_NL.keys
       themes = themes.select { |t| t.start_with?(query.downcase.strip) } if query.present?
       themes.first(limit)
+    end
+
+    def suggest_lyric_languages(query, limit)
+      scope = Lyric.where.not(language: [nil, ''])
+      scope = scope.where('language ILIKE ?', "#{ActiveRecord::Base.sanitize_sql_like(query.to_s.downcase.strip)}%") if query.present?
+      scope.distinct.order(:language).limit(limit).pluck(:language)
     end
   end
 end

--- a/app/services/llm/query_translator.rb
+++ b/app/services/llm/query_translator.rb
@@ -18,7 +18,7 @@ module Llm
 
     SORT_OPTIONS = %w[most_played newest popularity].freeze
     SEARCH_TYPES = %w[songs artists].freeze
-    STRING_FILTERS = %w[text_search artist title album genre radio_station period lyrics theme].freeze
+    STRING_FILTERS = %w[text_search artist title album genre radio_station period lyrics theme lyric_language].freeze
     MAX_STRING_LENGTH = 200
     COUNTRY_CODE_PATTERN = /\A[A-Z]{2,3}\z/
 
@@ -58,6 +58,7 @@ module Llm
         - "limit": max results to return (integer, default: 20, max: 50). Use when the user asks for "top N", "most popular", "number 1", etc. For example, "top 3" → limit: 3, "the most popular song" → limit: 1.
         - "lyrics": the lyrics or text snippet the user is searching by (string, for display purposes only)
         - "theme": a single lyric theme tag the user is searching by. Use this when the user asks for songs *about* a topic (e.g. "songs about freedom", "nummers over liefde"). Pick exactly one English lower-case tag from this controlled vocabulary: #{lyric_themes_vocabulary}. Map synonyms to the closest tag (e.g. "broken heart" → "heartbreak", "vrijheid" → "freedom", "verdriet" → "loss", "verliefd" → "love"). Skip the field if no tag fits.
+        - "lyric_language": ISO 639-1 lower-case code for the language the *lyrics* are written in (e.g. "en", "nl", "es", "fr", "de"). Use this when the user asks for songs *in* a language or *with* lyrics in a language ("songs in Dutch", "Nederlandstalige nummers", "Spanish lyrics", "Engelstalig"). Distinguish from "country": "Dutch songs" / "songs by Dutch artists" → country: "NL"; "songs in Dutch" / "Dutch lyrics" → lyric_language: "nl". When both are clearly implied, set both.
 
         Rules:
         - Return ONLY valid JSON, no explanation or markdown.
@@ -76,6 +77,10 @@ module Llm
         - "songs about drugs by Dutch artists" -> {"theme": "drugs", "country": "NL"}
         - "party songs about dancing" -> {"theme": "dance", "mood": "party"}
         - "top 5 songs about hope this month" -> {"theme": "hope", "period": "month", "sort_by": "most_played", "limit": 5}
+        - "songs in Dutch" -> {"lyric_language": "nl"}
+        - "Nederlandstalige liefdesnummers" -> {"lyric_language": "nl", "theme": "love"}
+        - "Spanish lyrics about heartbreak" -> {"lyric_language": "es", "theme": "heartbreak"}
+        - "Dutch songs by American artists" -> {"lyric_language": "nl", "country": "US"}
       PROMPT
     end
 

--- a/app/services/llm/search_examples.rb
+++ b/app/services/llm/search_examples.rb
@@ -21,7 +21,9 @@ module Llm
         category: 'mood' },
       { en: 'sad acoustic songs', nl: 'droevige akoestische nummers', category: 'mood' },
       { en: 'top 3 most played songs this month', nl: 'top 3 meest gedraaide nummers deze maand', category: 'chart' },
-      { en: 'British rock songs from the 80s', nl: 'Britse rocknummers uit de jaren 80', category: 'genre' }
+      { en: 'British rock songs from the 80s', nl: 'Britse rocknummers uit de jaren 80', category: 'genre' },
+      { en: 'songs with Dutch lyrics', nl: 'Nederlandstalige nummers', category: 'language' },
+      { en: 'Spanish lyrics about heartbreak', nl: 'Spaanstalige nummers over liefdesverdriet', category: 'language' }
     ].freeze
 
     def self.list

--- a/app/services/natural_language_search.rb
+++ b/app/services/natural_language_search.rb
@@ -62,6 +62,7 @@ class NaturalLanguageSearch
     scope = apply_genre_filter(scope) if filters[:genre].present?
     scope = apply_country_filter(scope) if filters[:country].present?
     scope = scope.filter_by_theme(filters[:theme]) if filters[:theme].present?
+    scope = scope.filter_by_lyric_language(filters[:lyric_language]) if filters[:lyric_language].present?
     scope
   end
 

--- a/spec/models/song_spec.rb
+++ b/spec/models/song_spec.rb
@@ -324,6 +324,25 @@ describe Song do
       end
     end
 
+    context 'with a lyric_language filter' do
+      before do
+        create(:lyric, song: hotline, language: 'en')
+        create(:lyric, song: rolling, language: 'nl')
+      end
+
+      it 'filters by the language of the lyrics', :aggregate_failures do
+        results = Song.faceted_search(lyric_language: 'nl')
+        expect(results).to include(rolling)
+        expect(results).not_to include(hotline)
+      end
+
+      it 'normalizes the language code', :aggregate_failures do
+        results = Song.faceted_search(lyric_language: ' NL ')
+        expect(results).to include(rolling)
+        expect(results).not_to include(hotline)
+      end
+    end
+
     it 'returns all songs when no filters given' do
       results = Song.faceted_search
       expect(results).to include(hotline, rolling)
@@ -378,8 +397,14 @@ describe Song do
       expect(Song.suggest(field: 'theme', query: 'free')).to include('freedom')
     end
 
+    it 'suggests lyric languages present in the database' do
+      create(:lyric, song: hotline, language: 'en')
+      create(:lyric, song: create(:song, title: 'Duurt Te Lang'), language: 'nl')
+      expect(Song.suggest(field: 'lyric_language')).to contain_exactly('en', 'nl')
+    end
+
     it 'returns available field names for unknown field' do
-      expect(Song.suggest(field: nil)).to eq(%w[artist title album year_from year_to theme])
+      expect(Song.suggest(field: nil)).to eq(%w[artist title album year_from year_to theme lyric_language])
     end
   end
 

--- a/spec/requests/api/v1/songs_spec.rb
+++ b/spec/requests/api/v1/songs_spec.rb
@@ -174,6 +174,9 @@ RSpec.describe 'Songs API', type: :request do
       parameter name: :theme, in: :query, type: :string, required: false,
                 description: 'Filter by lyric theme (e.g. love, freedom, drugs). Use ' \
                              '/search_suggestions?field=theme for the canonical vocabulary.'
+      parameter name: :lyric_language, in: :query, type: :string, required: false,
+                description: 'Filter by the language the lyrics are written in (ISO 639-1, e.g. nl, en, es). ' \
+                             'Use /search_suggestions?field=lyric_language for analyzed languages.'
       parameter name: :year_from, in: :query, type: :integer, required: false,
                 description: 'Filter songs released in or after this year'
       parameter name: :year_to, in: :query, type: :integer, required: false,
@@ -259,6 +262,26 @@ RSpec.describe 'Songs API', type: :request do
             titles = data['data'].map { |d| d['attributes']['title'] }
             expect(titles).to include('Free Bird')
             expect(titles).not_to include('Love Story')
+          end
+        end
+      end
+
+      context 'with a lyric_language filter' do
+        response '200', 'Filters by lyric language' do
+          let!(:dutch_song) { create(:song, title: 'Duurt Te Lang') }
+          let!(:english_song) { create(:song, title: 'Rolling in the Deep') }
+          let(:lyric_language) { 'nl' }
+
+          before do
+            create(:lyric, song: dutch_song, language: 'nl')
+            create(:lyric, song: english_song, language: 'en')
+          end
+
+          run_test! do |response|
+            data = JSON.parse(response.body)
+            titles = data['data'].map { |d| d['attributes']['title'] }
+            expect(titles).to include('Duurt Te Lang')
+            expect(titles).not_to include('Rolling in the Deep')
           end
         end
       end
@@ -350,13 +373,13 @@ RSpec.describe 'Songs API', type: :request do
 
       response '200', 'Available fields when no field specified' do
         example 'application/json', :available_fields, {
-          suggestions: %w[artist title album year_from year_to theme],
+          suggestions: %w[artist title album year_from year_to theme lyric_language],
           field: nil
         }
 
         run_test! do |response|
           data = JSON.parse(response.body)
-          expect(data['suggestions']).to eq(%w[artist title album year_from year_to theme])
+          expect(data['suggestions']).to eq(%w[artist title album year_from year_to theme lyric_language])
         end
       end
     end

--- a/spec/services/llm/query_translator_spec.rb
+++ b/spec/services/llm/query_translator_spec.rb
@@ -206,6 +206,21 @@ RSpec.describe Llm::QueryTranslator, type: :service do
       end
     end
 
+    context 'when the query asks for songs in a specific lyric language' do
+      let(:llm_response) do
+        { lyric_language: 'nl', theme: 'love' }.to_json
+      end
+
+      before do
+        allow(translator).to receive(:chat).and_return(llm_response)
+      end
+
+      it 'returns the lyric_language filter alongside other facets', :aggregate_failures do
+        expect(translate[:lyric_language]).to eq('nl')
+        expect(translate[:theme]).to eq('love')
+      end
+    end
+
     context 'when the query asks for a limited number of results' do
       let(:llm_response) do
         {

--- a/spec/services/natural_language_search_spec.rb
+++ b/spec/services/natural_language_search_spec.rb
@@ -211,6 +211,25 @@ RSpec.describe NaturalLanguageSearch, type: :service do
       end
     end
 
+    context 'when filtering songs by lyric language' do
+      let(:dutch_song) { create(:song, title: 'Duurt Te Lang') }
+      let(:english_song) { create(:song, title: 'Rolling in the Deep') }
+
+      before do
+        create(:lyric, song: dutch_song, language: 'nl')
+        create(:lyric, song: english_song, language: 'en')
+        create(:air_play, song: dutch_song, radio_station: radio_station, broadcasted_at: 1.day.ago, status: :confirmed)
+        create(:air_play, song: english_song, radio_station: radio_station, broadcasted_at: 1.day.ago, status: :confirmed)
+        allow(translator).to receive(:translate).and_return(lyric_language: 'nl', period: 'all')
+      end
+
+      it 'returns only songs whose lyrics are in the requested language', :aggregate_failures do
+        result_ids = search.map(&:id)
+        expect(result_ids).to include(dutch_song.id)
+        expect(result_ids).not_to include(english_song.id)
+      end
+    end
+
     context 'when filtering songs by lyric theme' do
       let(:freedom_song) { create(:song, title: 'Free Bird') }
       let(:love_song) { create(:song, title: 'Love Story') }

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -2911,6 +2911,14 @@ paths:
           for the canonical vocabulary.
         schema:
           type: string
+      - name: lyric_language
+        in: query
+        required: false
+        description: Filter by the language the lyrics are written in (ISO 639-1,
+          e.g. nl, en, es). Use /search_suggestions?field=lyric_language for analyzed
+          languages.
+        schema:
+          type: string
       - name: year_from
         in: query
         required: false
@@ -2943,7 +2951,7 @@ paths:
           type: integer
       responses:
         '200':
-          description: Filters by lyric theme
+          description: Filters by lyric language
           content:
             application/json:
               examples:
@@ -3055,6 +3063,7 @@ paths:
                     - year_from
                     - year_to
                     - theme
+                    - lyric_language
                     field:
   "/api/v1/songs/{id}":
     get:


### PR DESCRIPTION
## Summary
- Filter songs by the language the lyrics are written in via `GET /api/v1/songs/search?lyric_language=<iso639-1>` (e.g. `nl`, `en`, `es`).
- `GET /api/v1/songs/search_suggestions?field=lyric_language` returns the ISO 639-1 codes that have at least one analyzed song, so the frontend can populate a language picker without hard-coding a list.
- `Llm::QueryTranslator` now emits a `lyric_language` filter. The system prompt explicitly distinguishes "Dutch songs" / "songs by Dutch artists" → `country: "NL"` from "songs in Dutch" / "Nederlandstalige nummers" / "Dutch lyrics" → `lyric_language: "nl"`, with worked examples covering both axes (including combinations like "Dutch songs by American artists").
- Two new bilingual entries in `Llm::SearchExamples` so the frontend's example-prompt UI surfaces this capability immediately.

## Test plan
- [x] `bundle exec rspec` (1900 examples, 0 failures)
- [x] `bundle exec rubocop` on changed files
- [x] `bundle exec rake rswag:specs:swaggerize` (swagger.yaml updated)
- [ ] Verify on the frontend: language facet on `/songs/search`, language codes appear in `search_suggestions?field=lyric_language`, NL search routes "songs in Dutch" through `lyric_language: "nl"` (and not country).

🤖 Generated with [Claude Code](https://claude.com/claude-code)