### PR TITLE
Order admin artists list by total song count

### DIFF
--- a/app/controllers/api/v1/admins/artists_controller.rb
+++ b/app/controllers/api/v1/admins/artists_controller.rb
@@ -4,7 +4,7 @@ class Api::V1::Admins::ArtistsController < ApplicationController
   def index
     artists = Artist.includes(:songs)
                 .matching(params[:search_term])
-                .order(created_at: :desc)
+                .ordered_by_song_count
                 .paginate(page: params[:page], per_page: params[:per_page] || 24)
     render json: ArtistSerializer.new(artists).serializable_hash, status: :ok
   end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -72,6 +72,9 @@ class Artist < ApplicationRecord
   has_one :timeline, class_name: 'ArtistTimeline', dependent: :destroy
 
   scope :matching, ->(search_term) { search_by_name(search_term).reorder(nil) if search_term.present? }
+  scope :ordered_by_song_count, lambda {
+    order(Arel.sql('(SELECT COUNT(*) FROM artists_songs WHERE artists_songs.artist_id = artists.id) DESC, artists.created_at DESC'))
+  }
 
   before_create :set_slug
   after_commit :update_slug, on: [:update], if: :saved_change_to_name?

--- a/spec/controllers/api/v1/admins/artists_controller_spec.rb
+++ b/spec/controllers/api/v1/admins/artists_controller_spec.rb
@@ -14,8 +14,6 @@ describe Api::V1::Admins::ArtistsController, type: :controller do
   describe 'GET #index' do
     subject(:get_index) { get :index, params: { format: :json } }
 
-    let(:ordered_artist_ids) { Artist.order(created_at: :desc).pluck(:id).map(&:to_s) }
-
     context 'when there are artists' do
       before { create_list(:artist, 3) }
 
@@ -28,10 +26,22 @@ describe Api::V1::Admins::ArtistsController, type: :controller do
         get_index
         expect(json[:data].count).to eq(3)
       end
+    end
 
-      it 'returns the artists in descending order of creation' do
+    context 'when artists have different song counts' do
+      let(:artist_with_two_songs) { create(:artist) }
+      let(:artist_with_one_song) { create(:artist) }
+      let(:artist_with_no_songs) { create(:artist) }
+
+      before do
+        create_list(:song, 2, artists: [artist_with_two_songs])
+        create(:song, artists: [artist_with_one_song])
+        artist_with_no_songs
+      end
+
+      it 'orders artists by descending song count' do
         get_index
-        expect(json[:data].map { |a| a[:id] }).to eq(ordered_artist_ids)
+        expect(json[:data].map { |a| a[:id] }).to eq([artist_with_two_songs, artist_with_one_song, artist_with_no_songs].map { |a| a.id.to_s })
       end
     end
 


### PR DESCRIPTION
## Summary
- Add `Artist.ordered_by_song_count` scope using a correlated `COUNT(*)` subquery against `artists_songs` (works with `will_paginate`, uses the existing `index_artists_songs_on_artist_id`), with `created_at DESC` as tiebreaker.
- Swap `.order(created_at: :desc)` for `.ordered_by_song_count` in `Api::V1::Admins::ArtistsController#index` so heavy-catalog artists surface first when triaging.
- Replace the obsolete "descending order of creation" controller spec with one that asserts descending song-count ordering.

## Test plan
- [x] `bundle exec rspec spec/controllers/api/v1/admins/artists_controller_spec.rb`
- [x] `bundle exec rspec spec/requests/api/v1/admins/artists_spec.rb`
- [x] `bundle exec rubocop app/models/artist.rb app/controllers/api/v1/admins/artists_controller.rb spec/controllers/api/v1/admins/artists_controller_spec.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)