### PR TITLE
Artist timeline foundation: model, job, services

### DIFF
--- a/app/jobs/artist_timeline_enrichment_job.rb
+++ b/app/jobs/artist_timeline_enrichment_job.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class ArtistTimelineEnrichmentJob
+  THROTTLE_INTERVAL = 3
+  RECHECK_AFTER = 30.days
+
+  include Sidekiq::Job
+  sidekiq_options queue: 'enrichment', lock: :until_executed, lock_ttl: 1.hour
+
+  def self.enqueue_all
+    scope = Artist.where.not(id_on_musicbrainz: nil)
+    scope.find_each.with_index do |artist, index|
+      perform_in((index * THROTTLE_INTERVAL).seconds, artist.id)
+    end
+  end
+
+  def self.enqueue_stale(after: RECHECK_AFTER)
+    threshold = after.ago
+    artist_ids = Artist.where.not(id_on_musicbrainz: nil)
+                   .left_outer_joins(:timeline)
+                   .where('artist_timelines.fetched_at IS NULL OR artist_timelines.fetched_at < ?', threshold)
+                   .pluck(:id)
+
+    artist_ids.each_with_index do |artist_id, index|
+      perform_in((index * THROTTLE_INTERVAL).seconds, artist_id)
+    end
+  end
+
+  def perform(artist_id)
+    artist = Artist.find_by(id: artist_id)
+    return if artist.blank? || artist.id_on_musicbrainz.blank?
+
+    payload = ArtistTimelineBuilder.new(artist).()
+    upsert_timeline(artist, payload)
+  end
+
+  private
+
+  def upsert_timeline(artist, payload)
+    timeline = artist.timeline || artist.build_timeline
+    timeline.assign_attributes(
+      events: payload['events'],
+      musicbrainz_id: payload['musicbrainz_id'],
+      wikidata_id: payload['wikidata_id'],
+      llm_enriched: llm_enriched?(payload['events']),
+      fetched_at: Time.current
+    )
+    timeline.save!
+  end
+
+  def llm_enriched?(events)
+    events.any? { |event| event.key?('summary') || event.key?('notable') }
+  end
+end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -7,6 +7,7 @@
 #  id                           :bigint           not null, primary key
 #  aka_names                    :string           default([]), is an Array
 #  aka_names_checked_at         :datetime
+#  country_code                 :string
 #  country_of_origin            :string           default([]), is an Array
 #  country_of_origin_checked_at :datetime
 #  deezer_artist_url            :string
@@ -68,6 +69,7 @@ class Artist < ApplicationRecord
   has_many :songs, through: :artists_songs
   has_many :air_plays, through: :songs
   has_many :chart_positions, as: :positianable
+  has_one :timeline, class_name: 'ArtistTimeline', dependent: :destroy
 
   scope :matching, ->(search_term) { search_by_name(search_term).reorder(nil) if search_term.present? }
 

--- a/app/models/artist_timeline.rb
+++ b/app/models/artist_timeline.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: artist_timelines
+#
+#  id             :bigint           not null, primary key
+#  events         :jsonb            not null
+#  fetched_at     :datetime
+#  llm_enriched   :boolean          default(FALSE), not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  artist_id      :bigint           not null
+#  musicbrainz_id :string
+#  wikidata_id    :string
+#
+# Indexes
+#
+#  index_artist_timelines_on_artist_id   (artist_id) UNIQUE
+#  index_artist_timelines_on_fetched_at  (fetched_at)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (artist_id => artists.id)
+#
+class ArtistTimeline < ApplicationRecord
+  DEFAULT_STALE_AFTER = 30.days
+
+  belongs_to :artist
+
+  validates :artist_id, uniqueness: true
+
+  scope :stale, ->(after: DEFAULT_STALE_AFTER) { where(arel_table[:fetched_at].lt(after.ago)) }
+  scope :fresh, ->(after: DEFAULT_STALE_AFTER) { where(arel_table[:fetched_at].gteq(after.ago)) }
+
+  def stale?(after: DEFAULT_STALE_AFTER)
+    fetched_at.nil? || fetched_at < after.ago
+  end
+
+  def needs_refresh?(after: DEFAULT_STALE_AFTER)
+    stale?(after: after)
+  end
+end

--- a/app/serializers/artist_serializer.rb
+++ b/app/serializers/artist_serializer.rb
@@ -7,6 +7,7 @@
 #  id                           :bigint           not null, primary key
 #  aka_names                    :string           default([]), is an Array
 #  aka_names_checked_at         :datetime
+#  country_code                 :string
 #  country_of_origin            :string           default([]), is an Array
 #  country_of_origin_checked_at :datetime
 #  deezer_artist_url            :string

