### PR TITLE
Add admin endpoint to force-refresh artist timeline

### DIFF
--- a/app/controllers/api/v1/admins/artists_controller.rb
+++ b/app/controllers/api/v1/admins/artists_controller.rb
@@ -18,6 +18,17 @@ class Api::V1::Admins::ArtistsController < ApplicationController
     end
   end
 
+  def refresh_timeline
+    artist = Artist.find(params[:id])
+    if artist.id_on_musicbrainz.blank?
+      render json: { errors: ['Artist has no MusicBrainz ID; cannot build timeline'] }, status: :unprocessable_entity
+      return
+    end
+
+    ArtistTimelineEnrichmentJob.perform_async(artist.id)
+    render json: { status: 'enqueued', artist_id: artist.id }, status: :accepted
+  end
+
   private
 
   def artist_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
       patch 'admins/songs/:id', to: 'admins/songs#update'
       get 'admins/artists', to: 'admins/artists#index'
       patch 'admins/artists/:id', to: 'admins/artists#update'
+      post 'admins/artists/:id/refresh_timeline', to: 'admins/artists#refresh_timeline'
       get 'admins/radio_stations', to: 'admins/radio_stations#index'
 
       resources :air_plays, only: %i[index]

--- a/spec/requests/api/v1/admins/artists_spec.rb
+++ b/spec/requests/api/v1/admins/artists_spec.rb
@@ -74,4 +74,52 @@ RSpec.describe 'Admin Artists API', type: :request do
       end
     end
   end
+
+  path '/api/v1/admins/artists/{id}/refresh_timeline' do
+    post 'Force a refresh of an artist timeline' do
+      tags 'Admin Artists'
+      security [{ bearer_auth: [] }]
+      produces 'application/json'
+      description 'Enqueues an ArtistTimelineEnrichmentJob to rebuild the cached MusicBrainz + Wikidata timeline ' \
+                  'for an artist. Returns 422 if the artist has no MusicBrainz ID.'
+      parameter name: :id, in: :path, type: :integer, required: true, description: 'Artist ID'
+
+      response '202', 'Timeline refresh enqueued' do
+        let(:existing_artist) { create(:artist, id_on_musicbrainz: '056e4f3e-d505-4dad-8ec1-d04f521cbb56') }
+        let(:id) { existing_artist.id }
+
+        before { allow(ArtistTimelineEnrichmentJob).to receive(:perform_async) }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data).to include('status' => 'enqueued', 'artist_id' => existing_artist.id), :aggregate_failures
+          expect(ArtistTimelineEnrichmentJob).to have_received(:perform_async).with(existing_artist.id)
+        end
+      end
+
+      response '422', 'Artist has no MusicBrainz ID' do
+        let(:existing_artist) { create(:artist, id_on_musicbrainz: nil) }
+        let(:id) { existing_artist.id }
+
+        run_test! do |response|
+          data = JSON.parse(response.body)
+          expect(data['errors']).to include(a_string_matching(/MusicBrainz/))
+        end
+      end
+
+      response '401', 'Not authenticated' do
+        let(:Authorization) { 'Bearer invalid_token' }
+        let(:existing_artist) { create(:artist, id_on_musicbrainz: '056e4f3e-d505-4dad-8ec1-d04f521cbb56') }
+        let(:id) { existing_artist.id }
+
+        run_test!
+      end
+
+      response '404', 'Artist not found' do
+        let(:id) { 0 }
+
+        run_test!
+      end
+    end
+  end
 end

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -71,6 +71,32 @@ paths:
                       type: string
                     instagram_url:
                       type: string
+  "/api/v1/admins/artists/{id}/refresh_timeline":
+    post:
+      summary: Force a refresh of an artist timeline
+      tags:
+      - Admin Artists
+      security:
+      - bearer_auth: []
+      description: Enqueues an ArtistTimelineEnrichmentJob to rebuild the cached MusicBrainz
+        + Wikidata timeline for an artist. Returns 422 if the artist has no MusicBrainz
+        ID.
+      parameters:
+      - name: id
+        in: path
+        required: true
+        description: Artist ID
+        schema:
+          type: integer
+      responses:
+        '202':
+          description: Timeline refresh enqueued
+        '422':
+          description: Artist has no MusicBrainz ID
+        '401':
+          description: Not authenticated
+        '404':
+          description: Artist not found
   "/api/v1/admins/sign_in":
     post:
       summary: Admin sign in


### PR DESCRIPTION
## Summary
- New `POST /api/v1/admins/artists/:id/refresh_timeline` enqueues `ArtistTimelineEnrichmentJob` so the playlists-admin UI can trigger a manual rebuild
- Returns `422` when the artist has no `id_on_musicbrainz` (job would otherwise no-op)
- Sidekiq's `:until_executed` unique lock coalesces double-clicks into the in-flight run

## Test plan
- [x] `bundle exec rspec spec/requests/api/v1/admins/artists_spec.rb`
- [x] `bundle exec rubocop` on changed files
- [x] `bundle exec rake rswag:specs:swaggerize` — swagger committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)