### PR TITLE
Speed up paginated air_plays endpoint

### DIFF
--- a/app/controllers/api/v1/air_plays_controller.rb
+++ b/app/controllers/api/v1/air_plays_controller.rb
@@ -18,7 +18,7 @@ module Api
       private
 
       def air_plays
-        @air_plays ||= AirPlay.includes(:radio_station, song: :artists)
+        @air_plays ||= AirPlay.preload(:radio_station, song: :artists)
                          .last_played(params)
                          .paginate(page: params[:page], per_page: PER_PAGE, total_entries: cached_total_entries)
       end

--- a/app/controllers/api/v1/air_plays_controller.rb
+++ b/app/controllers/api/v1/air_plays_controller.rb
@@ -3,7 +3,12 @@
 module Api
   module V1
     class AirPlaysController < ApiController
+      PER_PAGE = 12
+      COUNT_CACHE_TTL = 5.minutes
+      HTTP_CACHE_TTL = 60.seconds
+
       def index
+        expires_in HTTP_CACHE_TTL, public: true
         render json: AirPlaySerializer.new(air_plays)
                        .serializable_hash
                        .merge(pagination_data(air_plays))
@@ -13,9 +18,20 @@ module Api
       private
 
       def air_plays
-        @air_plays ||= AirPlay.includes([:song, :radio_station])
+        @air_plays ||= AirPlay.includes(:radio_station, song: :artists)
                          .last_played(params)
-                         .paginate(page: params[:page], per_page: 12)
+                         .paginate(page: params[:page], per_page: PER_PAGE, total_entries: cached_total_entries)
+      end
+
+      def cached_total_entries
+        Rails.cache.fetch(count_cache_key, expires_in: COUNT_CACHE_TTL) do
+          AirPlay.last_played(params).unscope(:order, :group).count
+        end
+      end
+
+      def count_cache_key
+        key_params = params.except(:page, :format, :controller, :action).to_unsafe_h.sort.to_h
+        "air_plays:count:#{Digest::SHA256.hexdigest(key_params.to_json)}"
       end
     end
   end

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -19,8 +19,7 @@ module Api
         render json: { error: 'Not found' }, status: :not_found
       end
 
-      def render_bad_request(exception = nil)
-        Rails.logger.error("[API BadRequest] #{exception&.class}: #{exception&.message}\n#{exception&.backtrace&.first(10)&.join("\n")}")
+      def render_bad_request
         render json: { error: 'Bad request' }, status: :bad_request
       end
 

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -19,7 +19,8 @@ module Api
         render json: { error: 'Not found' }, status: :not_found
       end
 
-      def render_bad_request
+      def render_bad_request(exception = nil)
+        Rails.logger.error("[API BadRequest] #{exception&.class}: #{exception&.message}\n#{exception&.backtrace&.first(10)&.join("\n")}")
         render json: { error: 'Bad request' }, status: :bad_request
       end
 


### PR DESCRIPTION
## Summary
- Fix N+1: eager-load `song.artists` in `Api::V1::AirPlaysController#air_plays` so the serializer's `object.song.artists` stops firing per-record queries.
- Cache `COUNT(*)` for 5 minutes keyed on the query params; a 16-page walk now does one count instead of sixteen.
- Send `Cache-Control: public, max-age=60` via `expires_in` so browser/CDN can dedupe identical paginated requests within the minute.

Triggered by the artist page (e.g. /artists/david-guetta) firing 16 sequential `/api/v1/air_plays` requests for a 1-week window — ~30s of total network time. Top of stack was the missing eager-load + repeated COUNT.

## Test plan
- [ ] CI green (local rspec blocked by an unrelated PG 18.3/18.4 `pg_trgm` symbol mismatch; reproduces on `main`)
- [ ] Hit `/artists/david-guetta` in staging, confirm air_plays requests are noticeably faster and that the first page's response carries `Cache-Control: public, max-age=60`
- [ ] Confirm `total_entries`/`total_pages` in the JSON match what was returned before
- [ ] Refresh the page within a minute and verify the browser serves the paginated responses from cache (or 304s) instead of round-tripping