### PR TITLE
Disable weekly ArtistTimelineEnrichmentBatchJob

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -54,7 +54,7 @@
       ArtistTimelineEnrichmentBatchJob:
         cron: '0 6 * * 0' # weekly Sunday 6am
         queue: enrichment
-        enabled: true
+        enabled: false
       AvgSongGapCalculationJob:
         cron: '0 5 * * *' # daily at 5am
         queue: compute


### PR DESCRIPTION
## Summary

- Flip `ArtistTimelineEnrichmentBatchJob` (Sunday 6am) to `enabled: false` in `config/sidekiq.yml`.
- Wikidata SPARQL has been unstable (#2137 tightens the timeout and quiets the Sentry noise, but the entity API fallback only returns birth/death/formation/dissolution — not awards or notable works).
- Pausing the weekly batch until the SPARQL path and the fallback are both proven stable. Per-artist on-demand timeline builds still work.

## Test plan

- [ ] After merge & deploy, confirm Sidekiq scheduler shows `ArtistTimelineEnrichmentBatchJob` as disabled (Cron tab in Sidekiq Web UI)
- [ ] Verify no enqueue happens at next 06:00 UTC Sunday

🤖 Generated with [Claude Code](https://claude.com/claude-code)