--- a/app/services/artist_timeline_builder.rb
+++ b/app/services/artist_timeline_builder.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+class ArtistTimelineBuilder
+  def initialize(artist, language: 'en')
+    @artist = artist
+    @language = language
+  end
+
+  def call
+    return empty_payload if @artist.id_on_musicbrainz.blank?
+
+    mb_result = MusicBrainz::ArtistTimelineFetcher.new(@artist.id_on_musicbrainz).()
+    wikidata_events = fetch_wikidata_events(mb_result.wikidata_id)
+    events = merge_and_sort(mb_result.events, wikidata_events)
+    events = enrich_with_llm(events) if llm_enrichment_enabled?
+
+    {
+      'artist' => @artist.name,
+      'artist_id' => @artist.id,
+      'musicbrainz_id' => @artist.id_on_musicbrainz,
+      'wikidata_id' => mb_result.wikidata_id,
+      'events' => events
+    }
+  end
+
+  private
+
+  def fetch_wikidata_events(wikidata_id)
+    return [] if wikidata_id.blank?
+
+    Wikipedia::WikidataTimelineFinder.new(language: @language).(wikidata_id)
+  end
+
+  def llm_enrichment_enabled?
+    ActiveModel::Type::Boolean.new.cast(ENV.fetch('LLM_TIMELINE_ENABLED', 'false'))
+  end
+
+  def enrich_with_llm(events)
+    return events if events.empty?
+
+    article_text = fetch_article_text
+    return events if article_text.blank?
+
+    Llm::TimelineEventEnricher.new(events: events, article_text: article_text, artist_name: @artist.name).()
+  end
+
+  def fetch_article_text
+    info = Wikipedia::ArtistFinder.new(language: @language).get_info(@artist.name, include_general_info: false)
+    info&.dig('content').presence || info&.dig('summary').presence
+  end
+
+  def merge_and_sort(mb_events, wikidata_events)
+    deduped = (mb_events + wikidata_events).each_with_object({}) do |event, acc|
+      key = dedupe_key(event)
+      acc[key] = event unless acc.key?(key)
+    end
+    deduped.values.sort_by { |event| sort_key(event) }
+  end
+
+  def dedupe_key(event)
+    [year(event['date']), event['category'], event['title'].to_s.downcase.strip]
+  end
+
+  def sort_key(event)
+    [event['date'].to_s.empty? ? 1 : 0, event['date'].to_s, event['category']]
+  end
+
+  def year(date)
+    date.to_s[/-?\d{4}/]
+  end
+
+  def empty_payload
+    {
+      'artist' => @artist.name,
+      'artist_id' => @artist.id,
+      'musicbrainz_id' => nil,
+      'wikidata_id' => nil,
+      'events' => []
+    }
+  end
+end

--- a/app/services/llm/timeline_event_enricher.rb
+++ b/app/services/llm/timeline_event_enricher.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+module Llm
+  class TimelineEventEnricher < Base
+    MAX_ARTICLE_CHARS = 10_000
+    MAX_TOKENS = 4096
+    REQUEST_TIMEOUT = 60
+
+    def initialize(events:, article_text:, artist_name:)
+      super()
+      @events = events.to_a
+      @article_text = article_text.to_s
+      @artist_name = artist_name.to_s
+    end
+
+    def call
+      return @events if @events.empty? || @article_text.blank?
+
+      response = chat(system_prompt: system_prompt, user_message: user_message, max_tokens: MAX_TOKENS)
+      return @events if response.blank?
+
+      enrichments = parse_response(response)
+      return @events if enrichments.blank?
+
+      merge_enrichments(enrichments)
+    end
+
+    private
+
+    def client
+      @client ||= OpenAI::Client.new(access_token: ENV.fetch('OPENAI_API_KEY'), request_timeout: REQUEST_TIMEOUT)
+    end
+
+    def system_prompt
+      <<~PROMPT
+        You enrich a music-artist timeline with grounded summaries based on a Wikipedia article.
+
+        Input:
+        - The artist's Wikipedia article text.
+        - A JSON array of timeline events. Each event has: index, category, date, title.
+
+        For each event, decide:
+        - "summary": a 1-2 sentence factual description, ONLY using information present in the article. If the event is not mentioned, set null. Do NOT invent facts, dates, or quotes.
+        - "notable": true if the article explicitly discusses this event (e.g. covers an album in detail, mentions an award by name). Otherwise false. Compilation albums, live recordings, interview releases, and minor reissues should usually be notable=false unless the article highlights them.
+
+        Output ONLY a JSON object with key "enrichments" mapping to an array. Each item: {"index": <int>, "summary": <string|null>, "notable": <bool>}.
+        Include EVERY input event index exactly once. Match the order of the input events. No prose, no code fences.
+      PROMPT
+    end
+
+    def user_message
+      <<~MSG
+        Artist: #{@artist_name}
+
+        Wikipedia article (truncated):
+        #{truncate_article}
+
+        Events:
+        #{events_json}
+      MSG
+    end
+
+    def truncate_article
+      stripped = ActionController::Base.helpers.strip_tags(@article_text).gsub(/\s+/, ' ').strip
+      stripped.length > MAX_ARTICLE_CHARS ? stripped[0, MAX_ARTICLE_CHARS] : stripped
+    end
+
+    def events_json
+      indexed = @events.each_with_index.map do |event, index|
+        { 'index' => index, 'category' => event['category'], 'date' => event['date'], 'title' => event['title'] }
+      end
+      JSON.generate(indexed)
+    end
+
+    def parse_response(response)
+      json = extract_json(response)
+      return nil if json.blank?
+
+      parsed = JSON.parse(json)
+      enrichments = parsed.is_a?(Hash) ? parsed['enrichments'] : parsed
+      return nil unless enrichments.is_a?(Array)
+
+      enrichments.each_with_object({}) do |entry, acc|
+        next unless entry.is_a?(Hash)
+
+        index = entry['index']
+        next unless index.is_a?(Integer)
+
+        acc[index] = {
+          'summary' => entry['summary'].is_a?(String) ? entry['summary'].strip.presence : nil,
+          'notable' => entry['notable'] == true
+        }
+      end
+    rescue JSON::ParserError => e
+      Rails.logger.warn("[LLM::TimelineEventEnricher] Failed to parse JSON: #{e.message}")
+      nil
+    end
+
+    def merge_enrichments(enrichments)
+      @events.each_with_index.map do |event, index|
+        enrichment = enrichments[index] || {}
+        event.merge('summary' => enrichment['summary'], 'notable' => enrichment.fetch('notable', false))
+      end
+    end
+  end
+end

