### PR TITLE
Update Arrow Classic Rock scraping to new nowplaying API

### DIFF
--- a/app/services/track_scraper/arrow_api_processor.rb
+++ b/app/services/track_scraper/arrow_api_processor.rb
@@ -6,12 +6,12 @@ class TrackScraper::ArrowApiProcessor < TrackScraper
     return false if response.blank?
 
     @raw_response = response
-    track = response['current']
-    return false if track.blank? || track['artist'].blank? || commercial?(track)
+    return false unless music?(response)
+    return false if response['artist'].blank? || response['title'].blank?
 
-    @artist_name = track['artist'].titleize
-    @title = TitleSanitizer.sanitize(track['title']).titleize
-    @broadcasted_at = Time.zone.at(track['startTime'] / 1000)
+    @artist_name = response['artist'].titleize
+    @title = TitleSanitizer.sanitize(response['title']).titleize
+    @broadcasted_at = Time.zone.at(response['timestamp'])
     true
   rescue StandardError => e
     Rails.logger.warn("ArrowApiProcessor: #{e.message}")
@@ -21,7 +21,10 @@ class TrackScraper::ArrowApiProcessor < TrackScraper
 
   private
 
-  def commercial?(track)
-    track['category'].to_s.downcase.include?('commercials')
+  def music?(response)
+    return false if response['hasCurrentTrack'] == false
+
+    state = response['state'].to_s.downcase
+    state.blank? || state == 'music'
   end
 end

--- a/db/fixtures/001_radio_stations.rb
+++ b/db/fixtures/001_radio_stations.rb
@@ -141,7 +141,7 @@ RadioStation.seed(
   },
   {
     name: 'Arrow Classic Rock',
-    url: 'https://www.arrow.nl/wp-content/plugins/adeko-arrow-onair/playlistdata/Arrow_PLAYING_NOW.json',
+    url: 'https://www.arrow.nl/api/nowplaying',
     processor: 'arrow_api_processor',
     direct_stream_url: 'https://stream.player.arrow.nl/arrow',
     slug: 'arrow-classic-rock',

--- a/spec/factories/radio_station.rb
+++ b/spec/factories/radio_station.rb
@@ -132,7 +132,7 @@ FactoryBot.define do
 
   factory :arrow_classic_rock, parent: :radio_station do
     name { 'Arrow Classic Rock' }
-    url { 'https://www.arrow.nl/wp-content/plugins/adeko-arrow-onair/playlistdata/Arrow_PLAYING_NOW.json' }
+    url { 'https://www.arrow.nl/api/nowplaying' }
     processor { 'arrow_api_processor' }
     direct_stream_url { 'https://stream.player.arrow.nl/arrow' }
     slug { 'arrow-classic-rock' }

--- a/spec/services/track_scraper/arrow_api_processor_spec.rb
+++ b/spec/services/track_scraper/arrow_api_processor_spec.rb
@@ -12,14 +12,11 @@ describe TrackScraper::ArrowApiProcessor, type: :service do
     end
     let(:response) do
       {
-        'current' => {
-          'artist' => 'BLACK SABBATH',
-          'title' => 'FAIRIES WEAR BOOTS',
-          'startTime' => 1_772_788_567_023,
-          'length' => 368_369,
-          'type' => 'Standard',
-          'category' => 'ARROW - TOP 500 [ACTIEF]'
-        }
+        'title' => 'FAIRIES WEAR BOOTS',
+        'artist' => 'BLACK SABBATH',
+        'timestamp' => 1_772_788_567,
+        'hasCurrentTrack' => true,
+        'state' => 'music'
       }
     end
 
@@ -53,14 +50,11 @@ describe TrackScraper::ArrowApiProcessor, type: :service do
     context 'when the current track is a commercial' do
       let(:api_response) do
         {
-          'current' => {
-            'artist' => '',
-            'title' => 'ARROW C R - COMMERCIALS',
-            'startTime' => 1_772_788_355_684,
-            'length' => 207_606,
-            'type' => '',
-            'category' => 'Start commercials'
-          }
+          'title' => 'ARROW C R - COMMERCIALS',
+          'artist' => '',
+          'timestamp' => 1_772_788_355,
+          'hasCurrentTrack' => false,
+          'state' => 'commercial'
         }
       end
 
@@ -72,14 +66,11 @@ describe TrackScraper::ArrowApiProcessor, type: :service do
     context 'when the current track has no artist' do
       let(:api_response) do
         {
-          'current' => {
-            'artist' => '',
-            'title' => 'UNKNOWN TRACK',
-            'startTime' => 1_772_788_355_684,
-            'length' => 207_606,
-            'type' => 'Standard',
-            'category' => 'ARROW - TOP 500 [ACTIEF]'
-          }
+          'title' => 'UNKNOWN TRACK',
+          'artist' => '',
+          'timestamp' => 1_772_788_355,
+          'hasCurrentTrack' => true,
+          'state' => 'music'
         }
       end
 


### PR DESCRIPTION
## Summary
- Old Arrow playlist endpoint (`/wp-content/plugins/adeko-arrow-onair/...`) now returns 403; switched to `https://www.arrow.nl/api/nowplaying`.
- Rewrote `ArrowApiProcessor` for the new flatter response shape: `artist`/`title` at root, `timestamp` in seconds (was ms under `current.startTime`), commercial detection via `state` / `hasCurrentTrack` (no more `category`).
- Updated seed fixture, factory, and spec to match.

## Production note
The seed fixture only re-runs in CI. To pick up the new URL in prod, either re-run `rails db:seed` (seedbank `RadioStation.seed(:name, :country_code, …)` will update the existing row) or manually update `RadioStation.find_by(name: 'Arrow Classic Rock').update!(url: 'https://www.arrow.nl/api/nowplaying')`.

## Test plan
- [x] `bundle exec rspec spec/services/track_scraper/arrow_api_processor_spec.rb` (7 examples, 0 failures)
- [x] `bundle exec rubocop` on changed files (no offenses)
- [x] Verified live API response parses correctly (artist/title/timestamp/state fields all present and well-formed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)