### PR TITLE
Guard Wikidata timeline finder against non-JSON responses

### DIFF
--- a/app/services/wikipedia/wikidata_timeline_finder.rb
+++ b/app/services/wikipedia/wikidata_timeline_finder.rb
@@ -51,7 +51,7 @@ module Wikipedia
         response = entity_connection.get('/w/api.php') do |req|
           req.params = { action: 'wbgetentities', ids: wikibase_item, format: 'json', props: 'claims', languages: language }
         end
-        response.body&.dig('entities', wikibase_item)
+        parsed_json_body(response)&.dig('entities', wikibase_item)
       end
     rescue StandardError => e
       ExceptionNotifier.notify(e)
@@ -116,12 +116,20 @@ module Wikipedia
           req.params['query'] = query
           req.params['format'] = 'json'
         end
-        response.body&.dig('results', 'bindings') || []
+        parsed_json_body(response)&.dig('results', 'bindings') || []
       end
     rescue StandardError => e
       ExceptionNotifier.notify(e)
       Rails.logger.error("Wikidata timeline SPARQL error: #{e.message}")
       []
+    end
+
+    def parsed_json_body(response)
+      body = response.body
+      return body if body.is_a?(Hash)
+
+      Rails.logger.warn("Wikidata returned non-JSON response (status=#{response.status}, body_class=#{body.class})")
+      nil
     end
 
     def build_event(row)

--- a/spec/services/wikipedia/wikidata_timeline_finder_spec.rb
+++ b/spec/services/wikipedia/wikidata_timeline_finder_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Wikipedia::WikidataTimelineFinder, type: :service do
+  subject(:finder) { described_class.new }
+
+  let(:wikibase_item) { 'Q4936' }
+
+  before do
+    allow(Rails.cache).to receive(:fetch).and_yield
+  end
+
+  describe '#call' do
+    context 'when wikibase_item is blank' do
+      it 'returns an empty array for nil' do
+        expect(finder.(nil)).to eq([])
+      end
+
+      it 'returns an empty array for an empty string' do
+        expect(finder.('')).to eq([])
+      end
+    end
+
+    context 'when SPARQL endpoint returns a non-JSON body' do
+      let(:sparql_response) { instance_double(Faraday::Response, body: '<html>Service Unavailable</html>', status: 503) }
+      let(:entity_response) { instance_double(Faraday::Response, body: '<html>Service Unavailable</html>', status: 503) }
+      let(:sparql_connection) { instance_double(Faraday::Connection) }
+      let(:entity_connection) { instance_double(Faraday::Connection) }
+
+      before do
+        allow(Faraday).to receive(:new).with(hash_including(url: described_class::SPARQL_URL)).and_return(sparql_connection)
+        allow(Faraday).to receive(:new).with(hash_including(url: described_class::ENTITY_API_URL)).and_return(entity_connection)
+        allow(sparql_connection).to receive(:get).and_yield(double(params: {})).and_return(sparql_response)
+        allow(entity_connection).to receive(:get).and_return(entity_response)
+        allow(Rails.logger).to receive(:warn)
+      end
+
+      it 'returns an empty array instead of raising NoMethodError' do
+        expect { finder.(wikibase_item) }.not_to raise_error
+      end
+
+      it 'falls back to an empty array' do
+        expect(finder.(wikibase_item)).to eq([])
+      end
+
+      it 'logs a warning about the non-JSON response' do
+        finder.(wikibase_item)
+        expect(Rails.logger).to have_received(:warn).with(/Wikidata returned non-JSON response/).at_least(:once)
+      end
+    end
+
+    context 'when SPARQL endpoint returns valid JSON' do
+      let(:sparql_body) do
+        {
+          'results' => {
+            'bindings' => [
+              {
+                'category' => { 'value' => 'formation' },
+                'date' => { 'value' => '+1993-01-01T00:00:00Z' },
+                'subjectLabel' => { 'value' => 'Daft Punk formed' }
+              }
+            ]
+          }
+        }
+      end
+      let(:sparql_response) { instance_double(Faraday::Response, body: sparql_body, status: 200) }
+      let(:sparql_connection) { instance_double(Faraday::Connection) }
+      let(:entity_connection) { instance_double(Faraday::Connection) }
+
+      before do
+        allow(Faraday).to receive(:new).with(hash_including(url: described_class::SPARQL_URL)).and_return(sparql_connection)
+        allow(Faraday).to receive(:new).with(hash_including(url: described_class::ENTITY_API_URL)).and_return(entity_connection)
+        allow(sparql_connection).to receive(:get).and_yield(double(params: {})).and_return(sparql_response)
+      end
+
+      it 'returns the mapped events' do
+        result = finder.(wikibase_item)
+        expect(result.first).to include('category' => 'formation', 'source' => 'wikidata')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Production hit `NoMethodError: undefined method 'dig' for an instance of String` in `Wikipedia::WikidataTimelineFinder#execute_query` (Sentry 7472021391).
- Root cause: Wikidata's SPARQL endpoint sometimes returns HTML/plain-text error pages (rate limits, query timeouts, 5xx). Faraday's `:json` middleware leaves those bodies as raw strings, so `response.body.dig(...)` blows up.
- Added a `parsed_json_body` guard that returns `nil` (and logs a warning) for any non-Hash body. Both `execute_query` and the parallel `fetch_entity` path now route through it.

## Test plan
- [x] `bundle exec rspec spec/services/wikipedia/wikidata_timeline_finder_spec.rb` (new spec covers the non-JSON String body, valid JSON, and blank-input paths)
- [x] `bundle exec rubocop app/services/wikipedia/wikidata_timeline_finder.rb spec/services/wikipedia/wikidata_timeline_finder_spec.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)