--- a/app/services/music_brainz/artist_timeline_fetcher.rb
+++ b/app/services/music_brainz/artist_timeline_fetcher.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+module MusicBrainz
+  class ArtistTimelineFetcher
+    LOOKUP_ENDPOINT = 'https://musicbrainz.org/ws/2/artist'
+    USER_AGENT = 'Airplays/1.0.0 (https://airplays.nl)'
+    RATE_LIMIT_DELAY = 1.0
+    INCLUDED_RELEASE_GROUP_TYPES = %w[Album EP].freeze
+
+    Result = Struct.new(:events, :wikidata_id, keyword_init: true)
+
+    def initialize(mbid)
+      @mbid = mbid
+    end
+
+    def call
+      return Result.new(events: [], wikidata_id: nil) if @mbid.blank?
+
+      data = fetch_artist
+      return Result.new(events: [], wikidata_id: nil) if data.blank?
+
+      Result.new(
+        events: build_events(data),
+        wikidata_id: extract_wikidata_id(data)
+      )
+    end
+
+    private
+
+    def fetch_artist
+      Rails.cache.fetch(cache_key, expires_in: 24.hours) do
+        sleep(RATE_LIMIT_DELAY)
+        uri = URI("#{LOOKUP_ENDPOINT}/#{@mbid}")
+        uri.query = URI.encode_www_form(inc: 'release-groups artist-rels url-rels', fmt: 'json')
+
+        response = make_request(uri)
+        next nil unless response.is_a?(Net::HTTPSuccess)
+
+        JSON.parse(response.body)
+      end
+    rescue StandardError => e
+      Rails.logger.error "MusicBrainz::ArtistTimelineFetcher: #{e.message}"
+      nil
+    end
+
+    def build_events(data)
+      [
+        life_span_events(data),
+        member_relation_events(data),
+        release_group_events(data)
+      ].flatten.compact
+    end
+
+    def life_span_events(data)
+      life_span = data['life-span'] || {}
+      type = data['type'].to_s
+
+      events = []
+      events << event(category: begin_category(type), date: life_span['begin'], title: begin_title(type, data['name'])) if life_span['begin'].present?
+      events << event(category: end_category(type), date: life_span['end'], title: end_title(type, data['name'])) if life_span['end'].present?
+      events
+    end
+
+    def member_relation_events(data)
+      data['relations'].to_a.flat_map do |relation|
+        next [] unless relation['type'] == 'member of band'
+
+        target = relation.dig('artist', 'name')
+        next [] if target.blank?
+
+        events = []
+        events << event(category: 'joined_group', date: relation['begin'], title: "Member of #{target}") if relation['begin'].present?
+        events << event(category: 'left_group', date: relation['end'], title: "Left #{target}") if relation['end'].present?
+        events
+      end
+    end
+
+    def release_group_events(data)
+      data['release-groups'].to_a.filter_map do |rg|
+        next nil unless INCLUDED_RELEASE_GROUP_TYPES.include?(rg['primary-type'])
+        next nil if rg['first-release-date'].blank?
+
+        event(
+          category: rg['primary-type'].downcase == 'album' ? 'album_released' : 'ep_released',
+          date: rg['first-release-date'],
+          title: rg['title']
+        )
+      end
+    end
+
+    def extract_wikidata_id(data)
+      relation = data['relations'].to_a.find do |rel|
+        rel['type'] == 'wikidata' && rel.dig('url', 'resource').to_s.include?('wikidata.org')
+      end
+      return nil if relation.blank?
+
+      relation.dig('url', 'resource').to_s.split('/').last.presence
+    end
+
+    def event(category:, date:, title:)
+      { 'category' => category, 'date' => date, 'title' => title, 'source' => 'musicbrainz' }
+    end
+
+    def begin_category(type)
+      type.casecmp('group').zero? ? 'formation' : 'birth'
+    end
+
+    def end_category(type)
+      type.casecmp('group').zero? ? 'dissolution' : 'death'
+    end
+
+    def begin_title(type, name)
+      type.casecmp('group').zero? ? "#{name} formed" : "Birth of #{name}"
+    end
+
+    def end_title(type, name)
+      type.casecmp('group').zero? ? "#{name} disbanded" : "Death of #{name}"
+    end
+
+    def cache_key
+      "music_brainz:artist_timeline:#{@mbid}"
+    end
+
+    def make_request(uri)
+      https = Net::HTTP.new(uri.host, uri.port)
+      https.use_ssl = true
+      https.open_timeout = 10
+      https.read_timeout = 10
+
+      request = Net::HTTP::Get.new(uri)
+      request['User-Agent'] = USER_AGENT
+      request['Accept'] = 'application/json'
+
+      https.request(request)
+    end
+  end
+end

