### PR TITLE
Artist timeline API: GET /api/v1/artists/:id/timeline

### DIFF
--- a/app/controllers/api/v1/artists_controller.rb
+++ b/app/controllers/api/v1/artists_controller.rb
@@ -4,7 +4,8 @@ module Api
   module V1
     class ArtistsController < ApiController
       skip_before_action :authenticate_client!, only: :widget
-      before_action :artist, only: %i[show graph_data songs chart_positions time_analytics air_plays bio similar_artists widget]
+      before_action :artist,
+                    only: %i[show graph_data songs chart_positions time_analytics air_plays bio similar_artists widget timeline]
       def index
         render json: ArtistSerializer.new(artists)
                        .serializable_hash
@@ -186,6 +187,18 @@ module Api
         bio_data = Wikipedia::ArtistFinder.new(language: language_param).get_info(artist.name)
         artist.cache_wikipedia_url(bio_data['url']) if bio_data.is_a?(Hash)
         render json: { bio: bio_data }
+      end
+
+      def timeline
+        timeline_record = artist.timeline
+        if timeline_record.blank?
+          ArtistTimelineEnrichmentJob.perform_async(artist.id)
+          render json: { status: 'pending', events: [] }, status: :accepted
+          return
+        end
+
+        ArtistTimelineEnrichmentJob.perform_async(artist.id) if timeline_record.needs_refresh?
+        render json: ArtistTimelineSerializer.new(timeline_record).serializable_hash.to_json
       end
 
       private

--- a/app/serializers/artist_timeline_serializer.rb
+++ b/app/serializers/artist_timeline_serializer.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class ArtistTimelineSerializer
+  include FastJsonapi::ObjectSerializer
+
+  set_type :artist_timeline
+
+  attributes :events, :musicbrainz_id, :wikidata_id, :llm_enriched, :fetched_at
+
+  attribute :attribution do |_object|
+    {
+      'wikidata' => {
+        'license' => 'CC0',
+        'url' => 'https://www.wikidata.org/wiki/Wikidata:Licensing'
+      },
+      'musicbrainz' => {
+        'license' => 'CC0 (data) / CC BY-NC-SA (non-PD content)',
+        'url' => 'https://musicbrainz.org/doc/About/Data_License'
+      },
+      'wikipedia' => {
+        'license' => 'CC BY-SA',
+        'url' => 'https://en.wikipedia.org/wiki/Wikipedia:Reusing_Wikipedia_content',
+        'note' => 'Used as grounding source for LLM-generated event summaries.'
+      }
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
         get :bio, on: :member
         get :similar_artists, on: :member
         get :widget, on: :member
+        get :timeline, on: :member
       end
       resources :songs, only: %i[index show] do
         get :autocomplete, on: :collection

--- a/spec/requests/api/v1/artists_spec.rb
+++ b/spec/requests/api/v1/artists_spec.rb
@@ -657,4 +657,49 @@ RSpec.describe 'Artists API', type: :request do
       end
     end
   end
+
+  path '/api/v1/artists/{id}/timeline' do
+    get 'Get the cached event timeline for an artist' do
+      tags 'Artists'
+      produces 'application/json'
+      description 'Returns the cached MusicBrainz + Wikidata (and optionally LLM-enriched) timeline for an artist. ' \
+                  'If no cached timeline exists yet, enqueues a generation job and returns 202 Accepted.'
+      parameter name: :id, in: :path, type: :integer, required: true, description: 'Artist ID'
+
+      response '200', 'Timeline retrieved successfully' do
+        let(:artist) { create(:artist, name: 'Daft Punk', id_on_musicbrainz: '056e4f3e-d505-4dad-8ec1-d04f521cbb56') }
+        let(:id) { artist.id }
+        let!(:_timeline) do
+          create(:artist_timeline, artist: artist, fetched_at: 1.day.ago,
+                                   musicbrainz_id: artist.id_on_musicbrainz, wikidata_id: 'Q185828',
+                                   events: [
+                                     { 'category' => 'formation', 'date' => '1993', 'title' => 'Daft Punk formed', 'source' => 'musicbrainz' }
+                                   ])
+        end
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data.dig('data', 'attributes', 'events').size).to eq(1)
+        end
+      end
+
+      response '202', 'No cached timeline yet, generation enqueued' do
+        let(:artist) { create(:artist, name: 'Daft Punk', id_on_musicbrainz: '056e4f3e-d505-4dad-8ec1-d04f521cbb56') }
+        let(:id) { artist.id }
+
+        before { allow(ArtistTimelineEnrichmentJob).to receive(:perform_async) } # rubocop:disable RSpec/ScatteredSetup
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['status']).to eq('pending')
+        end
+      end
+
+      response '404', 'Artist not found' do
+        let(:id) { 0 }
+
+        run_test!
+      end
+    end
+  end
 end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -991,6 +991,28 @@ paths:
           description: Search results retrieved successfully
         '400':
           description: Missing query parameter
+  "/api/v1/artists/{id}/timeline":
+    get:
+      summary: Get the cached event timeline for an artist
+      tags:
+      - Artists
+      description: Returns the cached MusicBrainz + Wikidata (and optionally LLM-enriched)
+        timeline for an artist. If no cached timeline exists yet, enqueues a generation
+        job and returns 202 Accepted.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: Artist ID
+        schema:
+          type: integer
+      responses:
+        '200':
+          description: Timeline retrieved successfully
+        '202':
+          description: No cached timeline yet, generation enqueued
+        '404':
+          description: Artist not found
   "/api/v1/charts":
     get:
       summary: List chart positions


### PR DESCRIPTION
## Summary
- New \`GET /api/v1/artists/:id/timeline\` endpoint returning the cached \`ArtistTimeline\` via JSONAPI
- 202 Accepted with empty events when no timeline exists yet (frontend polls until ready)
- Stale rows are returned immediately while a refresh is enqueued in the background
- \`ArtistTimelineSerializer\` includes an \`attribution\` block with license info for Wikidata, MusicBrainz, and Wikipedia (CC BY-SA grounding for LLM summaries)
- Swagger regenerated

## Auth & rate limiting
- Inherits \`authenticate_client!\` from \`ApiController\` — JWT required (default per project policy on new endpoints)
- Inherits the 300 req/min/IP general rate limit; no per-endpoint limit needed since the work happens async

## Why no separate controller
\`ArtistsController\` already hosts member endpoints (\`bio\`, \`similar_artists\`, \`widget\`, …) for the artist resource — adding a sibling \`timeline\` action keeps the convention consistent. Logic stays thin: lookup, decide refresh, render. Heavy lifting is in \`ArtistTimelineEnrichmentJob\` (PR 1).

## Test plan
- [x] \`bundle exec rspec spec/requests/api/v1/artists_spec.rb\` — 200 (cached), 202 (pending), 404 (not found) all green
- [x] \`bundle exec rake rswag:specs:swaggerize\` — committed
- [x] \`bundle exec rubocop\` — clean
- [ ] Reviewer to verify behavior with concurrent requests (the unique-job lock from PR 1 prevents duplicate enrichment jobs)

## Base branch
This PR is stacked on \`artist-timeline-foundation\` (PR #2132). GitHub will retarget the base to \`main\` once that merges.

## Follow-ups
- Scheduled weekly refresh + Sentry alerts (PR 4)
- React component on playlists-interface (separate repo issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)