### PR TITLE
Tighten Artist.search_by_name to reduce cross-word fuzzy noise

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -60,7 +60,7 @@ class Artist < ApplicationRecord
   pg_search_scope :search_by_name,
                   against: :name,
                   using: {
-                    trigram: { threshold: 0.3, word_similarity: true },
+                    trigram: { threshold: 0.4 },
                     tsearch: { prefix: true }
                   },
                   ranked_by: ':trigram + (0.25 * :tsearch) + (0.01 * COALESCE(artists.spotify_popularity, 0))'

--- a/spec/models/artist_spec.rb
+++ b/spec/models/artist_spec.rb
@@ -163,7 +163,7 @@ describe Artist do
     end
 
     it 'finds artists with typo in query' do
-      expect(Artist.search_by_name('Coldpaly')).to include(coldplay)
+      expect(Artist.search_by_name('Coldlay')).to include(coldplay)
     end
 
     it 'finds artists with prefix match' do


### PR DESCRIPTION
## Summary
- Searching the admin artist library for "Olivia Dean" returned Oliver Heldens, Dean Martin, Olivia Rodrigo, Dean Lewis, Max Dean, Olivier Giacomotto, etc. because `pg_search_scope :search_by_name` used `word_similarity: true` with `threshold: 0.3` — each query word matched independently.
- Drop `word_similarity` and bump the trigram threshold to `0.4`. Empirically (`SELECT similarity(...)`), every "Olivia Dean" false positive sits at ≤0.35 while realistic typos (missing letters, accents, capitalization) stay above 0.4. Prefix search via `tsearch` is unchanged.
- Trade-off: degenerate transposition typos like `Coldpaly` (sim 0.385) no longer match. The `search_by_name` typo spec is swapped to `Coldlay` (dropped letter, sim 0.54) which still validates fuzzy behavior on realistic mistakes.

This scope is also reused by `Artist.most_played`, `ArtistSearchConcern#faceted_search`, and `Artist#suggest`, so the tightening benefits the public API too without removing typo tolerance.

## Test plan
- [x] `bundle exec rspec spec/models/artist_spec.rb` — 57 examples, 0 failures
- [x] `bundle exec rspec spec/requests/api/v1/admins/artists_spec.rb spec/requests/api/v1/artists_spec.rb` — 34 examples, 0 failures
- [x] `bundle exec rubocop app/models/artist.rb spec/models/artist_spec.rb` — clean
- [ ] After deploy: re-run admin search for "Olivia Dean" and confirm only Olivia Dean returns

🤖 Generated with [Claude Code](https://claude.com/claude-code)