--- a/app/services/wikipedia/wikidata_timeline_finder.rb
+++ b/app/services/wikipedia/wikidata_timeline_finder.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+module Wikipedia
+  class WikidataTimelineFinder
+    SPARQL_URL = 'https://query.wikidata.org/sparql'
+    ENTITY_API_URL = 'https://www.wikidata.org'
+    DEFAULT_LANGUAGE = 'en'
+
+    DATE_CLAIM_PROPERTIES = {
+      'P569' => { category: 'birth', title_template: 'Birth' },
+      'P570' => { category: 'death', title_template: 'Death' },
+      'P571' => { category: 'formation', title_template: 'Formation' },
+      'P576' => { category: 'dissolution', title_template: 'Dissolution' }
+    }.freeze
+
+    def initialize(language: DEFAULT_LANGUAGE)
+      @language = language
+    end
+
+    def call(wikibase_item)
+      return [] if wikibase_item.blank?
+
+      sparql_events(wikibase_item).presence || entity_api_events(wikibase_item)
+    end
+
+    private
+
+    attr_reader :language
+
+    def sparql_events(wikibase_item)
+      rows = execute_query(timeline_query(wikibase_item))
+      return [] if rows.blank?
+
+      rows.filter_map { |row| build_event(row) }
+    end
+
+    def entity_api_events(wikibase_item)
+      entity = fetch_entity(wikibase_item)
+      return [] if entity.blank?
+
+      DATE_CLAIM_PROPERTIES.filter_map do |property_id, meta|
+        date = extract_date_claim(entity, property_id)
+        next nil if date.blank?
+
+        { 'category' => meta[:category], 'date' => date, 'title' => meta[:title_template], 'source' => 'wikidata' }
+      end
+    end
+
+    def fetch_entity(wikibase_item)
+      Rails.cache.fetch("wikidata:timeline_entity:#{language}:#{wikibase_item}", expires_in: 24.hours) do
+        response = entity_connection.get('/w/api.php') do |req|
+          req.params = { action: 'wbgetentities', ids: wikibase_item, format: 'json', props: 'claims', languages: language }
+        end
+        response.body&.dig('entities', wikibase_item)
+      end
+    rescue StandardError => e
+      ExceptionNotifier.notify(e)
+      Rails.logger.error("Wikidata entity API error: #{e.message}")
+      nil
+    end
+
+    def extract_date_claim(entity, property_id)
+      claim = entity.dig('claims', property_id)&.first
+      time_value = claim&.dig('mainsnak', 'datavalue', 'value', 'time')
+      return nil if time_value.blank?
+
+      parse_date(time_value)
+    end
+
+    def entity_connection
+      @entity_connection ||= Faraday.new(url: ENTITY_API_URL) do |conn|
+        conn.response :json
+        conn.headers['User-Agent'] = 'Airplays/1.0 (https://airplays.nl)'
+      end
+    end
+
+    def timeline_query(wikibase_item)
+      <<~SPARQL
+        SELECT ?category ?date ?subject ?subjectLabel WHERE {
+          {
+            wd:#{wikibase_item} wdt:P569 ?date.
+            BIND("birth" AS ?category)
+            BIND(wd:#{wikibase_item} AS ?subject)
+          } UNION {
+            wd:#{wikibase_item} wdt:P570 ?date.
+            BIND("death" AS ?category)
+            BIND(wd:#{wikibase_item} AS ?subject)
+          } UNION {
+            wd:#{wikibase_item} wdt:P571 ?date.
+            BIND("formation" AS ?category)
+            BIND(wd:#{wikibase_item} AS ?subject)
+          } UNION {
+            wd:#{wikibase_item} wdt:P576 ?date.
+            BIND("dissolution" AS ?category)
+            BIND(wd:#{wikibase_item} AS ?subject)
+          } UNION {
+            wd:#{wikibase_item} p:P800 ?statement.
+            ?statement ps:P800 ?subject.
+            OPTIONAL { ?subject wdt:P577 ?date. }
+            BIND("notable_work" AS ?category)
+          } UNION {
+            wd:#{wikibase_item} p:P166 ?statement.
+            ?statement ps:P166 ?subject.
+            OPTIONAL { ?statement pq:P585 ?date. }
+            BIND("award" AS ?category)
+          }
+          SERVICE wikibase:label { bd:serviceParam wikibase:language "#{language}". }
+        }
+        ORDER BY ?date
+      SPARQL
+    end
+
+    def execute_query(query)
+      Rails.cache.fetch(cache_key(query), expires_in: 24.hours) do
+        response = connection.get do |req|
+          req.params['query'] = query
+          req.params['format'] = 'json'
+        end
+        response.body&.dig('results', 'bindings') || []
+      end
+    rescue StandardError => e
+      ExceptionNotifier.notify(e)
+      Rails.logger.error("Wikidata timeline SPARQL error: #{e.message}")
+      []
+    end
+
+    def build_event(row)
+      category = row.dig('category', 'value')
+      return nil if category.blank?
+
+      {
+        'category' => category,
+        'date' => parse_date(row.dig('date', 'value').to_s),
+        'title' => row.dig('subjectLabel', 'value').presence || category.humanize,
+        'source' => 'wikidata'
+      }
+    end
+
+    def parse_date(time_string)
+      match = time_string.match(/([+-]?\d+)-(\d{2})-(\d{2})/)
+      return nil unless match
+
+      year = match[1].to_i
+      return year.to_s if match[2].to_i.zero? || match[3].to_i.zero?
+
+      format('%<year>04d-%<month>02d-%<day>02d', year: year.abs, month: match[2].to_i, day: match[3].to_i)
+    end
+
+    def cache_key(query)
+      "wikidata:timeline:#{language}:#{Digest::MD5.hexdigest(query)}"
+    end
+
+    def connection
+      @connection ||= Faraday.new(url: SPARQL_URL) do |conn|
+        conn.response :json
+        conn.headers['Accept'] = 'application/sparql-results+json'
+        conn.headers['User-Agent'] = 'Airplays/1.0 (https://airplays.nl)'
+      end
+    end
+  end
+end

--- a/db/migrate/20260510221045_create_artist_timelines.rb
+++ b/db/migrate/20260510221045_create_artist_timelines.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class CreateArtistTimelines < ActiveRecord::Migration[8.1]
+  def change
+    create_table :artist_timelines do |t|
+      t.references :artist, null: false, foreign_key: true, index: { unique: true }
+      t.jsonb :events, null: false, default: []
+      t.string :musicbrainz_id
+      t.string :wikidata_id
+      t.boolean :llm_enriched, null: false, default: false
+      t.datetime :fetched_at
+
+      t.timestamps
+    end
+
+    add_index :artist_timelines, :fetched_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_06_082251) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_10_221045) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -82,6 +82,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_082251) do
     t.index ["song_id", "radio_station_id", "broadcasted_at"], name: "air_play_radio_song_time", unique: true
     t.index ["song_id"], name: "index_air_plays_on_song_id"
     t.index ["status"], name: "index_air_plays_on_status"
+  end
+
+  create_table "artist_timelines", force: :cascade do |t|
+    t.bigint "artist_id", null: false
+    t.datetime "created_at", null: false
+    t.jsonb "events", default: [], null: false
+    t.datetime "fetched_at"
+    t.boolean "llm_enriched", default: false, null: false
+    t.string "musicbrainz_id"
+    t.datetime "updated_at", null: false
+    t.string "wikidata_id"
+    t.index ["artist_id"], name: "index_artist_timelines_on_artist_id", unique: true
+    t.index ["fetched_at"], name: "index_artist_timelines_on_fetched_at"
   end
 
   create_table "artists", force: :cascade do |t|
@@ -327,6 +340,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_06_082251) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "air_plays", "radio_stations"
   add_foreign_key "air_plays", "songs"
