### PR TITLE
Tighten Wikidata SPARQL timeout and quiet Sentry on fallback

### DIFF
--- a/app/services/wikipedia/wikidata_timeline_finder.rb
+++ b/app/services/wikipedia/wikidata_timeline_finder.rb
@@ -5,6 +5,8 @@ module Wikipedia
     SPARQL_URL = 'https://query.wikidata.org/sparql'
     ENTITY_API_URL = 'https://www.wikidata.org'
     DEFAULT_LANGUAGE = 'en'
+    SPARQL_OPEN_TIMEOUT = 5
+    SPARQL_TIMEOUT = 8
 
     DATE_CLAIM_PROPERTIES = {
       'P569' => { category: 'birth', title_template: 'Birth' },
@@ -119,8 +121,7 @@ module Wikipedia
         parsed_json_body(response)&.dig('results', 'bindings') || []
       end
     rescue StandardError => e
-      ExceptionNotifier.notify(e)
-      Rails.logger.error("Wikidata timeline SPARQL error: #{e.message}")
+      Rails.logger.warn("Wikidata timeline SPARQL error: #{e.message}")
       []
     end
 
@@ -159,7 +160,7 @@ module Wikipedia
     end
 
     def connection
-      @connection ||= Faraday.new(url: SPARQL_URL) do |conn|
+      @connection ||= Faraday.new(url: SPARQL_URL, request: { open_timeout: SPARQL_OPEN_TIMEOUT, timeout: SPARQL_TIMEOUT }) do |conn|
         conn.response :json
         conn.headers['Accept'] = 'application/sparql-results+json'
         conn.headers['User-Agent'] = 'Airplays/1.0 (https://airplays.nl)'

--- a/spec/services/wikipedia/wikidata_timeline_finder_spec.rb
+++ b/spec/services/wikipedia/wikidata_timeline_finder_spec.rb
@@ -50,6 +50,43 @@ RSpec.describe Wikipedia::WikidataTimelineFinder, type: :service do
       end
     end
 
+    context 'when SPARQL endpoint times out' do
+      let(:entity_body) do
+        {
+          'entities' => {
+            wikibase_item => {
+              'claims' => {
+                'P569' => [{ 'mainsnak' => { 'datavalue' => { 'value' => { 'time' => '+1989-12-13T00:00:00Z' } } } }]
+              }
+            }
+          }
+        }
+      end
+      let(:entity_response) { instance_double(Faraday::Response, body: entity_body, status: 200) }
+      let(:sparql_connection) { instance_double(Faraday::Connection) }
+      let(:entity_connection) { instance_double(Faraday::Connection) }
+
+      before do
+        allow(Faraday).to receive(:new).with(hash_including(url: described_class::SPARQL_URL)).and_return(sparql_connection)
+        allow(Faraday).to receive(:new).with(hash_including(url: described_class::ENTITY_API_URL)).and_return(entity_connection)
+        allow(sparql_connection).to receive(:get).and_raise(Faraday::TimeoutError.new('execution expired'))
+        allow(entity_connection).to receive(:get).and_return(entity_response)
+        allow(Rails.logger).to receive(:warn)
+        allow(ExceptionNotifier).to receive(:notify)
+      end
+
+      it 'falls back to the entity API result', :aggregate_failures do
+        result = finder.(wikibase_item)
+        expect(result).to eq([{ 'category' => 'birth', 'date' => '1989-12-13', 'title' => 'Birth', 'source' => 'wikidata' }])
+        expect(ExceptionNotifier).not_to have_received(:notify)
+      end
+
+      it 'logs a warning about the SPARQL failure' do
+        finder.(wikibase_item)
+        expect(Rails.logger).to have_received(:warn).with(/Wikidata timeline SPARQL error/).at_least(:once)
+      end
+    end
+
     context 'when SPARQL endpoint returns valid JSON' do
       let(:sparql_body) do
         {


### PR DESCRIPTION
## Summary

- Add an 8s read / 5s open timeout on the Wikidata SPARQL Faraday connection so artist-timeline requests fail fast when `query.wikidata.org` is degraded (currently every query hangs ~60s with `java.util.concurrent.TimeoutException`).
- Demote SPARQL error handling from `ExceptionNotifier.notify` to `Rails.logger.warn`. The entity API fallback (`wbgetentities`) already returns valid date events, so SPARQL is best-effort — flooding Sentry on every artist timeline during a WMF outage isn't actionable.
- Leave the entity API rescue's `ExceptionNotifier.notify` in place — that path *is* a real failure with no further fallback.

Observed today against the live endpoint:

| Artist | Wikidata ID | Before (60s default) | After (8s timeout) | Events |
|---|---|---|---|---|
| Daft Punk | Q185828 | 60.5s | ≤8s | Formation 1993, Dissolution 2021 |
| Taylor Swift | Q26876 | 60.7s | ≤8s | Birth 1989-12-13 |

## Test plan

- [x] `bundle exec rspec spec/services/wikipedia/wikidata_timeline_finder_spec.rb` — added a `when SPARQL endpoint times out` context that raises `Faraday::TimeoutError` and asserts the entity API fallback runs and `ExceptionNotifier` is NOT called
- [x] `bundle exec rubocop app/services/wikipedia/wikidata_timeline_finder.rb spec/services/wikipedia/wikidata_timeline_finder_spec.rb`
- [ ] Verify after merge that Sentry stops getting Wikidata SPARQL error noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)