### PR TITLE
Schedule weekly ArtistTimelineEnrichmentBatchJob

### DIFF
--- a/app/jobs/artist_timeline_enrichment_batch_job.rb
+++ b/app/jobs/artist_timeline_enrichment_batch_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ArtistTimelineEnrichmentBatchJob
+  include Sidekiq::Job
+  sidekiq_options queue: 'enrichment'
+
+  def perform
+    ArtistTimelineEnrichmentJob.enqueue_stale
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -51,6 +51,10 @@
         cron: '0 5 * * 0' # weekly Sunday 5am
         queue: enrichment
         enabled: true
+      ArtistTimelineEnrichmentBatchJob:
+        cron: '0 6 * * 0' # weekly Sunday 6am
+        queue: enrichment
+        enabled: true
       AvgSongGapCalculationJob:
         cron: '0 5 * * *' # daily at 5am
         queue: compute

--- a/spec/jobs/artist_timeline_enrichment_batch_job_spec.rb
+++ b/spec/jobs/artist_timeline_enrichment_batch_job_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ArtistTimelineEnrichmentBatchJob do
+  describe '#perform' do
+    it 'delegates to ArtistTimelineEnrichmentJob.enqueue_stale' do
+      allow(ArtistTimelineEnrichmentJob).to receive(:enqueue_stale)
+      described_class.new.perform
+      expect(ArtistTimelineEnrichmentJob).to have_received(:enqueue_stale)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- New \`ArtistTimelineEnrichmentBatchJob\` (matches \`ArtistEnrichmentBatchJob\` shape) calling \`ArtistTimelineEnrichmentJob.enqueue_stale\`
- New cron entry: weekly Sunday 06:00 (slot after existing 03/04/05 batch jobs)
- Reuses the throttled enqueue from PR 1 (3 s spacing) so MB stays under 1 req/sec

## Sentry
No new wiring is needed — every external call in the timeline pipeline already routes errors through \`ExceptionNotifier.notify\`, which calls \`Sentry.capture_exception\`. Coverage matrix:
- \`MusicBrainz::ArtistTimelineFetcher\` — \`Net::HTTP\` errors → ExceptionNotifier
- \`Wikipedia::WikidataTimelineFinder\` — SPARQL + entity API errors → ExceptionNotifier
- \`Llm::Base\` — OpenAI errors → ExceptionNotifier

If we want first-class Sentry alerts for "LLM circuit breaker open" or "Wikidata SPARQL down", that's better expressed as a Sentry rule on the existing exception stream than as code; happy to add explicit \`Sentry.capture_message\` calls in a follow-up if you'd prefer.

## Test plan
- [x] \`bundle exec rspec spec/jobs/artist_timeline_enrichment_batch_job_spec.rb\` — passes
- [x] \`bundle exec rubocop\` — clean on the two new \`.rb\` files (the YAML is data, not Ruby)
- [ ] Reviewer to confirm 06:00 Sunday slot doesn't collide with anything else on the worker

## Base branch
Stacked on \`artist-timeline-api\` (PR #2133). GitHub will retarget to main once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)