+  add_foreign_key "artist_timelines", "artists"
   add_foreign_key "chart_positions", "charts"
   add_foreign_key "lyrics", "songs"
   add_foreign_key "music_profiles", "songs"

--- a/lib/tasks/timeline.rake
+++ b/lib/tasks/timeline.rake
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+namespace :timeline do
+  desc 'Print a Wikidata + MusicBrainz timeline for an artist as JSON'
+  task :fetch, %i[artist_id language] => :environment do |_t, args|
+    artist_id = args[:artist_id]
+    if artist_id.blank?
+      $stdout.puts 'Usage: bundle exec rake timeline:fetch[<artist_id>,<language>]'
+      next
+    end
+
+    artist = Artist.find(artist_id)
+    payload = ArtistTimelineBuilder.new(artist, language: args[:language] || 'en').()
+    $stdout.puts JSON.pretty_generate(payload)
+  end
+
+  desc 'Enqueue ArtistTimelineEnrichmentJob for every artist with a MusicBrainz ID'
+  task backfill: :environment do
+    $stdout.puts 'Enqueueing artists for timeline backfill...'
+    ArtistTimelineEnrichmentJob.enqueue_all
+    $stdout.puts 'Done.'
+  end
+
+  desc 'Enqueue ArtistTimelineEnrichmentJob for artists with stale or missing timelines (default 30 days)'
+  task :refresh_stale, [:days] => :environment do |_t, args|
+    days = (args[:days].presence || 30).to_i
+    $stdout.puts "Enqueueing artists with timelines older than #{days} days..."
+    ArtistTimelineEnrichmentJob.enqueue_stale(after: days.days)
+    $stdout.puts 'Done.'
+  end
+end

--- a/spec/factories/artist_timeline.rb
+++ b/spec/factories/artist_timeline.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :artist_timeline do
+    artist
+    events { [] }
+    musicbrainz_id { nil }
+    wikidata_id { nil }
+    llm_enriched { false }
+    fetched_at { Time.current }
+  end
+end

--- a/spec/jobs/artist_timeline_enrichment_job_spec.rb
+++ b/spec/jobs/artist_timeline_enrichment_job_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ArtistTimelineEnrichmentJob do
+  let(:artist) { create(:artist, name: 'Daft Punk', id_on_musicbrainz: '056e4f3e-d505-4dad-8ec1-d04f521cbb56') }
+  let(:job) { described_class.new }
+  let(:builder_payload) do
+    {
+      'artist' => 'Daft Punk',
+      'artist_id' => artist.id,
+      'musicbrainz_id' => '056e4f3e-d505-4dad-8ec1-d04f521cbb56',
+      'wikidata_id' => 'Q185828',
+      'events' => [
+        { 'category' => 'formation', 'date' => '1993', 'title' => 'Daft Punk formed', 'source' => 'musicbrainz' }
+      ]
+    }
+  end
+
+  before do
+    builder = instance_double(ArtistTimelineBuilder, call: builder_payload)
+    allow(ArtistTimelineBuilder).to receive(:new).and_return(builder)
+  end
+
+  describe '#perform' do
+    context 'when artist has a MusicBrainz ID and no existing timeline' do
+      it 'creates a new timeline row', :aggregate_failures do
+        expect { job.perform(artist.id) }.to change(ArtistTimeline, :count).by(1)
+        timeline = artist.reload.timeline
+        expect(timeline.events).to eq(builder_payload['events'])
+        expect(timeline.wikidata_id).to eq('Q185828')
+        expect(timeline.fetched_at).to be_within(5.seconds).of(Time.current)
+      end
+    end
+
+    context 'when artist already has a timeline' do
+      let!(:existing) { create(:artist_timeline, artist: artist, fetched_at: 60.days.ago, events: []) }
+
+      it 'updates the existing row instead of creating a new one', :aggregate_failures do
+        expect { job.perform(artist.id) }.not_to change(ArtistTimeline, :count)
+        existing.reload
+        expect(existing.events).to eq(builder_payload['events'])
+        expect(existing.fetched_at).to be_within(5.seconds).of(Time.current)
+      end
+    end
+
+    context 'when artist is missing' do
+      it 'returns without calling the builder' do
+        job.perform(-1)
+        expect(ArtistTimelineBuilder).not_to have_received(:new)
+      end
+    end
+
+    context 'when artist has no MusicBrainz ID' do
+      let(:artist) { create(:artist, name: 'Unknown', id_on_musicbrainz: nil) }
+
+      it 'returns without calling the builder' do
+        job.perform(artist.id)
+        expect(ArtistTimelineBuilder).not_to have_received(:new)
+      end
+    end
+
+    context 'when builder returns LLM-enriched events' do
+      let(:builder_payload) do
+        {
+          'artist' => 'Daft Punk', 'artist_id' => artist.id, 'musicbrainz_id' => 'mb', 'wikidata_id' => 'wd',
+          'events' => [{ 'category' => 'formation', 'date' => '1993', 'title' => 't', 'source' => 'mb', 'summary' => 'x', 'notable' => true }]
+        }
+      end
+
+      it 'sets llm_enriched to true' do
+        job.perform(artist.id)
+        expect(artist.reload.timeline.llm_enriched).to be(true)
+      end
+    end
+  end
+
+  describe '.enqueue_stale' do
+    let!(:stale) { create(:artist, id_on_musicbrainz: 'mb-stale') }
+    let!(:fresh) { create(:artist, id_on_musicbrainz: 'mb-fresh') }
+    let!(:no_mbid) { create(:artist, id_on_musicbrainz: nil) }
+
+    before do
+      create(:artist_timeline, artist: stale, fetched_at: 60.days.ago)
+      create(:artist_timeline, artist: fresh, fetched_at: 1.day.ago)
+    end
+
+    it 'enqueues only artists whose timelines are stale or missing', :aggregate_failures do
+      allow(described_class).to receive(:perform_in)
+      described_class.enqueue_stale
+      expect(described_class).to have_received(:perform_in).with(anything, stale.id)
+      expect(described_class).not_to have_received(:perform_in).with(anything, fresh.id)
+      expect(described_class).not_to have_received(:perform_in).with(anything, no_mbid.id)
+    end
+  end
+end

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -5,6 +5,7 @@
 #  id                           :bigint           not null, primary key
 #  aka_names                    :string           default([]), is an Array
 #  aka_names_checked_at         :datetime
+#  country_code                 :string
 #  country_of_origin            :string           default([]), is an Array
 #  country_of_origin_checked_at :datetime
 #  deezer_artist_url            :string

--- a/spec/models/artist_timeline_spec.rb
+++ b/spec/models/artist_timeline_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: artist_timelines
+#
+#  id             :bigint           not null, primary key
+#  events         :jsonb            not null
+#  fetched_at     :datetime
+#  llm_enriched   :boolean          default(FALSE), not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  artist_id      :bigint           not null
+#  musicbrainz_id :string
+#  wikidata_id    :string
+#
+# Indexes
+#
+#  index_artist_timelines_on_artist_id   (artist_id) UNIQUE
+#  index_artist_timelines_on_fetched_at  (fetched_at)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (artist_id => artists.id)
+#
+require 'rails_helper'
+
+RSpec.describe ArtistTimeline, type: :model do
+  describe 'associations' do
+    it { is_expected.to belong_to(:artist) }
+  end
+
+  describe 'validations' do
+    subject { build(:artist_timeline) }
+
+    it { is_expected.to validate_uniqueness_of(:artist_id) }
+  end
+
+  describe '#stale?' do
+    context 'when fetched_at is nil' do
+      let(:timeline) { build(:artist_timeline, fetched_at: nil) }
+
+      it 'returns true' do
+        expect(timeline.stale?).to be(true)
+      end
+    end
+
+    context 'when fetched_at is older than the threshold' do
+      let(:timeline) { build(:artist_timeline, fetched_at: 31.days.ago) }
+
+      it 'returns true' do
+        expect(timeline.stale?).to be(true)
+      end
+    end
+
+    context 'when fetched_at is within the threshold' do
+      let(:timeline) { build(:artist_timeline, fetched_at: 1.day.ago) }
+
+      it 'returns false' do
+        expect(timeline.stale?).to be(false)
+      end
+    end
+  end
+
+  describe '.stale and .fresh scopes' do
+    let!(:fresh_timeline) { create(:artist_timeline, fetched_at: 1.day.ago) }
+    let!(:stale_timeline) { create(:artist_timeline, fetched_at: 60.days.ago) }
+
+    it 'separates rows by fetched_at threshold', :aggregate_failures do
+      expect(described_class.stale).to contain_exactly(stale_timeline)
+      expect(described_class.fresh).to contain_exactly(fresh_timeline)
+    end
+  end
+end

--- a/spec/services/artist_timeline_builder_spec.rb
+++ b/spec/services/artist_timeline_builder_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ArtistTimelineBuilder, type: :service do
+  let(:artist) { create(:artist, name: 'Daft Punk', id_on_musicbrainz: '056e4f3e-d505-4dad-8ec1-d04f521cbb56') }
+  let(:builder) { described_class.new(artist) }
+  let(:wikidata_id) { 'Q4936' }
+
+  let(:mb_result) do
+    MusicBrainz::ArtistTimelineFetcher::Result.new(
+      events: [
+        { 'category' => 'formation', 'date' => '1993', 'title' => 'Daft Punk formed', 'source' => 'musicbrainz' },
+        { 'category' => 'album_released', 'date' => '2001-03-12', 'title' => 'Discovery', 'source' => 'musicbrainz' },
+        { 'category' => 'dissolution', 'date' => '2021-02-22', 'title' => 'Daft Punk disbanded', 'source' => 'musicbrainz' }
+      ],
+      wikidata_id: wikidata_id
+    )
+  end
+
+  let(:wikidata_events) do
+    [
+      { 'category' => 'formation', 'date' => '1993', 'title' => 'Daft Punk formed', 'source' => 'wikidata' },
+      { 'category' => 'notable_work', 'date' => '2013-05-17', 'title' => 'Random Access Memories', 'source' => 'wikidata' },
+      { 'category' => 'award', 'date' => '2014-01-26', 'title' => 'Grammy Award for Album of the Year', 'source' => 'wikidata' }
+    ]
+  end
+
+  before do
+    allow(MusicBrainz::ArtistTimelineFetcher).to receive(:new).with(artist.id_on_musicbrainz).and_return(
+      instance_double(MusicBrainz::ArtistTimelineFetcher, call: mb_result)
+    )
+    allow(Wikipedia::WikidataTimelineFinder).to receive(:new).and_return(
+      instance_double(Wikipedia::WikidataTimelineFinder, call: wikidata_events)
+    )
+  end
+
+  describe '#call' do
+    context 'when artist has a MusicBrainz ID' do
+      it 'returns a payload with artist metadata and merged events', :aggregate_failures do
+        result = builder.()
+        expect(result['artist']).to eq('Daft Punk')
+        expect(result['musicbrainz_id']).to eq(artist.id_on_musicbrainz)
+        expect(result['wikidata_id']).to eq(wikidata_id)
+        expect(result['events']).to be_an(Array)
+      end
+
+      it 'dedupes overlapping events from MusicBrainz and Wikidata' do
+        result = builder.()
+        formations = result['events'].select { |e| e['category'] == 'formation' }
+        expect(formations.size).to eq(1)
+      end
+
+      it 'sorts events chronologically' do
+        result = builder.()
+        dates = result['events'].map { |e| e['date'] }
+        expect(dates).to eq(dates.sort)
+      end
+
+      it 'includes events from both sources', :aggregate_failures do
+        sources = builder.().fetch('events').map { |e| e['source'] }.uniq
+        expect(sources).to include('musicbrainz')
+        expect(sources).to include('wikidata')
+      end
+    end
+
+    context 'when artist has no MusicBrainz ID' do
+      let(:artist) { create(:artist, name: 'Unknown', id_on_musicbrainz: nil) }
+
+      it 'returns an empty events array without calling external services', :aggregate_failures do
+        result = builder.()
+        expect(result['events']).to eq([])
+        expect(result['musicbrainz_id']).to be_nil
+        expect(MusicBrainz::ArtistTimelineFetcher).not_to have_received(:new)
+      end
+    end
+
+    context 'when MusicBrainz returns no Wikidata link' do
+      let(:mb_result) do
+        MusicBrainz::ArtistTimelineFetcher::Result.new(
+          events: [{ 'category' => 'formation', 'date' => '1993', 'title' => 'Daft Punk formed', 'source' => 'musicbrainz' }],
+          wikidata_id: nil
+        )
+      end
+
+      it 'still returns MusicBrainz events without querying Wikidata', :aggregate_failures do
+        result = builder.()
+        expect(result['events'].size).to eq(1)
+        expect(Wikipedia::WikidataTimelineFinder).not_to have_received(:new)
+      end
+    end
+
+    context 'when LLM_TIMELINE_ENABLED is false' do
+      before do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with('LLM_TIMELINE_ENABLED', 'false').and_return('false')
+        allow(Llm::TimelineEventEnricher).to receive(:new)
+      end
+
+      it 'skips the LLM enricher and returns plain events' do
+        builder.()
+        expect(Llm::TimelineEventEnricher).not_to have_received(:new)
+      end
+    end
+
+    context 'when LLM_TIMELINE_ENABLED is true and Wikipedia article is available' do
+      let(:enricher_double) { instance_double(Llm::TimelineEventEnricher) }
+      let(:enriched_events) { mb_result.events.map { |e| e.merge('summary' => 'fake', 'notable' => true) } }
+
+      before do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with('LLM_TIMELINE_ENABLED', 'false').and_return('true')
+        allow(Wikipedia::ArtistFinder).to receive(:new).and_return(
+          instance_double(Wikipedia::ArtistFinder, get_info: { 'content' => 'Daft Punk formed in 1993...' })
+        )
+        allow(Llm::TimelineEventEnricher).to receive(:new).and_return(enricher_double)
+        allow(enricher_double).to receive(:call).and_return(enriched_events)
+      end
+
+      it 'enriches events with summary and notable' do
+        result = builder.()
+        expect(result['events'].first).to include('summary' => 'fake', 'notable' => true)
+      end
+    end
+
+    context 'when LLM_TIMELINE_ENABLED is true but Wikipedia article is missing' do
+      before do
+        allow(ENV).to receive(:fetch).and_call_original
+        allow(ENV).to receive(:fetch).with('LLM_TIMELINE_ENABLED', 'false').and_return('true')
+        allow(Wikipedia::ArtistFinder).to receive(:new).and_return(
+          instance_double(Wikipedia::ArtistFinder, get_info: nil)
+        )
+        allow(Llm::TimelineEventEnricher).to receive(:new)
+      end
+
+      it 'returns plain events without calling the LLM enricher' do
+        builder.()
+        expect(Llm::TimelineEventEnricher).not_to have_received(:new)
+      end
+    end
+  end
+end

--- a/spec/services/llm/timeline_event_enricher_spec.rb
+++ b/spec/services/llm/timeline_event_enricher_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Llm::TimelineEventEnricher, type: :service do
+  let(:events) do
+    [
+      { 'category' => 'formation', 'date' => '1993', 'title' => 'Daft Punk formed', 'source' => 'musicbrainz' },
+      { 'category' => 'album_released', 'date' => '2001-03-12', 'title' => 'Discovery', 'source' => 'musicbrainz' },
+      { 'category' => 'album_released', 'date' => '2002', 'title' => 'Daft Club', 'source' => 'musicbrainz' }
+    ]
+  end
+  let(:article_text) { 'Daft Punk formed in Paris in 1993. Discovery (2001) introduced a more melodic, house-oriented sound.' }
+  let(:enricher) { described_class.new(events: events, article_text: article_text, artist_name: 'Daft Punk') }
+
+  describe '#call' do
+    context 'when the LLM returns valid enrichments' do
+      let(:llm_response) do
+        {
+          'enrichments' => [
+            { 'index' => 0, 'summary' => 'Formed in Paris in 1993.', 'notable' => true },
+            { 'index' => 1, 'summary' => 'A melodic, house-oriented album.', 'notable' => true },
+            { 'index' => 2, 'summary' => nil, 'notable' => false }
+          ]
+        }.to_json
+      end
+
+      before { allow(enricher).to receive(:chat).and_return(llm_response) }
+
+      it 'merges summary and notable into each event', :aggregate_failures do
+        result = enricher.()
+        expect(result.size).to eq(3)
+        expect(result[0]['summary']).to eq('Formed in Paris in 1993.')
+        expect(result[0]['notable']).to be(true)
+        expect(result[2]['notable']).to be(false)
+      end
+
+      it 'preserves the original event fields' do
+        result = enricher.()
+        expect(result[1]).to include('category' => 'album_released', 'title' => 'Discovery', 'source' => 'musicbrainz')
+      end
+    end
+
+    context 'when LLM response is malformed' do
+      before { allow(enricher).to receive(:chat).and_return('not json at all') }
+
+      it 'returns the original events unchanged' do
+        expect(enricher.()).to eq(events)
+      end
+    end
+
+    context 'when LLM returns nil' do
+      before { allow(enricher).to receive(:chat).and_return(nil) }
+
+      it 'returns the original events unchanged' do
+        expect(enricher.()).to eq(events)
+      end
+    end
+
+    context 'when article text is blank' do
+      let(:article_text) { '' }
+
+      it 'returns events without calling the LLM', :aggregate_failures do
+        allow(enricher).to receive(:chat)
+        expect(enricher.()).to eq(events)
+        expect(enricher).not_to have_received(:chat)
+      end
+    end
+
+    context 'when events list is empty' do
+      let(:events) { [] }
+
+      it 'returns the empty list without calling the LLM', :aggregate_failures do
+        allow(enricher).to receive(:chat)
+        expect(enricher.()).to eq([])
+        expect(enricher).not_to have_received(:chat)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- New \`ArtistTimeline\` model + migration backed by JSONB \`events\` column, one row per artist
- New \`ArtistTimelineEnrichmentJob\` (enrichment queue, \`until_executed\` lock) that orchestrates \`ArtistTimelineBuilder\` and upserts the row
- Builder merges MusicBrainz release-groups + Wikidata SPARQL (with entity-API fallback) + optional LLM enrichment that adds Wikipedia-grounded summaries and \`notable\` flags
- LLM enrichment is gated by \`LLM_TIMELINE_ENABLED\` (default off) so this PR can ship cold

Rake tasks:
- \`timeline:fetch[artist_id]\` — print JSON to stdout (already used in POC)
- \`timeline:backfill\` — enqueue every artist with a MusicBrainz ID
- \`timeline:refresh_stale[days]\` — enqueue artists with stale or missing timelines (default 30 days)

## Why this design
- Single JSONB column instead of a per-event table: timeline UI renders the whole array; per-event filtering happens client-side. Keeps the schema simple and refresh atomic.
- Separate job (not extending \`ArtistEnrichmentJob\`): \`ArtistEnrichmentJob\` early-returns on \`country_of_origin.present?\`, so a single job doing both would either skip enriched artists or require restructuring that job.
- Wikidata SPARQL primary, entity-API fallback: SPARQL gives qualifier dates (P585 awards, P577 publication date) that the entity API can't easily resolve, but its endpoint flakes. Fallback returns the dated claims (birth/death/formation/dissolution) so the timeline degrades gracefully.

## Test plan
- [x] \`bundle exec rspec spec/models/artist_timeline_spec.rb spec/jobs/artist_timeline_enrichment_job_spec.rb spec/services/artist_timeline_builder_spec.rb spec/services/llm/timeline_event_enricher_spec.rb\` — 27 examples pass
- [x] \`bundle exec rubocop\` clean on all new + modified files
- [x] Live test: \`bundle exec rake "timeline:fetch[<artist_id>]"\` for Daft Punk returns 35 events from MB + Wikidata
- [x] Live test with \`LLM_TIMELINE_ENABLED=true\`: enricher annotates 21/35 events as notable, accurate Wikipedia-grounded summaries
- [ ] Reviewer to sanity-check JSONB query plan if expecting many rows (unique index on \`artist_id\` makes lookups O(1))

## Follow-ups (separate PRs)
- API endpoint exposing the timeline (PR 2)
- Scheduled weekly refresh + Sentry alerts (PR 4)
- React component on playlists-interface (separate repo issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)